### PR TITLE
Fix model templates

### DIFF
--- a/pyramid_oereb/contrib/models/oereblex/contaminated_sites.py
+++ b/pyramid_oereb/contrib/models/oereblex/contaminated_sites.py
@@ -80,7 +80,7 @@ class DataIntegration(Base):
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The actual office instance which the id points to.
     """
@@ -88,7 +88,10 @@ class DataIntegration(Base):
     __tablename__ = 'data_integration'
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+        sa.String,
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -133,7 +136,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.contaminated_sites.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -148,7 +151,7 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -177,11 +180,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.contaminated_sites.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The dedicated relation to the office instance from database.
@@ -199,7 +202,7 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -208,7 +211,7 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -228,12 +231,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.contaminated_sites
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The dedicated relation to the office instance from database.
@@ -249,7 +252,7 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('GEOMETRYCOLLECTION', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -258,7 +261,7 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -273,9 +276,9 @@ class PublicLawRestrictionBase(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -286,12 +289,12 @@ class PublicLawRestrictionBase(Base):
     __table_args__ = {'schema': 'contaminated_sites'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -314,9 +317,9 @@ class PublicLawRestrictionRefinement(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -327,12 +330,12 @@ class PublicLawRestrictionRefinement(Base):
     __table_args__ = {'schema': 'contaminated_sites'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/contrib/models/oereblex/forest_distance_lines.py
+++ b/pyramid_oereb/contrib/models/oereblex/forest_distance_lines.py
@@ -80,7 +80,7 @@ class DataIntegration(Base):
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The actual office instance which the id points to.
     """
