### PR TITLE
Sorting legend

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -23,6 +23,8 @@ else:
 
 log = logging.getLogger(__name__)
 
+LEGEND_ELEMENT_SORT_ORDER = {'AreaShare': 1, 'LengthShare': 2, 'NrOfPoints': 3}
+
 
 class Renderer(JsonRenderer):
 
@@ -604,31 +606,42 @@ class Renderer(JsonRenderer):
 
     def _get_sorted_legend(self, legend_list):
         """
-        Takes an unsorted list of legend and returns it sorts, depending on the geometry type
-        and on the value of the geomety tye if this is available
+        Takes an unsorted list of legends and returns it sorts, depending on the geometry type and on the
+        value of the geometry type in reverse order (largest first) for AreaShare, LengthShare.
 
         Args:
-            legend_list: list of legends
+            legend_list: list of legend dictionaries
 
         Returns:
-             sorted list of legends
+             sorted list of legend dictionaries
         """
         return sorted(legend_list, key=self._sort_legend_elem)
 
     @staticmethod
     def _sort_legend_elem(elem):
         """
-        Returns a tuple of the geometry type of the element and the value of the geometry
-        type if it is available. Else it returns the geometry type and 0 as value
+        Used to map the elements of a list of dictionaries (the legend list) to a tuple of two values to
+        sort against. The first value is to sort after it the geometry type the second is the value of
+        the geometry type if this is available.
+
+        This function:
+            * first determines the category of the current geometry type according to what is defined in
+            LEGEND_ELEMENT_SORT_ORDER. This returned the order in which the geometry_types are sorted.
+
+            * determines the value of the geometry_type and returns it so these values will be sorted
+            in reverse order. This is done for the geometry types AreaShare and LengthShare. There is no
+            Information about this in NrOfPoints so they are not further sorted
 
         Args:
-            elem: one legend entry
+            elem: one legend entry in form of a dict
 
         Returns:
-            geom_type, int value
+            category: int between 1 and 4
+            value: int value of the geometry_type if available else 0
         """
         geom_type = elem['Geom_Type']
-        if geom_type == 'NrOfPoints':
-            return (geom_type, 0)
-        else:
-            return geom_type, elem[geom_type]
+
+        category = LEGEND_ELEMENT_SORT_ORDER.get(geom_type, 4)
+        value = elem.get(geom_type, 0)
+
+        return category, -value

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -404,8 +404,10 @@ class Renderer(JsonRenderer):
                         legend[item] = legend[item]
             # After transformation, get the new legend entries, sorted by TypeCode
             transformed_legend = \
-                list([transformed_entry for (key, transformed_entry) in sorted(legends.items())])
-            restriction['Legend'] = transformed_legend
+                list([transformed_entry for (key, transformed_entry) in legends.items()])
+
+            restriction['Legend'] = self._get_sorted_legend(transformed_legend)
+            # sorted(transformed_legend, key=self._sort_legend_list)
 
         sorted_restrictions = []
         if split_sub_themes:
@@ -601,3 +603,16 @@ class Renderer(JsonRenderer):
         sorter = Renderer._load_sorter(sorter_config['module'], sorter_config['class_name'])
         params = sorter_config.get('params', {})
         return sorter, params
+
+    def _get_sorted_legend(self, legend_list):
+        return sorted(legend_list, key=self._sort_legend_elem)
+
+    @staticmethod
+    def _sort_legend_elem(elem):
+        geom_type = elem['Geom_Type']
+        if geom_type is 'AreaShare':
+            return elem['AreaShare']
+        elif geom_type is 'LengthShare':
+            return elem['LengthShare']
+        else:
+            return 0

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -23,7 +23,11 @@ else:
 
 log = logging.getLogger(__name__)
 
-LEGEND_ELEMENT_SORT_ORDER = {'AreaShare': 1, 'LengthShare': 2, 'NrOfPoints': 3}
+LEGEND_ELEMENT_SORT_ORDER = [
+    'AreaShare',
+    'LengthShare',
+    'NrOfPoints'
+]
 
 
 class Renderer(JsonRenderer):
@@ -606,42 +610,40 @@ class Renderer(JsonRenderer):
 
     def _get_sorted_legend(self, legend_list):
         """
-        Takes an unsorted list of legends and returns it sorts, depending on the geometry type and on the
-        value of the geometry type in reverse order (largest first) for AreaShare, LengthShare.
+        Sorts list of legends by type (as defined in LEGEND_ELEMENT_SORT_ORDER) and value (ascending order).
 
         Args:
             legend_list: list of legend dictionaries
 
         Returns:
-             sorted list of legend dictionaries
+            sorted list of legend dictionaries
         """
         return sorted(legend_list, key=self._sort_legend_elem)
 
     @staticmethod
     def _sort_legend_elem(elem):
         """
-        Used to map the elements of a list of dictionaries (the legend list) to a tuple of two values to
-        sort against. The first value is to sort after it the geometry type the second is the value of
-        the geometry type if this is available.
-
-        This function:
-            * first determines the category of the current geometry type according to what is defined in
-            LEGEND_ELEMENT_SORT_ORDER. This returned the order in which the geometry_types are sorted.
-
-            * determines the value of the geometry_type and returns it so these values will be sorted
-            in reverse order. This is done for the geometry types AreaShare and LengthShare. There is no
-            Information about this in NrOfPoints so they are not further sorted
+        Provides the sort key for the supplied legend element as a tuple consisting of:
+         * rank of the geometry type as defined in LEGEND_ELEMENT_SORT_ORDER
+         * value of the geometry if available (AreaShare and LengthShare)
 
         Args:
-            elem: one legend entry in form of a dict
+            elem (dict): legend entry
 
         Returns:
-            category: int between 1 and 4
-            value: int value of the geometry_type if available else 0
+            sort key (tuple)
         """
         geom_type = elem['Geom_Type']
 
