### PR TITLE
Fix version of pyproj to avoid problematic >=2.0.0 releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ urllib3[secure]==1.24.1
 waitress==1.2.1
 zope.sqlalchemy==1.1
 jsonschema==3.0.1
+pyproj==1.9.6  # rq.filter: <2.0.0
 pyreproj==1.0.0
 lxml==4.3.2
 requests==2.21.0


### PR DESCRIPTION
The new major release of pyproj returns different (wrong?) results for coordinate transformations.
Setting the version to be lower than the new 2.0.0 major release lets our tests pass again.

[Related merge request for python-reprojector](https://gitlab.com/gf-bl/python-reprojector/merge_requests/17)