@@ -88,7 +88,10 @@ class DataIntegration(Base):
     __tablename__ = 'data_integration'
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+        sa.String,
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -133,7 +136,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.forest_distance_lines.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -148,7 +151,7 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -177,11 +180,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.forest_distance_lines.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The dedicated relation to the office instance from database.
@@ -199,7 +202,7 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -208,7 +211,7 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -228,12 +231,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.forest_distance_lines
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The dedicated relation to the office instance from database.
@@ -249,7 +252,7 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('LINESTRING', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -258,7 +261,7 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -273,9 +276,9 @@ class PublicLawRestrictionBase(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.forest_distance_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -286,12 +289,12 @@ class PublicLawRestrictionBase(Base):
     __table_args__ = {'schema': 'forest_distance_lines'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -314,9 +317,9 @@ class PublicLawRestrictionRefinement(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.forest_distance_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -327,12 +330,12 @@ class PublicLawRestrictionRefinement(Base):
     __table_args__ = {'schema': 'forest_distance_lines'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/contrib/models/oereblex/forest_perimeters.py
+++ b/pyramid_oereb/contrib/models/oereblex/forest_perimeters.py
@@ -80,7 +80,7 @@ class DataIntegration(Base):
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The actual office instance which the id points to.
     """
@@ -88,7 +88,10 @@ class DataIntegration(Base):
     __tablename__ = 'data_integration'
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+        sa.String,
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -133,7 +136,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.forest_perimeters.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -148,7 +151,7 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -177,11 +180,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.forest_perimeters.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The dedicated relation to the office instance from database.
@@ -199,7 +202,7 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -208,7 +211,7 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -228,12 +231,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.forest_perimeters
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The dedicated relation to the office instance from database.
@@ -249,7 +252,7 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('LINESTRING', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -258,7 +261,7 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -273,9 +276,9 @@ class PublicLawRestrictionBase(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.forest_perimeters.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -286,12 +289,12 @@ class PublicLawRestrictionBase(Base):
     __table_args__ = {'schema': 'forest_perimeters'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -314,9 +317,9 @@ class PublicLawRestrictionRefinement(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.forest_perimeters.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -327,12 +330,12 @@ class PublicLawRestrictionRefinement(Base):
     __table_args__ = {'schema': 'forest_perimeters'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/contrib/models/oereblex/groundwater_protection_sites.py
+++ b/pyramid_oereb/contrib/models/oereblex/groundwater_protection_sites.py
@@ -80,7 +80,7 @@ class DataIntegration(Base):
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The actual office instance which the id points to.
     """
@@ -88,7 +88,10 @@ class DataIntegration(Base):
     __tablename__ = 'data_integration'
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+        sa.String,
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -133,7 +136,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_sites.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -148,7 +151,7 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -177,11 +180,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_sites.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The dedicated relation to the office instance from database.
@@ -199,7 +202,7 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -208,7 +211,7 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -228,12 +231,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.groundwater_protection_sites
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The dedicated relation to the office instance from database.
@@ -249,7 +252,7 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('POLYGON', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -258,7 +261,7 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -273,9 +276,9 @@ class PublicLawRestrictionBase(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -286,12 +289,12 @@ class PublicLawRestrictionBase(Base):
     __table_args__ = {'schema': 'groundwater_protection_sites'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -314,9 +317,9 @@ class PublicLawRestrictionRefinement(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -327,12 +330,12 @@ class PublicLawRestrictionRefinement(Base):
     __table_args__ = {'schema': 'groundwater_protection_sites'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/contrib/models/oereblex/groundwater_protection_zones.py
+++ b/pyramid_oereb/contrib/models/oereblex/groundwater_protection_zones.py
@@ -80,7 +80,7 @@ class DataIntegration(Base):
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The actual office instance which the id points to.
     """
@@ -88,7 +88,10 @@ class DataIntegration(Base):
     __tablename__ = 'data_integration'
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+        sa.String,
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -133,7 +136,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_zones.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -148,7 +151,7 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -177,11 +180,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_zones.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The dedicated relation to the office instance from database.
@@ -199,7 +202,7 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -208,7 +211,7 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -228,12 +231,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.groundwater_protection_zones
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The dedicated relation to the office instance from database.
@@ -249,7 +252,7 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('POLYGON', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -258,7 +261,7 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -273,9 +276,9 @@ class PublicLawRestrictionBase(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -286,12 +289,12 @@ class PublicLawRestrictionBase(Base):
     __table_args__ = {'schema': 'groundwater_protection_zones'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -314,9 +317,9 @@ class PublicLawRestrictionRefinement(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -327,12 +330,12 @@ class PublicLawRestrictionRefinement(Base):
     __table_args__ = {'schema': 'groundwater_protection_zones'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/contrib/models/oereblex/land_use_plans.py
+++ b/pyramid_oereb/contrib/models/oereblex/land_use_plans.py
@@ -80,7 +80,7 @@ class DataIntegration(Base):
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.land_use_plans.Office):
             The actual office instance which the id points to.
     """
@@ -88,7 +88,10 @@ class DataIntegration(Base):
     __tablename__ = 'data_integration'
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+        sa.String,
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -133,7 +136,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.land_use_plans.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -148,7 +151,7 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -177,11 +180,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.land_use_plans.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.land_use_plans.Office):
             The dedicated relation to the office instance from database.
@@ -199,7 +202,7 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -208,7 +211,7 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -228,12 +231,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.land_use_plans
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.land_use_plans.Office):
             The dedicated relation to the office instance from database.
@@ -249,7 +252,7 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('GEOMETRYCOLLECTION', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -258,7 +261,7 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -273,9 +276,9 @@ class PublicLawRestrictionBase(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.land_use_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -286,12 +289,12 @@ class PublicLawRestrictionBase(Base):
     __table_args__ = {'schema': 'land_use_plans'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -314,9 +317,9 @@ class PublicLawRestrictionRefinement(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.land_use_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -327,12 +330,12 @@ class PublicLawRestrictionRefinement(Base):
     __table_args__ = {'schema': 'land_use_plans'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/contrib/models/oereblex/noise_sensitivity_levels.py
+++ b/pyramid_oereb/contrib/models/oereblex/noise_sensitivity_levels.py
@@ -80,7 +80,7 @@ class DataIntegration(Base):
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The actual office instance which the id points to.
     """
@@ -88,7 +88,10 @@ class DataIntegration(Base):
     __tablename__ = 'data_integration'
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+        sa.String,
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -133,7 +136,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.noise_sensitivity_levels.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -148,7 +151,7 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -177,11 +180,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.noise_sensitivity_levels.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The dedicated relation to the office instance from database.
@@ -199,7 +202,7 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -208,7 +211,7 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -228,12 +231,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.noise_sensitivity_levels
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The dedicated relation to the office instance from database.
@@ -249,7 +252,7 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('POLYGON', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -258,7 +261,7 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -273,9 +276,9 @@ class PublicLawRestrictionBase(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.noise_sensitivity_levels.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -286,12 +289,12 @@ class PublicLawRestrictionBase(Base):
     __table_args__ = {'schema': 'noise_sensitivity_levels'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -314,9 +317,9 @@ class PublicLawRestrictionRefinement(Base):
     Attributes:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.noise_sensitivity_levels.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -327,12 +330,12 @@ class PublicLawRestrictionRefinement(Base):
     __table_args__ = {'schema': 'noise_sensitivity_levels'}
     id = sa.Column(sa.String, primary_key=True, autoincrement=False)
     public_law_restriction_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
-        sa.Integer,
+        sa.String,
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/contrib/templates/plr_oereb.py.mako
+++ b/pyramid_oereb/contrib/templates/plr_oereb.py.mako
@@ -103,7 +103,11 @@ class DataIntegration(Base):
             you  don't like it - don't care about.
 % endif
         date (datetime.date): The date when this data set was delivered.
+% if primary_key_is_string:
+        office_id (str): A foreign key which points to the actual office instance.
+% else:
         office_id (int): A foreign key which points to the actual office instance.
+% endif
         office (pyramid_oereb.standard.models.${schema_name}.Office):
             The actual office instance which the id points to.
     """
@@ -115,7 +119,14 @@ class DataIntegration(Base):
     id = sa.Column(sa.Integer, primary_key=True, autoincrement=False)
 % endif
     date = sa.Column(sa.DateTime, nullable=False)
-    office_id = sa.Column(sa.Integer, sa.ForeignKey(Office.id), nullable=False)
+    office_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
+        sa.Integer,
+% endif
+        sa.ForeignKey(Office.id),
+        nullable=False)
     office = relationship(Office)
     checksum = sa.Column(sa.String, nullable=True)
 
@@ -174,7 +185,11 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
+% if primary_key_is_string:
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
+% else:
         view_service_id (int): The foreign key to the view service this legend entry is related to.
+% endif
         view_service (pyramid_oereb.standard.models.${schema_name}.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -193,7 +208,11 @@ class LegendEntry(Base):
     sub_theme = sa.Column(JSONType, nullable=True)
     other_theme = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -227,12 +246,21 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
+% if primary_key_is_string:
+        view_service_id (str): The foreign key to the view service this public law restriction is
+            related to.
+        view_service (pyramid_oereb.standard.models.${schema_name}.ViewService):
+            The dedicated relation to the view service instance from database.
+        office_id (str): The foreign key to the office which is responsible to this public law
+            restriction.
+%else:
         view_service_id (int): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.${schema_name}.ViewService):
             The dedicated relation to the view service instance from database.
         office_id (int): The foreign key to the office which is responsible to this public law
             restriction.
+% endif
         responsible_office (pyramid_oereb.standard.models.${schema_name}.Office):
             The dedicated relation to the office instance from database.
     """
@@ -253,7 +281,11 @@ class PublicLawRestriction(Base):
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
     view_service_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(ViewService.id),
         nullable=False
     )
@@ -262,7 +294,11 @@ class PublicLawRestriction(Base):
         backref='public_law_restrictions'
     )
     office_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -287,13 +323,23 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
+% if primary_key_is_string:
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
+            is  related to.
+% else:
         public_law_restriction_id (int): The foreign key to the public law restriction this geometry
             is  related to.
+% endif
         public_law_restriction (pyramid_oereb.standard.models.${schema_name}
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
+% if primary_key_is_string:
+        office_id (str): The foreign key to the office which is responsible to this public law
+            restriction.
+% else:
         office_id (int): The foreign key to the office which is responsible to this public law
             restriction.
+% endif
         responsible_office (pyramid_oereb.standard.models.${schema_name}.Office):
             The dedicated relation to the office instance from database.
         geom (geoalchemy2.types.Geometry): The geometry it's self. For type information see
@@ -312,7 +358,11 @@ class Geometry(Base):
     geo_metadata = sa.Column(sa.String, nullable=True)
     geom = sa.Column(GeoAlchemyGeometry('${geometry_type}', srid=srid), nullable=False)
     public_law_restriction_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -321,7 +371,11 @@ class Geometry(Base):
         backref='geometries'
     )
     office_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(Office.id),
         nullable=False
     )
@@ -337,14 +391,18 @@ class PublicLawRestrictionBase(Base):
 % if primary_key_is_string:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
+            on another  public law restriction.
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
+            the  base for the public law restriction.
 %else:
         id (int): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-% endif
         public_law_restriction_id (int): The foreign key to the public law restriction which bases
             on another  public law restriction.
         public_law_restriction_base_id (int): The foreign key to the public law restriction which is
             the  base for the public law restriction.
+% endif
         plr (pyramid_oereb.standard.models.${schema_name}.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
         base (pyramid_oereb.standard.models.${schema_name}.PublicLawRestriction):
@@ -358,12 +416,20 @@ class PublicLawRestrictionBase(Base):
     id = sa.Column(sa.Integer, primary_key=True, autoincrement=False)
 % endif
     public_law_restriction_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_base_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
@@ -387,14 +453,18 @@ class PublicLawRestrictionRefinement(Base):
 % if primary_key_is_string:
         id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
+            refined by  another public law restriction.
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
+            which is  the refinement of the public law restriction.
 %else:
         id (int): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-% endif
         public_law_restriction_id (int): The foreign key to the public law restriction which is
             refined by  another public law restriction.
         public_law_restriction_refinement_id (int): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
+% endif
         plr (pyramid_oereb.standard.models.${schema_name}.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
         base (pyramid_oereb.standard.models.${schema_name}.PublicLawRestriction):
@@ -408,12 +478,20 @@ class PublicLawRestrictionRefinement(Base):
     id = sa.Column(sa.Integer, primary_key=True, autoincrement=False)
 % endif
     public_law_restriction_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )
     public_law_restriction_refinement_id = sa.Column(
+% if primary_key_is_string:
+        sa.String,
+% else:
         sa.Integer,
+% endif
         sa.ForeignKey(PublicLawRestriction.id),
         nullable=False
     )

--- a/pyramid_oereb/standard/models/airports_building_lines.py
+++ b/pyramid_oereb/standard/models/airports_building_lines.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.airports_building_lines.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.airports_building_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.airports_building_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.airports_building_lines.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.airports_building_lines.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.airports_building_lines.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.airports_building_lines.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.airports_building_lines.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.airports_building_lines
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.airports_building_lines.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.airports_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.airports_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.airports_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.airports_building_lines.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.airports_building_lines.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/airports_project_planning_zones.py
+++ b/pyramid_oereb/standard/models/airports_project_planning_zones.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.airports_project_planning_zones.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.airports_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.airports_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.airports_project_planning_zones.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.airports_project_planning_zones.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.airports_project_planning_zones.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.airports_project_planning_zones.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.airports_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.airports_project_planning_zones
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.airports_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.airports_project_planning_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.airports_project_planning_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.airports_project_planning_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.airports_project_planning_zones.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.airports_project_planning_zones.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/airports_security_zone_plans.py
+++ b/pyramid_oereb/standard/models/airports_security_zone_plans.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.airports_security_zone_plans.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.airports_security_zone_plans.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.airports_security_zone_plans.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.airports_security_zone_plans.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.airports_security_zone_plans.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.airports_security_zone_plans.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.airports_security_zone_plans.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.airports_security_zone_plans.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.airports_security_zone_plans
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.airports_security_zone_plans.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.airports_security_zone_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.airports_security_zone_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.airports_security_zone_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.airports_security_zone_plans.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.airports_security_zone_plans.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/contaminated_civil_aviation_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_civil_aviation_sites.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.contaminated_civil_aviation_sites.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.contaminated_civil_aviation_sites
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.contaminated_civil_aviation_sites.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/contaminated_military_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_military_sites.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.contaminated_military_sites.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.contaminated_military_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.contaminated_military_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.contaminated_military_sites.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.contaminated_military_sites.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.contaminated_military_sites.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.contaminated_military_sites.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_military_sites.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.contaminated_military_sites
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_military_sites.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_military_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_military_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.contaminated_military_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.contaminated_military_sites.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.contaminated_military_sites.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/contaminated_public_transport_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_public_transport_sites.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.contaminated_public_transport_sites.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.contaminated_public_transport_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.contaminated_public_transport_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.contaminated_public_transport_sites.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.contaminated_public_transport_sites.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.contaminated_public_transport_sites.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.contaminated_public_transport_sites.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_public_transport_sites.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.contaminated_public_transport_sites
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_public_transport_sites.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_public_transport_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_public_transport_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.contaminated_public_transport_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.contaminated_public_transport_sites.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.contaminated_public_transport_sites.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/contaminated_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_sites.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.contaminated_sites.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.contaminated_sites.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.contaminated_sites.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.contaminated_sites.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.contaminated_sites
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.contaminated_sites.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.contaminated_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.contaminated_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.contaminated_sites.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.contaminated_sites.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/forest_distance_lines.py
+++ b/pyramid_oereb/standard/models/forest_distance_lines.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.forest_distance_lines.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.forest_distance_lines.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.forest_distance_lines.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.forest_distance_lines.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.forest_distance_lines
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_distance_lines.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.forest_distance_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.forest_distance_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.forest_distance_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.forest_distance_lines.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.forest_distance_lines.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/forest_perimeters.py
+++ b/pyramid_oereb/standard/models/forest_perimeters.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.forest_perimeters.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.forest_perimeters.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.forest_perimeters.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.forest_perimeters.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.forest_perimeters
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.forest_perimeters.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.forest_perimeters.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.forest_perimeters.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.forest_perimeters.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.forest_perimeters.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.forest_perimeters.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/groundwater_protection_sites.py
+++ b/pyramid_oereb/standard/models/groundwater_protection_sites.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.groundwater_protection_sites.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.groundwater_protection_sites.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_sites.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_sites.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.groundwater_protection_sites
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_sites.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_sites.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.groundwater_protection_sites.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.groundwater_protection_sites.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/groundwater_protection_zones.py
+++ b/pyramid_oereb/standard/models/groundwater_protection_zones.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.groundwater_protection_zones.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.groundwater_protection_zones.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_zones.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.groundwater_protection_zones.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.groundwater_protection_zones
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.groundwater_protection_zones.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.groundwater_protection_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.groundwater_protection_zones.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.groundwater_protection_zones.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/land_use_plans.py
+++ b/pyramid_oereb/standard/models/land_use_plans.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.land_use_plans.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.land_use_plans.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.land_use_plans.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.land_use_plans.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.land_use_plans.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.land_use_plans.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.land_use_plans.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.land_use_plans.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.land_use_plans
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.land_use_plans.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.land_use_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.land_use_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.land_use_plans.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.land_use_plans.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.land_use_plans.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/motorways_building_lines.py
+++ b/pyramid_oereb/standard/models/motorways_building_lines.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.motorways_building_lines.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.motorways_building_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.motorways_building_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.motorways_building_lines.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.motorways_building_lines.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.motorways_building_lines.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.motorways_building_lines.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.motorways_building_lines.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.motorways_building_lines
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.motorways_building_lines.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.motorways_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.motorways_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.motorways_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.motorways_building_lines.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.motorways_building_lines.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/motorways_project_planing_zones.py
+++ b/pyramid_oereb/standard/models/motorways_project_planing_zones.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.motorways_project_planing_zones.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.motorways_project_planing_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.motorways_project_planing_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.motorways_project_planing_zones.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.motorways_project_planing_zones.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.motorways_project_planing_zones.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.motorways_project_planing_zones.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.motorways_project_planing_zones.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.motorways_project_planing_zones
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.motorways_project_planing_zones.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.motorways_project_planing_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.motorways_project_planing_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.motorways_project_planing_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.motorways_project_planing_zones.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.motorways_project_planing_zones.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/noise_sensitivity_levels.py
+++ b/pyramid_oereb/standard/models/noise_sensitivity_levels.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.noise_sensitivity_levels.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.noise_sensitivity_levels.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.noise_sensitivity_levels.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.noise_sensitivity_levels.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.noise_sensitivity_levels
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.noise_sensitivity_levels.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.noise_sensitivity_levels.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.noise_sensitivity_levels.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.noise_sensitivity_levels.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.noise_sensitivity_levels.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.noise_sensitivity_levels.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/railways_building_lines.py
+++ b/pyramid_oereb/standard/models/railways_building_lines.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.railways_building_lines.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.railways_building_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.railways_building_lines.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.railways_building_lines.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.railways_building_lines.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.railways_building_lines.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.railways_building_lines.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.railways_building_lines.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.railways_building_lines
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.railways_building_lines.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.railways_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.railways_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.railways_building_lines.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.railways_building_lines.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.railways_building_lines.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/models/railways_project_planning_zones.py
+++ b/pyramid_oereb/standard/models/railways_project_planning_zones.py
@@ -45,7 +45,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -77,10 +77,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.railways_project_planning_zones.Office):
             The actual office instance which the id points to.
     """
@@ -100,12 +100,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.railways_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -127,7 +127,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -157,7 +157,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -170,7 +170,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.railways_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
     """
@@ -207,11 +207,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.railways_project_planning_zones.Document):
             The dedicated relation to the document instance from database.
     """
@@ -245,7 +245,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -264,7 +264,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.railways_project_planning_zones.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -280,7 +280,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.railways_project_planning_zones.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -307,7 +307,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -324,11 +324,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.railways_project_planning_zones.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.railways_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
@@ -366,7 +366,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -374,12 +374,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.railways_project_planning_zones
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.railways_project_planning_zones.Office):
             The dedicated relation to the office instance from database.
@@ -417,11 +417,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.railways_project_planning_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -458,11 +458,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.railways_project_planning_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -498,11 +498,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.railways_project_planning_zones.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -537,10 +537,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.railways_project_planning_zones.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.railways_project_planning_zones.Document):
@@ -578,11 +578,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'

--- a/pyramid_oereb/standard/templates/plr_string_primary_keys.py.mako
+++ b/pyramid_oereb/standard/templates/plr_string_primary_keys.py.mako
@@ -46,7 +46,7 @@ class Office(Base):
     geometry.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         name (dict): The multilingual name of the office.
         office_at_web (str): A web accessible url to a presentation of this office.
@@ -78,10 +78,10 @@ class DataIntegration(Base):
     able to find out who was the delivering instance.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         date (datetime.date): The date when this data set was delivered.
-        office_id (int): A foreign key which points to the actual office instance.
+        office_id (str): A foreign key which points to the actual office instance.
         office (pyramid_oereb.standard.models.${schema_name}.Office):
             The actual office instance which the id points to.
     """
@@ -101,12 +101,12 @@ class ReferenceDefinition(Base):
     which are related to an extract but not directly on a special public law restriction situation.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         topic (str): The topic which this definition might be related to.
         canton (str): The canton this definition is related to.
         municipality (int): The municipality this definition is related to.
-        office_id (int): The foreign key constraint which the definition is related to.
+        office_id (str): The foreign key constraint which the definition is related to.
         responsible_office (pyramid_oereb.standard.models.${schema_name}.Office):
             The dedicated relation to the office instance from database.
     """
@@ -128,7 +128,7 @@ class DocumentBase(Base):
     produce the addressable primary key and to provide the common document attributes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         text_at_web (dict): A multilingual link which leads to the documents content in the web.
         law_status (str): The status switch if the document is legally approved or not.
@@ -158,7 +158,7 @@ class Document(DocumentBase):
     This represents the main document in the whole system. It is specialized in some sub classes.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         document_type (str): The document type. It must be "LegalProvision", "Law" or "Hint".
         title (dict): The multilingual title or if existing the short title ot his document.
@@ -171,7 +171,7 @@ class Document(DocumentBase):
             the document is  related to the whole canton or even the confederation.
         file (str): The document itself as a binary representation (PDF). It is string but
             BaseCode64 encoded.
-        office_id (int): The foreign key to the office which is in charge for this document.
+        office_id (str): The foreign key to the office which is in charge for this document.
         responsible_office (pyramid_oereb.standard.models.${schema_name}.Office):
             The dedicated relation to the office instance from database.
     """
@@ -208,11 +208,11 @@ class Article(DocumentBase):
     described as a special part of the whole law document and reflects a dedicated content of this.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         number (str): The number which identifies this article in its parent document.
         text (dict): A simple multilingual string to describe the article or give some related info.
-        document_id (int): The foreign key to the document this article is taken from.
+        document_id (str): The foreign key to the document this article is taken from.
         document_id (pyramid_oereb.standard.models.${schema_name}.Document):
             The dedicated relation to the document instance from database.
     """
@@ -246,7 +246,7 @@ class ViewService(Base):
     A view service aka WM(T)S which can deliver a cartographic representation via web.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         reference_wms (str): The actual url which leads to the desired cartographic representation.
         legend_at_web (dict of str): A multilingual dictionary of links. Keys are the language, values
@@ -265,7 +265,7 @@ class LegendEntry(Base):
     :class:`pyramid_oereb.standard.models.${schema_name}.ViewService`.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         symbol (str): An image with represents the legend entry. This can be png or svg. It is string
             but BaseCode64  encoded.
@@ -281,7 +281,7 @@ class LegendEntry(Base):
             * ch.{canton}.{topic}  * fl.{topic}  * ch.{bfsnr}.{topic}  This with {canton} as
             the official two letters short version (e.g.'BE') {topic} as the name of the
             topic and {bfsnr} as the municipality id of the federal office of statistics.
-        view_service_id (int): The foreign key to the view service this legend entry is related to.
+        view_service_id (str): The foreign key to the view service this legend entry is related to.
         view_service (pyramid_oereb.standard.models.${schema_name}.ViewService):
             The dedicated relation to the view service instance from database.
     """
@@ -308,7 +308,7 @@ class PublicLawRestriction(Base):
     The container where you can fill in all your public law restrictions to the topic.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         information (dict): The multilingual textual representation of the public law restriction.
         topic (str): Category for this public law restriction (name of the topic).
@@ -325,11 +325,11 @@ class PublicLawRestriction(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        view_service_id (int): The foreign key to the view service this public law restriction is
+        view_service_id (str): The foreign key to the view service this public law restriction is
             related to.
         view_service (pyramid_oereb.standard.models.${schema_name}.ViewService):
             The dedicated relation to the view service instance from database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.${schema_name}.Office):
             The dedicated relation to the office instance from database.
@@ -367,7 +367,7 @@ class Geometry(Base):
     The dedicated model for all geometries in relation to their public law restriction.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
         law_status (str): The status switch if the document is legally approved or not.
         published_from (datetime.date): The date when the document should be available for
@@ -375,12 +375,12 @@ class Geometry(Base):
             generation.
         geo_metadata (str): A link to the metadata which this geometry is based on which delivers
             machine  readable response format (XML).
-        public_law_restriction_id (int): The foreign key to the public law restriction this geometry
+        public_law_restriction_id (str): The foreign key to the public law restriction this geometry
             is  related to.
         public_law_restriction (pyramid_oereb.standard.models.${schema_name}
             .PublicLawRestriction): The dedicated relation to the public law restriction instance from
             database.
-        office_id (int): The foreign key to the office which is responsible to this public law
+        office_id (str): The foreign key to the office which is responsible to this public law
             restriction.
         responsible_office (pyramid_oereb.standard.models.${schema_name}.Office):
             The dedicated relation to the office instance from database.
@@ -418,11 +418,11 @@ class PublicLawRestrictionBase(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which bases
+        public_law_restriction_id (str): The foreign key to the public law restriction which bases
             on another  public law restriction.
-        public_law_restriction_base_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_base_id (str): The foreign key to the public law restriction which is
             the  base for the public law restriction.
         plr (pyramid_oereb.standard.models.${schema_name}.PublicLawRestriction):
             The dedicated relation to the public law restriction (which bases on) instance from  database.
@@ -459,11 +459,11 @@ class PublicLawRestrictionRefinement(Base):
     restrictions.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which is
+        public_law_restriction_id (str): The foreign key to the public law restriction which is
             refined by  another public law restriction.
-        public_law_restriction_refinement_id (int): The foreign key to the public law restriction
+        public_law_restriction_refinement_id (str): The foreign key to the public law restriction
             which is  the refinement of the public law restriction.
         plr (pyramid_oereb.standard.models.${schema_name}.PublicLawRestriction):
             The dedicated relation to the public law restriction (which refines) instance from  database.
@@ -499,11 +499,11 @@ class PublicLawRestrictionDocument(Base):
     Meta bucket (join table) for the relationship between public law restrictions and documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        public_law_restriction_id (int): The foreign key to the public law restriction which has
+        public_law_restriction_id (str): The foreign key to the public law restriction which has
             relation to  a document.
-        document_id (int): The foreign key to the document which has relation to the public law
+        document_id (str): The foreign key to the document which has relation to the public law
             restriction.
         plr (pyramid_oereb.standard.models.${schema_name}.PublicLawRestriction):
             The dedicated relation to the public law restriction instance from database.
@@ -538,10 +538,10 @@ class DocumentReference(Base):
     Meta bucket (join table) for the relationship between documents.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which references to another document.
-        reference_document_id (int): The foreign key to the document which is referenced.
+        document_id (str): The foreign key to the document which references to another document.
+        reference_document_id (str): The foreign key to the document which is referenced.
         document (pyramid_oereb.standard.models.${schema_name}.Document):
             The dedicated relation to the document (which references) instance from database.
         referenced_document (pyramid_oereb.standard.models.${schema_name}.Document):
@@ -579,11 +579,11 @@ class DocumentReferenceDefinition(Base):
     Meta bucket (join table) for the relationship between documents and the reference definition.
 
     Attributes:
-        id (int): The identifier. This is used in the database only and must not be set manually. If
+        id (str): The identifier. This is used in the database only and must not be set manually. If
             you  don't like it - don't care about.
-        document_id (int): The foreign key to the document which is related to a reference
+        document_id (str): The foreign key to the document which is related to a reference
             definition.
-        reference_definition_id (int): The foreign key to the document which is related to a
+        reference_definition_id (str): The foreign key to the document which is related to a
             reference  definition.
     """
     __tablename__ = 'document_reference_definition'


### PR DESCRIPTION
There were still wrong types in the model templates. For the standard models only documentation was affected, oereblex models though had wrong types in actual code.