### PR TITLE
Fix encoding issue in __str__ method

### DIFF
--- a/pyramid_oereb/lib/records/plr.py
+++ b/pyramid_oereb/lib/records/plr.py
@@ -215,4 +215,4 @@ class PlrRecord(EmptyPlrRecord):
         return '<{} -- type_code: {} theme: {} information: {}'\
                     ' (further attributes not shown)>'\
                     .format(self.__class__.__name__, self.type_code, self.theme,
-                            self.information)
+                            self.information.encode('utf-8'))

--- a/pyramid_oereb/lib/records/plr.py
+++ b/pyramid_oereb/lib/records/plr.py
@@ -217,4 +217,5 @@ class PlrRecord(EmptyPlrRecord):
             information[key] = self.information[key].encode('utf-8')
         return '<{} -- type_code: {} theme: {} information: {}'\
                     ' (further attributes not shown)>'\
-                    .format(self.__class__.__name__, self.type_code, self.theme, information)
+                    .format(self.__class__.__name__, self.type_code, self.theme, 
+                            information)

--- a/pyramid_oereb/lib/records/plr.py
+++ b/pyramid_oereb/lib/records/plr.py
@@ -215,7 +215,5 @@ class PlrRecord(EmptyPlrRecord):
         information = dict()
         for key in self.information:
             information[key] = self.information[key].encode('utf-8')
-        return '<{} -- type_code: {} theme: {} information: {}'\
-                    ' (further attributes not shown)>'\
-                    .format(self.__class__.__name__, self.type_code, self.theme,
-                            information)
+        tpl = '<{} -- type_code: {} theme: {} information: {} (further attributes not shown)>'
+        return tpl.format(self.__class__.__name__, self.type_code, self.theme, information)

--- a/pyramid_oereb/lib/records/plr.py
+++ b/pyramid_oereb/lib/records/plr.py
@@ -212,7 +212,9 @@ class PlrRecord(EmptyPlrRecord):
         return inside
 
     def __str__(self):
+        information = dict()
+        for key in self.information:
+            information[key] = self.information[key].encode('utf-8')
         return '<{} -- type_code: {} theme: {} information: {}'\
                     ' (further attributes not shown)>'\
-                    .format(self.__class__.__name__, self.type_code, self.theme,
-                            self.information.encode('utf-8'))
+                    .format(self.__class__.__name__, self.type_code, self.theme, information)

--- a/pyramid_oereb/lib/records/plr.py
+++ b/pyramid_oereb/lib/records/plr.py
@@ -217,5 +217,5 @@ class PlrRecord(EmptyPlrRecord):
             information[key] = self.information[key].encode('utf-8')
         return '<{} -- type_code: {} theme: {} information: {}'\
                     ' (further attributes not shown)>'\
-                    .format(self.__class__.__name__, self.type_code, self.theme, 
+                    .format(self.__class__.__name__, self.type_code, self.theme,
                             information)


### PR DESCRIPTION
The PLR record has a string formatting method, which is used for debugging. This method needs to encode non-ASCII content, especially for the attribute `information`.