### PR TITLE
font size in topicpage.jrxml

### DIFF
--- a/print/print-apps/oereb/topicpage.jrxml
+++ b/print/print-apps/oereb/topicpage.jrxml
@@ -543,7 +543,7 @@
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
-					<font fontName="Cadastra" size="6.5"/>
+					<font fontName="Cadastra" size="6"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Footer}]]></textFieldExpression>
 			</textField>
@@ -552,7 +552,7 @@
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<textElement textAlignment="Right">
-					<font fontName="Cadastra" size="6.5"/>
+					<font fontName="Cadastra" size="6"/>
 				</textElement>
 				<textFieldExpression><![CDATA[String.format($R{PageLabel}, $V{MASTER_CURRENT_PAGE}, $V{MASTER_TOTAL_PAGES})]]></textFieldExpression>
 			</textField>


### PR DESCRIPTION
Same font size of the footer and the page counter text field as in other templates. In our instance it has the effect, that the information is not visible when we use 6.5 instead of 6.