### PR TITLE
Only show map and table if a PLR is available for a real estate

### DIFF
--- a/print/print-apps/oereb/pdfextract.jrxml
+++ b/print/print-apps/oereb/pdfextract.jrxml
@@ -310,7 +310,11 @@
 	</group>
 	<detail>
 		<part uuid="dbf7b612-de21-4609-8537-6538c611480c">
-			<!-- IMPORTANT NOTE: This report part is only printed if there is a PLR for this real estate to avoid empty pages and tables. -->
+			<!--
+			IMPORTANT NOTE:
+			The RealEstate_RestrictionOnLandownershipDataSource is only of type JRMapCollectionDataSource
+			if there is at least one PLR for the real estate. If there is no PLR it's empty and of type JREmptyDataSource.
+			 -->
 			<printWhenExpression><![CDATA[$P{RealEstate_RestrictionOnLandownershipDataSource} instanceof net.sf.jasperreports.engine.data.JRMapCollectionDataSource]]></printWhenExpression>
 			<p:subreportPart xmlns:p="http://jasperreports.sourceforge.net/jasperreports/parts" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/parts http://jasperreports.sourceforge.net/xsd/parts.xsd">
 				<subreportParameter name="REPORT_CONNECTION">

--- a/print/print-apps/oereb/pdfextract.jrxml
+++ b/print/print-apps/oereb/pdfextract.jrxml
@@ -310,6 +310,8 @@
 	</group>
 	<detail>
 		<part uuid="dbf7b612-de21-4609-8537-6538c611480c">
+			<!-- IMPORTANT NOTE: This report part is only printed if there is a PLR for this real estate to avoid empty pages and tables. -->
+			<printWhenExpression><![CDATA[$P{RealEstate_RestrictionOnLandownershipDataSource} instanceof net.sf.jasperreports.engine.data.JRMapCollectionDataSource]]></printWhenExpression>
 			<p:subreportPart xmlns:p="http://jasperreports.sourceforge.net/jasperreports/parts" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/parts http://jasperreports.sourceforge.net/xsd/parts.xsd">
 				<subreportParameter name="REPORT_CONNECTION">
 					<subreportParameterExpression><![CDATA[$P{REPORT_CONNECTION}]]></subreportParameterExpression>


### PR DESCRIPTION
Addresses issue #774.
This only prints the PLR section of the PDF if at least one PLR is available for a real estate.

@peterschaer and @svareg can please you check if this works for you.

**Developers note:**
To reconstruct a real estate with out a PLR do the following:

in the print_proxy make the function [convert_to_printable_extract](https://github.com/openoereb/pyramid_oereb/blob/af0262a654a540fa1fe4d311077a23d7ee0fa291/pyramid_oereb/contrib/print_proxy/mapfish_print.py#L161) return an empty `RealEstate_RestrictionOnLandownership`in the `extract_dict` list by adding the following lines at the end of the function

        extract_dict['RealEstate_RestrictionOnLandownership'] = []
        extract_dict['NotConcernedTheme'] += extract_dict['ConcernedTheme']
        extract_dict['ConcernedTheme'] = []