### PR TITLE
Fix footer with MapFish print 3.18

### DIFF
--- a/print/print-apps/oereb/topicpage.jrxml
+++ b/print/print-apps/oereb/topicpage.jrxml
@@ -543,7 +543,7 @@
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
-					<font fontName="Cadastra" size="6.5"/>
+					<font fontName="Cadastra" size="6"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{Footer}]]></textFieldExpression>
 			</textField>
@@ -552,7 +552,7 @@
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<textElement textAlignment="Right">
-					<font fontName="Cadastra" size="6.5"/>
+					<font fontName="Cadastra" size="6"/>
 				</textElement>
 				<textFieldExpression><![CDATA[String.format($R{PageLabel}, $V{MASTER_CURRENT_PAGE}, $V{MASTER_TOTAL_PAGES})]]></textFieldExpression>
 			</textField>


### PR DESCRIPTION
The problem was just a font a bit too big.

Closes #813 