-        category = LEGEND_ELEMENT_SORT_ORDER.get(geom_type, 4)
-        value = elem.get(geom_type, 0)
+        if geom_type in LEGEND_ELEMENT_SORT_ORDER:
+            # Get predefined order
+            category = LEGEND_ELEMENT_SORT_ORDER.index(geom_type)
+        else:
+            # Put elements not found predefined order last
+            category = len(LEGEND_ELEMENT_SORT_ORDER)
 
-        return category, -value
+        # Use value as secondary criteria if available (defaults to 0 if not available).
+        # Negative value for ascending sort order.
+        value = -elem.get(geom_type, 0)
+
+        return category, value

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -407,7 +407,6 @@ class Renderer(JsonRenderer):
                 list([transformed_entry for (key, transformed_entry) in legends.items()])
 
             restriction['Legend'] = self._get_sorted_legend(transformed_legend)
-            # sorted(transformed_legend, key=self._sort_legend_list)
 
         sorted_restrictions = []
         if split_sub_themes:
@@ -610,9 +609,7 @@ class Renderer(JsonRenderer):
     @staticmethod
     def _sort_legend_elem(elem):
         geom_type = elem['Geom_Type']
-        if geom_type is 'AreaShare':
-            return elem['AreaShare']
-        elif geom_type is 'LengthShare':
-            return elem['LengthShare']
+        if geom_type == 'NrOfPoints':
+            return (geom_type, 0)
         else:
-            return 0
+            return geom_type, elem[geom_type]

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -405,7 +405,6 @@ class Renderer(JsonRenderer):
             # After transformation, get the new legend entries, sorted by TypeCode
             transformed_legend = \
                 list([transformed_entry for (key, transformed_entry) in legends.items()])
-
             restriction['Legend'] = self._get_sorted_legend(transformed_legend)
 
         sorted_restrictions = []
@@ -604,10 +603,30 @@ class Renderer(JsonRenderer):
         return sorter, params
 
     def _get_sorted_legend(self, legend_list):
+        """
+        Takes an unsorted list of legend and returns it sorts, depending on the geometry type
+        and on the value of the geomety tye if this is available
+
+        Args:
+            legend_list: list of legends
+
+        Returns:
+             sorted list of legends
+        """
         return sorted(legend_list, key=self._sort_legend_elem)
 
     @staticmethod
     def _sort_legend_elem(elem):
+        """
+        Returns a tuple of the geometry type of the element and the value of the geometry
+        type if it is available. Else it returns the geometry type and 0 as value
+
+        Args:
+            elem: one legend entry
+
+        Returns:
+            geom_type, int value
+        """
         geom_type = elem['Geom_Type']
         if geom_type == 'NrOfPoints':
             return (geom_type, 0)

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -145,7 +145,6 @@ def test_mapfish_print_entire_extract():
 
 
 def test_split_restrictions_by_theme_code():
-    renderer = Renderer(DummyRenderInfo())
     test_data = [
                {
                    "Theme_Code": "ContaminatedPublicTransportSites",
@@ -196,7 +195,7 @@ def test_split_restrictions_by_theme_code():
         ]
     }
 
-    splitted = renderer._split_restrictions_by_theme_code(test_data)
+    splitted = Renderer._split_restrictions_by_theme_code(test_data)
     for theme in splitted:
         for index in range(len(splitted[theme])):
             assert splitted[theme][index]["Theme_Code"] == expected_result[theme][index]["Theme_Code"]

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -145,6 +145,7 @@ def test_mapfish_print_entire_extract():
 
 
 def test_split_restrictions_by_theme_code():
+    renderer = Renderer(DummyRenderInfo())
     test_data = [
                {
                    "Theme_Code": "ContaminatedPublicTransportSites",
@@ -195,7 +196,7 @@ def test_split_restrictions_by_theme_code():
         ]
     }
 
-    splitted = Renderer._split_restrictions_by_theme_code(test_data)
+    splitted = renderer._split_restrictions_by_theme_code(test_data)
     for theme in splitted:
         for index in range(len(splitted[theme])):
             assert splitted[theme][index]["Theme_Code"] == expected_result[theme][index]["Theme_Code"]
