### PR TITLE
Upgrade MapFish-Print version in Docker template

### DIFF
--- a/print/Dockerfile
+++ b/print/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/mapfish_print:3.10.7
+FROM camptocamp/mapfish_print:3.18.2
 MAINTAINER Camptocamp "info@camptocamp.com"
 
 RUN rm -rf webapps/ROOT/print-apps


### PR DESCRIPTION
Upgrade MapFish-Print version in Docker template (used for localhost tests, too)