### PR TITLE
update MapFish Print

### DIFF
--- a/print/Dockerfile
+++ b/print/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/mapfish_print:3.18.2
+FROM camptocamp/mapfish_print:3.18.4
 MAINTAINER Camptocamp "info@camptocamp.com"
 
 RUN rm -rf webapps/ROOT/print-apps


### PR DESCRIPTION
Update MapFish Print to latest minor release of 3.18 (3.18.4)

P.S. there is also a 3.19.0 available, but this is not working with pyramid_oereb, I will investigate that further.