### PR TITLE
Fix long titles in pdf

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,2 +1,3 @@
 exclude_paths:
   - 'tests/**'
+  - 'sample_data/*.json'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,3 @@
 exclude_paths:
   - 'tests/**'
-  - 'sample_data/**/*.json'
+  - 'sample_data/**.json'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,3 @@
 exclude_paths:
   - 'tests/**'
-  - 'sample_data/*.json'
+  - 'sample_data/**/*.json'

--- a/print/print-apps/oereb/exclusion_of_liability.jrxml
+++ b/print/print-apps/oereb/exclusion_of_liability.jrxml
@@ -15,11 +15,12 @@
 	<field name="Title" class="java.lang.String"/>
 	<field name="Content" class="java.lang.String"/>
 	<detail>
-		<band height="20" splitType="Immediate">
+		<band height="23" splitType="Immediate">
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement positionType="Float" x="0" y="0" width="233" height="10" uuid="bbc8f3dd-19b0-4440-aa6c-c04468e54bc2">
+				<reportElement positionType="Float" x="0" y="4" width="233" height="7" uuid="bbc8f3dd-19b0-4440-aa6c-c04468e54bc2">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -33,9 +34,9 @@
 				<textFieldExpression><![CDATA[$F{Title}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement positionType="Float" x="0" y="10" width="233" height="10" isRemoveLineWhenBlank="true" uuid="ed1963ea-5903-4816-87e0-b7b4f474e961">
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				<reportElement positionType="Float" x="0" y="13" width="233" height="10" isRemoveLineWhenBlank="true" uuid="ed1963ea-5903-4816-87e0-b7b4f474e961">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -43,7 +44,7 @@
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement markup="html">
+				<textElement textAlignment="Left" markup="html">
 					<font size="6" isBold="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{Content}]]></textFieldExpression>

--- a/print/print-apps/oereb/exclusion_of_liability.jrxml
+++ b/print/print-apps/oereb/exclusion_of_liability.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
+<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
+<!-- 2019-04-25T15:01:56 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Contents" pageWidth="493" pageHeight="842" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Key" uuid="e034c6ef-7449-4a6a-9b5e-4ce04cc083b2">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
@@ -17,7 +18,7 @@
 	<detail>
 		<band height="20" splitType="Immediate">
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="0" y="0" width="233" height="10" uuid="bbc8f3dd-19b0-4440-aa6c-c04468e54bc2">
+				<reportElement positionType="Float" x="0" y="0" width="233" height="10" uuid="bbc8f3dd-19b0-4440-aa6c-c04468e54bc2">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
@@ -33,7 +34,7 @@
 				<textFieldExpression><![CDATA[$F{Title}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="0" y="10" width="233" height="10" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="ed1963ea-5903-4816-87e0-b7b4f474e961">
+				<reportElement positionType="Float" x="0" y="10" width="233" height="10" isRemoveLineWhenBlank="true" uuid="ed1963ea-5903-4816-87e0-b7b4f474e961">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>

--- a/print/print-apps/oereb/exclusion_of_liability.jrxml
+++ b/print/print-apps/oereb/exclusion_of_liability.jrxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
-<!-- 2019-04-25T15:01:56 -->
+<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Contents" pageWidth="493" pageHeight="842" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Key" uuid="e034c6ef-7449-4a6a-9b5e-4ce04cc083b2">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>

--- a/print/print-apps/oereb/toc.jrxml
+++ b/print/print-apps/oereb/toc.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
+<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
+<!-- 2019-04-25T15:36:38 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="TocReport main" pageWidth="595" pageHeight="842" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" whenResourceMissingType="Empty" uuid="6e74177b-d551-4a75-ae51-6cdde3f284ce">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
@@ -277,7 +278,7 @@
 		</band>
 		<band height="47">
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="0" y="37" width="230" height="10" isPrintWhenDetailOverflows="true" uuid="9463b6fb-b28a-4793-9bc1-1c24749e48c4"/>
+				<reportElement x="0" y="37" width="230" height="10" uuid="9463b6fb-b28a-4793-9bc1-1c24749e48c4"/>
 				<textElement>
 					<font fontName="Cadastra" size="6"/>
 				</textElement>
@@ -313,7 +314,7 @@
 		<band height="30">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="0" y="15" width="230" height="10" isPrintWhenDetailOverflows="true" uuid="a362c07e-fbe0-4a89-917b-bb72fa58f73c">
+				<reportElement x="0" y="15" width="230" height="10" uuid="a362c07e-fbe0-4a89-917b-bb72fa58f73c">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>

--- a/print/print-apps/oereb/toc.jrxml
+++ b/print/print-apps/oereb/toc.jrxml
@@ -305,7 +305,9 @@
 				<textFieldExpression><![CDATA[$R{GeneralInformationLabel}]]></textFieldExpression>
 			</textField>
 			<subreport>
-				<reportElement x="260" y="26" width="233" height="21" isPrintWhenDetailOverflows="true" uuid="9fd65c2b-a447-43f1-88f6-9a41a9ca02be"/>
+				<reportElement x="260" y="24" width="233" height="21" isPrintWhenDetailOverflows="true" uuid="9fd65c2b-a447-43f1-88f6-9a41a9ca02be">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
 				<dataSourceExpression><![CDATA[$P{ExclusionOfLiabilityDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["exclusion_of_liability.jasper"]]></subreportExpression>
 			</subreport>

--- a/print/print-apps/oereb/toc.jrxml
+++ b/print/print-apps/oereb/toc.jrxml
@@ -275,7 +275,8 @@
 				<subreportExpression><![CDATA["themelist.jasper"]]></subreportExpression>
 			</subreport>
 		</band>
-		<band height="47">
+		<band height="77">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement x="0" y="37" width="230" height="10" uuid="9463b6fb-b28a-4793-9bc1-1c24749e48c4"/>
 				<textElement>
@@ -311,21 +312,8 @@
 				<dataSourceExpression><![CDATA[$P{ExclusionOfLiabilityDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["exclusion_of_liability.jasper"]]></subreportExpression>
 			</subreport>
-		</band>
-		<band height="30">
-			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="0" y="15" width="230" height="10" uuid="a362c07e-fbe0-4a89-917b-bb72fa58f73c">
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-				</reportElement>
-				<textElement>
-					<font fontName="Cadastra" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{BaseData}]]></textFieldExpression>
-			</textField>
 			<textField>
-				<reportElement x="0" y="5" width="230" height="10" uuid="d8ae8e69-0dd9-4161-8df2-f2e91b0211e5">
+				<reportElement positionType="Float" x="0" y="52" width="230" height="10" uuid="85c6358a-de30-4b2c-a2b4-15d2925ed1e1">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
@@ -334,6 +322,16 @@
 					<font fontName="Cadastra" size="6" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$R{BaseDataLabel}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement positionType="Float" x="0" y="62" width="230" height="10" uuid="684f53e7-19a1-4d70-9d04-82bf62c78d03">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{BaseData}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/print/print-apps/oereb/toc.jrxml
+++ b/print/print-apps/oereb/toc.jrxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
-<!-- 2019-04-25T15:36:38 -->
+<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="TocReport main" pageWidth="595" pageHeight="842" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" whenResourceMissingType="Empty" uuid="6e74177b-d551-4a75-ae51-6cdde3f284ce">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>

--- a/pyramid_oereb/standard/load_sample_data.py
+++ b/pyramid_oereb/standard/load_sample_data.py
@@ -114,6 +114,10 @@ class SampleData(object):
                 table=schema.Glossary.__table__.name
             ))
             self._connection.execute('TRUNCATE {schema}.{table} CASCADE;'.format(
+                schema=schema.ExclusionOfLiability.__table__.schema,
+                table=schema.ExclusionOfLiability.__table__.name
+            ))
+            self._connection.execute('TRUNCATE {schema}.{table} CASCADE;'.format(
                 schema=schema.Municipality.__table__.schema,
                 table=schema.Municipality.__table__.name
             ))
@@ -172,7 +176,7 @@ class SampleData(object):
         """
         from pyramid_oereb.standard.models import contaminated_public_transport_sites, \
             groundwater_protection_zones, forest_perimeters
-        from pyramid_oereb.standard.models.main import RealEstate, Address, Municipality, Glossary
+        from pyramid_oereb.standard.models.main import RealEstate, Address, Municipality, Glossary, ExclusionOfLiability
 
         if self._sql_file is None:
             self._connection = self._engine.connect()
@@ -231,6 +235,7 @@ class SampleData(object):
                 (Address, 'addresses.json'),
                 (Municipality, 'municipalities_with_logo.json'),
                 (Glossary, 'glossary.json'),
+                (ExclusionOfLiability, 'exclusion_of_liability.json')
             ]:
                 self._load_sample(class_, file_name)
 

--- a/pyramid_oereb/standard/load_sample_data.py
+++ b/pyramid_oereb/standard/load_sample_data.py
@@ -176,7 +176,8 @@ class SampleData(object):
         """
         from pyramid_oereb.standard.models import contaminated_public_transport_sites, \
             groundwater_protection_zones, forest_perimeters
-        from pyramid_oereb.standard.models.main import RealEstate, Address, Municipality, Glossary, ExclusionOfLiability
+        from pyramid_oereb.standard.models.main import RealEstate, Address, Municipality, \
+            Glossary, ExclusionOfLiability
 
         if self._sql_file is None:
             self._connection = self._engine.connect()

--- a/sample_data/exclusion_of_liability.json
+++ b/sample_data/exclusion_of_liability.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 1,
+    "title": {
+      "de": "DE Nulla tincidunt tellus at orci porta, in pharetra ante porta",
+      "fr": "FR clause de non-responsabilité ",
+      "it": "IT Nulla tincidunt tellus at orci porta, in pharetra ante porta",
+      "rm": ""
+    },
+    "content": {
+      "de": "Suspendisse potenti. Donec dapibus sapien vel mi blandit varius. Suspendisse condimentum tempor libero vitae molestie. Sed hendrerit magna at venenatis condimentum. Nam ullamcorper dui eget tristique consectetur. Nulla tincidunt tellus at orci porta, in pharetra ante porta. Nullam at quam in lectus blandit tincidunt. Curabitur sit amet lorem fringilla, mattis elit et, varius risus. Proin aliquam odio vel cursus aliquam. Quisque maximus ipsum eget neque bibendum bibendum.",
+      "fr": "Integer a felis risus. Nam maximus magna eget ligula tincidunt, hendrerit vehicula massa semper. In maximus scelerisque leo, quis aliquet augue luctus eu. Aliquam erat volutpat. Donec id maximus tellus. Suspendisse mauris orci, sagittis eget gravida in, pulvinar vitae neque. In nec nisl ipsum. Quisque sed libero at erat consequat molestie commodo posuere ipsum.",
+      "it": "Nullam eu nisl non massa tempus dictum vulputate ut neque. Aliquam in augue ultrices ipsum laoreet aliquam.",
+      "rm": ""
+    }
+  },
+    {
+    "id": 2,
+    "title": {
+      "de": "DE Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "fr": "FR Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "it": "IT Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "rm": ""
+    },
+    "content": {
+      "de": "Curabitur eros mauris, tincidunt et felis nec, sagittis imperdiet metus. Nulla ac massa sollicitudin, egestas erat eget, sodales mauris. Quisque nulla ante, laoreet ut massa in, auctor ullamcorper massa. Etiam tortor nisi, luctus eu nisi vel, elementum euismod sem. Cras convallis ut felis et tristique. Mauris erat eros, vehicula sit amet ipsum vitae, lobortis ultricies libero. Pellentesque euismod massa nec risus iaculis porta. Vivamus et sollicitudin quam. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut tempus justo",
+      "fr": "Integer a felis risus. Nam maximus magna eget ligula tincidunt, hendrerit vehicula massa semper. In maximus scelerisque leo, quis aliquet augue luctus eu. Aliquam erat volutpat. Donec id maximus tellus. Suspendisse mauris orci, sagittis eget gravida in, pulvinar vitae neque. In nec nisl ipsum. Quisque sed libero at erat consequat molestie commodo posuere ipsum.",
+      "it": "Nullam eu nisl non massa tempus dictum vulputate ut neque. Aliquam in augue ultrices ipsum laoreet aliquam.",
+      "rm": ""
+    }
+  }
+]

--- a/sample_data/exclusion_of_liability.json
+++ b/sample_data/exclusion_of_liability.json
@@ -2,19 +2,19 @@
   {
     "id": 1,
     "title": {
-      "de": "DE Nulla tincidunt tellus at orci porta, in pharetra ante porta",
-      "fr": "FR clause de non-responsabilité ",
-      "it": "IT Nulla tincidunt tellus at orci porta, in pharetra ante porta",
+      "de": "Haftungsausschluss Kataster der belasteten Standorte (KbS) vel tincidunt velit congue sed",
+      "fr": "Clause de non-responsabilité du cadastre des sites pollués (CSP) ",
+      "it": "Clausola di esclusione della responsabilità relativa al catasto dei siti inquinati (CSIN)",
       "rm": ""
     },
     "content": {
-      "de": "Suspendisse potenti. Donec dapibus sapien vel mi blandit varius. Suspendisse condimentum tempor libero vitae molestie. Sed hendrerit magna at venenatis condimentum. Nam ullamcorper dui eget tristique consectetur. Nulla tincidunt tellus at orci porta, in pharetra ante porta. Nullam at quam in lectus blandit tincidunt. Curabitur sit amet lorem fringilla, mattis elit et, varius risus. Proin aliquam odio vel cursus aliquam. Quisque maximus ipsum eget neque bibendum bibendum.",
-      "fr": "Integer a felis risus. Nam maximus magna eget ligula tincidunt, hendrerit vehicula massa semper. In maximus scelerisque leo, quis aliquet augue luctus eu. Aliquam erat volutpat. Donec id maximus tellus. Suspendisse mauris orci, sagittis eget gravida in, pulvinar vitae neque. In nec nisl ipsum. Quisque sed libero at erat consequat molestie commodo posuere ipsum.",
-      "it": "Nullam eu nisl non massa tempus dictum vulputate ut neque. Aliquam in augue ultrices ipsum laoreet aliquam.",
+      "de": "Der Kataster der belasteten Standorte (KbS) wurde anhand der vom Bundesamt für Umwelt BAFU festgelegten Kriterien erstellt und wird fortwährend aufgrund neuer Erkenntnisse (z.B. Untersuchungen) aktualisiert. Die im KbS eingetragenen Flächen können vom tatsächlichen Ausmass der Belastung abweichen. Erscheint ein Grundstück nicht im KbS, besteht keine absolute Gewähr, dass das Areal frei von jeglichen Abfall- oder Schadstoffbelastungen ist. Bahnbetrieblich, militärisch und für die Luftfahrt genutzte Standorte liegen im Zuständigkeitsbereich des Bundes.Für weitere Informationen wenden Sie sich an die kantonale Altlastenfachstelle: E-Mail Adresse und/oder Webseite",
+      "fr": "Le cadastre des sites pollués (CSP) est établi d’après les critères émis par l’Office fédéral de l’environnement OFEV. Il est mis à jour continuellement sur la base des nouvelles connaissances (investigations). Les surfaces des sites indiqués dans le cadastre des sites pollués peuvent ne pas correspondre à la surface effectivement polluée. Cela ne signifie pas que tout terrain non inscrit au cadastre ne soit pas pollué et libre de tout déchet et pollution. Les zones utilisées à des fins de transports publics, militaire et aéronautique sont de la responsabilité de la Confédération. Pour de plus amples informations, veuillez vous adresser au service spécialisé cantonal des déchets: adresse mail et/ou site web.",
+      "it": "Il catasto dei siti inquinati (CSIN) è stato elaborato sulla base dei criteri definiti dall'Ufficio federale dell'ambiente (UFAM) e viene continuamente aggiornato sulla base delle nuove conoscenze ottenute (p.es. in seguito a indagini). Le superfici riportate nel CSIN possono discostarsi dalla portata dell'inquinamento effettivo. Se un fondo non figura nel CSIN, non esiste alcuna garanzia assoluta che l'area sia libera da inquinamento dovuto a rifiuti o sostanze nocive. I siti sfruttati per finalità ferroviarie, militari o relative all'aviazione civile rientrano nella sfera di competenze della Confederazione. Per ulteriori informazioni vi invitiamo a rivolgervi al servizio cantonale responsabile dei siti inquinati: indirizzo e-mail e/o sito Internet",
       "rm": ""
     }
   },
-    {
+  {
     "id": 2,
     "title": {
       "de": "DE Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
@@ -26,6 +26,21 @@
       "de": "Curabitur eros mauris, tincidunt et felis nec, sagittis imperdiet metus. Nulla ac massa sollicitudin, egestas erat eget, sodales mauris. Quisque nulla ante, laoreet ut massa in, auctor ullamcorper massa. Etiam tortor nisi, luctus eu nisi vel, elementum euismod sem. Cras convallis ut felis et tristique. Mauris erat eros, vehicula sit amet ipsum vitae, lobortis ultricies libero. Pellentesque euismod massa nec risus iaculis porta. Vivamus et sollicitudin quam. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut tempus justo",
       "fr": "Integer a felis risus. Nam maximus magna eget ligula tincidunt, hendrerit vehicula massa semper. In maximus scelerisque leo, quis aliquet augue luctus eu. Aliquam erat volutpat. Donec id maximus tellus. Suspendisse mauris orci, sagittis eget gravida in, pulvinar vitae neque. In nec nisl ipsum. Quisque sed libero at erat consequat molestie commodo posuere ipsum.",
       "it": "Nullam eu nisl non massa tempus dictum vulputate ut neque. Aliquam in augue ultrices ipsum laoreet aliquam.",
+      "rm": ""
+    }
+  },
+  {
+    "id": 3,
+    "title": {
+      "de": "2DE Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "fr": "2FR Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "it": "2IT Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "rm": ""
+    },
+    "content": {
+      "de": "2Curabitur eros mauris, tincidunt et felis nec, sagittis imperdiet metus. Nulla ac massa sollicitudin, egestas erat eget, sodales mauris. Quisque nulla ante, laoreet ut massa in, auctor ullamcorper massa. Etiam tortor nisi, luctus eu nisi vel, elementum euismod sem. Cras convallis ut felis et tristique. Mauris erat eros, vehicula sit amet ipsum vitae, lobortis ultricies libero. Pellentesque euismod massa nec risus iaculis porta. Vivamus et sollicitudin quam. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ut tempus justo",
+      "fr": "2Integer a felis risus. Nam maximus magna eget ligula tincidunt, hendrerit vehicula massa semper. In maximus scelerisque leo, quis aliquet augue luctus eu. Aliquam erat volutpat. Donec id maximus tellus. Suspendisse mauris orci, sagittis eget gravida in, pulvinar vitae neque. In nec nisl ipsum. Quisque sed libero at erat consequat molestie commodo posuere ipsum.",
+      "it": "2Nullam eu nisl non massa tempus dictum vulputate ut neque. Aliquam in augue ultrices ipsum laoreet aliquam.",
       "rm": ""
     }
   }

--- a/sample_data/exclusion_of_liability.json
+++ b/sample_data/exclusion_of_liability.json
@@ -17,7 +17,7 @@
   {
     "id": 2,
     "title": {
-      "de": "DE Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "de": "DE Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed Morbi et ligula tempor, pulvinar sapien quis, mattis mi",
       "fr": "FR Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
       "it": "IT Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
       "rm": ""
@@ -32,9 +32,9 @@
   {
     "id": 3,
     "title": {
-      "de": "2DE Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
-      "fr": "2FR Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
-      "it": "2IT Morbi et ligula tempor, pulvinar sapien quis, mattis mi. Nam luctus fringilla nunc, vel tincidunt velit congue sed",
+      "de": "2DE Morbi et ligula tempor",
+      "fr": "2FR Morbi et ligula tempor",
+      "it": "2IT Morbi et ligula tempor",
       "rm": ""
     },
     "content": {


### PR DESCRIPTION
This PR:
- fixes titles overlapping the contents in the exclusion of liability section
- adds data which is shown in the exclusion of liability section

Fixes #703

Please note that the `Grundlagendaten` are pushed down to the end of the exclusion of liability (see screenshot). @peterschaer can you please check if this is correct.

![grundlagenDaten](https://user-images.githubusercontent.com/1460598/56785584-2dd41400-67f6-11e9-9a09-4bf550fc9a88.png)