@@ -210,3 +211,97 @@ def test_load_sorter():
     assert alphabetic_sort == AlphabeticSort
     list_sort = Renderer._load_sorter(module_name, class_list_sort)
     assert list_sort == ListSort
+
+
+def test_get_sorted_legend():
+    renderer = Renderer(DummyRenderInfo())
+    test_legend_list = [
+        {
+            'TypeCode': u'StaoTyp2',
+            'Geom_Type': u'AreaShare',
+            'TypeCodelist': '',
+            'AreaShare': 11432,
+            'PartInPercent': 32.6,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp2',
+            'Information': u'Belastet, untersuchungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp3',
+            'Geom_Type': u'LengthShare',
+            'TypeCodelist': '',
+            'LengthShare': 164,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp3',
+            'Information': u'Belastet, überwachungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp1',
+            'Geom_Type': u'NrOfPoints',
+            'TypeCodelist': '',
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp1',
+            'Information': u'Belastet, keine schädlichen oder lästigen Einwirkungen zu erwarten'
+        }, {
+            'TypeCode': u'StaoTyp3',
+            'Geom_Type': u'LengthShare',
+            'TypeCodelist': '',
+            'LengthShare': 2000,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp3',
+            'Information': u'Belastet, untersuchungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp2',
+            'Geom_Type': u'AreaShare',
+            'TypeCodelist': '',
+            'AreaShare': 114,
+            'PartInPercent': 32.6,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp2',
+            'Information': u'Belastet, untersuchungsbedürftig'
+        }
+    ]
+    sorted_list = renderer._get_sorted_legend(test_legend_list)
+    expected_result = [
+        {
+            'TypeCode': u'StaoTyp2',
+            'Geom_Type': u'AreaShare',
+            'TypeCodelist': '',
+            'AreaShare': 114,
+            'PartInPercent': 32.6,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp2',
+            'Information': u'Belastet, untersuchungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp2',
+            'Geom_Type': u'AreaShare',
+            'TypeCodelist': '',
+            'AreaShare': 11432,
+            'PartInPercent': 32.6,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp2',
+            'Information': u'Belastet, untersuchungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp3',
+            'Geom_Type': u'LengthShare',
+            'TypeCodelist': '',
+            'LengthShare': 164,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp3',
+            'Information': u'Belastet, überwachungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp3',
+            'Geom_Type': u'LengthShare',
+            'TypeCodelist': '',
+            'LengthShare': 2000,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp3',
+            'Information': u'Belastet, untersuchungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp1',
+            'Geom_Type': u'NrOfPoints',
+            'TypeCodelist': '',
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp1',
+            'Information': u'Belastet, keine schädlichen oder lästigen Einwirkungen zu erwarten'
+        }
+    ]
+    assert sorted_list == expected_result

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -264,7 +264,7 @@ def test_get_sorted_legend():
             'TypeCode': u'StaoTyp2',
             'Geom_Type': u'AreaShare',
             'TypeCodelist': '',
-            'AreaShare': 114,
+            'AreaShare': 11432,
             'PartInPercent': 32.6,
             'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
                         ContaminatedPublicTransportSites/1/StaoTyp2',
@@ -273,10 +273,18 @@ def test_get_sorted_legend():
             'TypeCode': u'StaoTyp2',
             'Geom_Type': u'AreaShare',
             'TypeCodelist': '',
-            'AreaShare': 11432,
+            'AreaShare': 114,
             'PartInPercent': 32.6,
             'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
                         ContaminatedPublicTransportSites/1/StaoTyp2',
+            'Information': u'Belastet, untersuchungsbedürftig'
+        }, {
+            'TypeCode': u'StaoTyp3',
+            'Geom_Type': u'LengthShare',
+            'TypeCodelist': '',
+            'LengthShare': 2000,
+            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
+                        ContaminatedPublicTransportSites/1/StaoTyp3',
             'Information': u'Belastet, untersuchungsbedürftig'
         }, {
             'TypeCode': u'StaoTyp3',
@@ -286,14 +294,6 @@ def test_get_sorted_legend():
             'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
                         ContaminatedPublicTransportSites/1/StaoTyp3',
             'Information': u'Belastet, überwachungsbedürftig'
-        }, {
-            'TypeCode': u'StaoTyp3',
-            'Geom_Type': u'LengthShare',
-            'TypeCodelist': '',
-            'LengthShare': 2000,
-            'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
-                        ContaminatedPublicTransportSites/1/StaoTyp3',
-            'Information': u'Belastet, untersuchungsbedürftig'
         }, {
             'TypeCode': u'StaoTyp1',
             'Geom_Type': u'NrOfPoints',


### PR DESCRIPTION
Sorts the legends according to:
1. geometry Type
2. length or pars in percent

Fixes #380

**NOTE**
for testing you can set the sub-theme flag to false in [docker/config.yaml](https://github.com/openoereb/pyramid_oereb/blob/master/docker/config.yaml#L94) to have a better example with more legends.