### PR TITLE
Make Section 'Certification' in PDF configurable

### DIFF
--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -86,7 +86,7 @@ vars:
       # Whether to display the RealEstate_SubunitOfLandRegister (Grundbuchkreis) in the pdf extract or not.
       # Default to true.
       display_real_estate_subunit_of_land_register: true
-      # Wheder to display the Certification section in the pdf extract or not.
+      # Whether to display the Certification section in the pdf extract or not.
       # Default to true
       display_certification: false
       # Split themes up, so that each sub theme gets its own page

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -86,6 +86,9 @@ vars:
       # Whether to display the RealEstate_SubunitOfLandRegister (Grundbuchkreis) in the pdf extract or not.
       # Default to true.
       display_real_estate_subunit_of_land_register: true
+      # Wheder to display the Certification section in the pdf extract or not.
+      # Default to true
+      display_certification: false
       # Split themes up, so that each sub theme gets its own page
       # Disabled by default.
       split_sub_themes: true

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -88,7 +88,7 @@ vars:
       display_real_estate_subunit_of_land_register: true
       # Whether to display the Certification section in the pdf extract or not.
       # Default to true
-      display_certification: false
+      display_certification: true
       # Split themes up, so that each sub theme gets its own page
       # Disabled by default.
       split_sub_themes: true

--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -65,6 +65,8 @@ templates:
                 default: ''
             Display_RealEstate_SubunitOfLandRegister: !boolean
                 default: true
+            Display_Certification: !boolean
+                default: true
             RealEstate_FosNr: !string {}
             RealEstate_MetadataOfGeographicalBaseData: !string
                 default: ''

--- a/print/print-apps/oereb/mainpage.jrxml
+++ b/print/print-apps/oereb/mainpage.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
+<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
+<!-- 2019-04-25T10:00:25 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="titlepage" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" uuid="8ffd7940-5d69-45af-b3ac-fa15a5db24b6">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
@@ -32,11 +33,12 @@
 	<parameter name="RealEstate_FosNr" class="java.lang.String"/>
 	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
 	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
+	<parameter name="Display_Certification" class="java.lang.Boolean"/>
 	<parameter name="Display_RealEstate_SubunitOfLandRegister" class="java.lang.Boolean"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>
-    <parameter name="Certification" class="java.lang.String"/>
+	<parameter name="Certification" class="java.lang.String"/>
 	<title>
 		<band height="735">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
