### PR TITLE
fix tests for exclusion of liability

### DIFF
--- a/tests/readers/test_exclusion_of_liability.py
+++ b/tests/readers/test_exclusion_of_liability.py
@@ -23,6 +23,6 @@ def test_read():
     )
     results = reader.read()
     assert isinstance(results, list)
-    assert len(results) == 0
+    assert len(results) == 3
 
 # TODO: Implement tests for return values, not possible now, cause there is no data in database

--- a/tests/sources/test_exclusion_of_liability_database.py
+++ b/tests/sources/test_exclusion_of_liability_database.py
@@ -23,4 +23,4 @@ def test_read():
         **Config.get_exclusion_of_liability_config().get('source').get('params')
     )
     source.read()
-    assert len(source.records) == 0
+    assert len(source.records) == 3


### PR DESCRIPTION
After adding data for the exclusion of liability the tests also need to be corrected. For some reason the CI did not fail in this but local tests did. This PR is to correct this.