### PR TITLE
add test check for ordering of non-concerned themes

### DIFF
--- a/pyramid_oereb/lib/processor.py
+++ b/pyramid_oereb/lib/processor.py
@@ -89,11 +89,16 @@ class Processor(object):
         outside_plrs = []
 
         for public_law_restriction in real_estate.public_law_restrictions:
+
             if isinstance(public_law_restriction, PlrRecord) and public_law_restriction.published:
                 # Test if the geometries list is now empty - if so remove plr from plr list
                 if public_law_restriction.calculate(real_estate):
+                    log.debug("plr_tolerance_check: keeping as potentially concerned plr {}".
+                              format(public_law_restriction))
                     inside_plrs.append(self.filter_published_documents(public_law_restriction))
                 else:
+                    log.debug("plr_tolerance_check: removing from the concerned plrs {}".
+                              format(public_law_restriction))
                     outside_plrs.append(public_law_restriction)
 
         # Check if theme is concerned

--- a/pyramid_oereb/lib/processor.py
+++ b/pyramid_oereb/lib/processor.py
@@ -89,7 +89,6 @@ class Processor(object):
         outside_plrs = []
 
         for public_law_restriction in real_estate.public_law_restrictions:
-
             if isinstance(public_law_restriction, PlrRecord) and public_law_restriction.published:
                 # Test if the geometries list is now empty - if so remove plr from plr list
                 if public_law_restriction.calculate(real_estate):

--- a/tests/webservice/test_getextractbyid.py
+++ b/tests/webservice/test_getextractbyid.py
@@ -206,6 +206,22 @@ def test_return_json(topics):
         assert restrictions[0]['Theme']['Code'] == 'LandUsePlans'
         assert restrictions[1]['Theme']['Code'] == 'MotorwaysBuildingLines'
         assert restrictions[2]['Theme']['Code'] == 'ContaminatedSites'
+        # Check consistency of ordering (according to config) for not concerned themes
+        assert extract.get('NotConcernedTheme')[0]['Code'] == 'MotorwaysProjectPlaningZones'
+        assert extract.get('NotConcernedTheme')[1]['Code'] == 'RailwaysBuildingLines'
+        assert extract.get('NotConcernedTheme')[2]['Code'] == 'RailwaysProjectPlanningZones'
+        assert extract.get('NotConcernedTheme')[3]['Code'] == 'AirportsProjectPlanningZones'
+        assert extract.get('NotConcernedTheme')[4]['Code'] == 'AirportsBuildingLines'
+        assert extract.get('NotConcernedTheme')[5]['Code'] == 'AirportsSecurityZonePlans'
+        assert extract.get('NotConcernedTheme')[6]['Code'] == 'ContaminatedMilitarySites'
+        assert extract.get('NotConcernedTheme')[7]['Code'] == 'ContaminatedCivilAviationSites'
+        assert extract.get('NotConcernedTheme')[8]['Code'] == 'ContaminatedPublicTransportSites'
+        assert extract.get('NotConcernedTheme')[9]['Code'] == 'GroundwaterProtectionZones'
+        assert extract.get('NotConcernedTheme')[10]['Code'] == 'GroundwaterProtectionSites'
+        assert extract.get('NotConcernedTheme')[11]['Code'] == 'NoiseSensitivityLevels'
+        assert extract.get('NotConcernedTheme')[12]['Code'] == 'ForestPerimeters'
+        assert extract.get('NotConcernedTheme')[13]['Code'] == 'ForestDistanceLines'
+
     if topics == 'ALL_FEDERAL':
         assert len(real_estate.get('RestrictionOnLandownership')) == 1
         assert len(extract.get('ConcernedTheme')) == 1


### PR DESCRIPTION
Test data follow-up of PR #429 and issue #428, now, the theme ordering is fully covered by the test (the themes can move from concerned to not_concerned after the tolerance_check, therefore we need to test that the relative order stays consistent with project configuration).

Note that this also preparation work for the refactoring planned in #443 .