@@ -137,6 +139,7 @@
 			<textField>
 				<reportElement x="0" y="697" width="100" height="12" uuid="e0c1f775-61b3-41c4-a7ec-b8e68adeeb11">
 					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<printWhenExpression><![CDATA[true]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font fontName="Cadastra" size="7" isBold="true"/>
@@ -146,6 +149,7 @@
 			<textField isBlankWhenNull="true">
 				<reportElement x="0" y="725" width="493" height="10" uuid="f8b5d9a5-d842-43c8-b8d7-a8b68f697303">
 					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<printWhenExpression><![CDATA[$P{Display_Certification}==true]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font fontName="Cadastra" size="7"/>
@@ -155,6 +159,7 @@
 			<textField>
 				<reportElement isPrintRepeatedValues="false" x="0" y="709" width="490" height="12" uuid="5090c0e3-b8c0-4df8-9447-d203a7d6a664">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<printWhenExpression><![CDATA[$P{Display_Certification}==true]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font fontName="Cadastra" size="7"/>

--- a/print/print-apps/oereb/mainpage.jrxml
+++ b/print/print-apps/oereb/mainpage.jrxml
@@ -139,7 +139,7 @@
 			<textField>
 				<reportElement x="0" y="697" width="100" height="12" uuid="e0c1f775-61b3-41c4-a7ec-b8e68adeeb11">
 					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<printWhenExpression><![CDATA[true]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{Display_Certification}]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font fontName="Cadastra" size="7" isBold="true"/>
@@ -149,7 +149,7 @@
 			<textField isBlankWhenNull="true">
 				<reportElement x="0" y="725" width="493" height="10" uuid="f8b5d9a5-d842-43c8-b8d7-a8b68f697303">
 					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
-					<printWhenExpression><![CDATA[$P{Display_Certification}==true]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{Display_Certification}]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font fontName="Cadastra" size="7"/>
@@ -159,7 +159,7 @@
 			<textField>
 				<reportElement isPrintRepeatedValues="false" x="0" y="709" width="490" height="12" uuid="5090c0e3-b8c0-4df8-9447-d203a7d6a664">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<printWhenExpression><![CDATA[$P{Display_Certification}==true]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{Display_Certification}]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font fontName="Cadastra" size="7"/>

--- a/print/print-apps/oereb/pdfextract.jrxml
+++ b/print/print-apps/oereb/pdfextract.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.3.1.final using JasperReports Library version 6.3.1  -->
-<!-- 2018-01-30T10:40:05 -->
+<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
+<!-- 2019-04-25T09:53:26 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="pdfextract" pageWidth="595" pageHeight="842" sectionType="Part" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="30" bottomMargin="30" whenResourceMissingType="Error" uuid="d2716064-8ae4-40cf-a575-33afba400e3a">
 	<property name="net.sf.jasperreports.print.create.bookmarks" value="true"/>
 	<property name="net.sf.jasperreports.export.pdfa.icc.profile.path" value="sRGB_IEC61966-2-1_black_scaled.icc"/>
@@ -45,6 +45,7 @@
 	<parameter name="RealEstate_Municipality" class="java.lang.String"/>
 	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
 	<parameter name="Display_RealEstate_SubunitOfLandRegister" class="java.lang.Boolean"/>
+	<parameter name="Display_Certification" class="java.lang.Boolean"/>
 	<parameter name="RealEstate_Type" class="java.lang.String"/>
 	<parameter name="RealEstate_Canton" class="java.lang.String"/>
 	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
@@ -138,6 +139,9 @@
 					</subreportParameter>
 					<subreportParameter name="Display_RealEstate_SubunitOfLandRegister">
 						<subreportParameterExpression><![CDATA[$P{Display_RealEstate_SubunitOfLandRegister}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="Display_Certification">
+						<subreportParameterExpression><![CDATA[$P{Display_Certification}]]></subreportParameterExpression>
 					</subreportParameter>
 					<subreportParameter name="RealEstate_LandRegistryArea">
 						<subreportParameterExpression><![CDATA[$P{RealEstate_LandRegistryArea}]]></subreportParameterExpression>

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -76,6 +76,10 @@ class Renderer(JsonRenderer):
             'display_real_estate_subunit_of_land_register', True
         )
 
+        extract_as_dict['Display_Certification'] = print_config.get(
+            'display_certification', True
+        )
+
         spec = {
             'layout': Config.get('print', {})['template_name'],
             'outputFormat': 'pdf',

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -87,7 +87,7 @@ pyramid_oereb:
     display_real_estate_subunit_of_land_register: true
     # whether to display the "Certification" section in the pdf extract or not.
     # Default to true
-    display_certification: false
+    display_certification: true
     # Split themes up, so that each sub theme gets its own page
     # Disabled by default.
     split_sub_themes: false

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -85,6 +85,9 @@ pyramid_oereb:
     # Whether to display the RealEstate_SubunitOfLandRegister (Grundbuchkreis) in the pdf extract or not.
     # Default to true.
     display_real_estate_subunit_of_land_register: true
+    # whether to display the "Certification" section in the pdf extract or not.
+    # Default to true
+    display_certification: false
     # Split themes up, so that each sub theme gets its own page
     # Disabled by default.
     split_sub_themes: false


### PR DESCRIPTION
This adds a new config variable to make the Certification section in the print template configurable.
The variable defaults to `true` for which value the certification section is shown in the pdf extract.

Fixes #765 