### PR TITLE
Fix page numbers in longer TOC

### DIFF
--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -92,6 +92,10 @@ vars:
       # Split themes up, so that each sub theme gets its own page
       # Disabled by default.
       split_sub_themes: true
+      # Determine if a multiple page table of content (TOC) is used with a slightly different layout but
+      # better page numbering. If it is known that the TOC is very long and runs over more than one page it
+      # is preferred to set this to true.
+      multi_page_TOC: false
       # Specify any additional URL parameters that the print shall use for WMS calls
       wms_url_params:
         TRANSPARENT: 'true'

--- a/print/print-apps/oereb/additionalInfoMultipageTOC.jrxml
+++ b/print/print-apps/oereb/additionalInfoMultipageTOC.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
+<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
+<!-- 2019-05-24T14:23:19 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="TocReport main" pageWidth="595" pageHeight="842" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" whenResourceMissingType="Empty" uuid="6e74177b-d551-4a75-ae51-6cdde3f284ce">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
@@ -152,7 +153,6 @@
 	</pageHeader>
 	<columnHeader>
 		<band height="113">
-			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 			<textField>
 				<reportElement x="0" y="60" width="493" height="22" uuid="fa52aeda-5e82-410d-9ef5-cc1a9443f5a5">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
@@ -163,15 +163,9 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$R{TableofContentLabel}]]></textFieldExpression>
 			</textField>
-		</band>
-	</columnHeader>
-	<detail>
-		<band height="63">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<textField>
-				<reportElement x="0" y="28" width="493" height="15" uuid="26bc8336-77bd-4624-92a9-58bb947c6098">
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				<reportElement x="0" y="97" width="493" height="15" uuid="26bc8336-77bd-4624-92a9-58bb947c6098">
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
 				</reportElement>
 				<box>
 					<bottomPen lineWidth="0.2"/>
@@ -181,11 +175,17 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$R{Topicsnotaffectingtherealestate}]]></textFieldExpression>
 			</textField>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="20">
+			<property name="local_mesure_unitheight" value="pixel"/>
 			<subreport>
-				<reportElement x="0" y="48" width="493" height="15" isPrintWhenDetailOverflows="true" uuid="285be929-4832-42d1-907e-8ad64f1ff057">
+				<reportElement x="0" y="5" width="493" height="15" isPrintWhenDetailOverflows="true" uuid="285be929-4832-42d1-907e-8ad64f1ff057">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<dataSourceExpression><![CDATA[$P{NotConcernedThemeDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["themelist.jasper"]]></subreportExpression>

--- a/print/print-apps/oereb/additionalInfoMultipageTOC.jrxml
+++ b/print/print-apps/oereb/additionalInfoMultipageTOC.jrxml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="TocReport main" pageWidth="595" pageHeight="842" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" whenResourceMissingType="Empty" uuid="6e74177b-d551-4a75-ae51-6cdde3f284ce">
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+	<property name="net.sf.jasperreports.print.create.bookmarks" value="true"/>
+	<style name="Default" isDefault="true" fontName="Cadastra" fontSize="8"/>
+	<style name="Title" hTextAlign="Right" hImageAlign="Right" fontSize="32">
+		<box>
+			<topPen lineWidth="1.0"/>
+		</box>
+	</style>
+	<style name="Heading1" style="Default" fontSize="16" isBold="true">
+		<box>
+			<bottomPen lineWidth="0.5" lineStyle="Dashed"/>
+		</box>
+	</style>
+	<style name="HeadingLabel1" style="Heading1"/>
+	<style name="HeadingIndex1" style="Heading1"/>
+	<style name="Heading2" style="Default" fontSize="16">
+		<box>
+			<bottomPen lineWidth="0.5" lineStyle="Dashed"/>
+		</box>
+	</style>
+	<style name="HeadingLabel2" style="Heading2"/>
+	<style name="HeadingIndex2" style="Heading2"/>
+	<style name="Heading3" style="Default" fontSize="12">
+		<box>
+			<bottomPen lineWidth="0.0" lineStyle="Dashed"/>
+		</box>
+	</style>
+	<style name="HeadingLabel3" style="Heading3"/>
+	<style name="HeadingIndex3" style="Heading3"/>
+	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
+	<parameter name="BookmarkDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="isReduced" class="java.lang.Boolean"/>
+	<parameter name="ExtractIdentifier" class="java.lang.String"/>
+	<parameter name="CreationDate" class="java.lang.String"/>
+	<parameter name="Footer" class="java.lang.String"/>
+	<parameter name="FederalLogo" class="java.lang.String"/>
+	<parameter name="FederalLogoRef" class="java.lang.String"/>
+	<parameter name="CantonalLogo" class="java.lang.String"/>
+	<parameter name="CantonalLogoRef" class="java.lang.String"/>
+	<parameter name="MunicipalityLogo" class="java.lang.String"/>
+	<parameter name="MunicipalityLogoRef" class="java.lang.String"/>
+	<parameter name="LogoPLRCadastre" class="java.lang.String"/>
+	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_UID" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Name" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_OfficeAtWeb" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Line1" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Line2" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Street" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Number" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_PostalCode" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_City" class="java.lang.String"/>
+	<parameter name="Signature" class="java.lang.String"/>
+	<parameter name="BaseData" class="java.lang.String"/>
+	<parameter name="GeneralInformation" class="java.lang.String"/>
+	<parameter name="ExclusionOfLiabilityDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="ConcernedThemeDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="NotConcernedThemeDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="ThemeWithoutDataDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="QRCode" class="java.lang.String"/>
+	<parameter name="QRCodeRef" class="java.lang.String"/>
+	<parameter name="RealEstate_Number" class="java.lang.String"/>
+	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
+	<parameter name="RealEstate_Municipality" class="java.lang.String"/>
+	<parameter name="RealEstate_FosNr" class="java.lang.String"/>
+	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
+	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
+	<parameter name="TOC_Appendices" class="java.util.Map"/>
+	<field name="Text" class="java.lang.String"/>
+	<pageHeader>
+		<band height="60">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<image scaleImage="RetainShape" hAlign="Center">
+				<reportElement x="0" y="0" width="124" height="40" uuid="cf244674-e3aa-4c26-a00a-d6e9ecce9958">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="local_mesure_unity" value="mm"/>
+					<property name="local_mesure_unitwidth" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+					<property name="local_mesure_unitheight" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{FederalLogoRef}]]></imageExpression>
+			</image>
+			<image hAlign="Center">
+				<reportElement x="170" y="0" width="85" height="28" uuid="4e47be90-0b29-4b21-9927-be7e17a08e66">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{CantonalLogoRef}]]></imageExpression>
+			</image>
+			<image hAlign="Center" onErrorType="Blank">
+				<reportElement x="269" y="0" width="85" height="28" uuid="61c41ba3-9b96-48ac-b21a-e8c44dd887b5">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{MunicipalityLogoRef}]]></imageExpression>
+			</image>
+			<textField>
+				<reportElement stretchType="RelativeToTallestObject" x="269" y="29" width="85" height="15" uuid="31fc5499-78b7-4ae1-880e-e93d48c7c9a2">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Center">
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_Municipality}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="0" y="54" width="493" height="1" uuid="2c7bc46a-93be-4dfe-b2ea-273b4e077203">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.2" lineStyle="Solid"/>
+				</graphicElement>
+			</line>
+			<image hAlign="Center">
+				<reportElement x="394" y="0" width="99" height="28" uuid="8192d808-4d37-4eb7-adce-086d5702197f">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{LogoPLRCadastreRef}]]></imageExpression>
+			</image>
+		</band>
+	</pageHeader>
+	<columnHeader>
+		<band height="113">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<textField>
+				<reportElement x="0" y="60" width="493" height="22" uuid="fa52aeda-5e82-410d-9ef5-cc1a9443f5a5">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="15" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{TableofContentLabel}]]></textFieldExpression>
+			</textField>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="63">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField>
+				<reportElement x="0" y="28" width="493" height="15" uuid="26bc8336-77bd-4624-92a9-58bb947c6098">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<box>
+					<bottomPen lineWidth="0.2"/>
+				</box>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="9" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{Topicsnotaffectingtherealestate}]]></textFieldExpression>
+			</textField>
+			<subreport>
+				<reportElement x="0" y="48" width="493" height="15" isPrintWhenDetailOverflows="true" uuid="285be929-4832-42d1-907e-8ad64f1ff057">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<dataSourceExpression><![CDATA[$P{NotConcernedThemeDataSource}]]></dataSourceExpression>
+				<subreportExpression><![CDATA["themelist.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+		<band height="63">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<textField>
+				<reportElement key="" x="0" y="28" width="493" height="15" uuid="de8e740f-3672-4620-8d7d-b68c68018d9f">
+					<printWhenExpression><![CDATA["hallo" == "hallo"]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<bottomPen lineWidth="0.2"/>
+				</box>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="9" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{Topicswithoutdata}]]></textFieldExpression>
+			</textField>
+			<subreport>
+				<reportElement x="0" y="48" width="493" height="15" isPrintWhenDetailOverflows="true" uuid="ec7e076f-0e37-4f8a-ba49-aee32f5b1b78">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<dataSourceExpression><![CDATA[$P{ThemeWithoutDataDataSource}]]></dataSourceExpression>
+				<subreportExpression><![CDATA["themelist.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+		<band height="77">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement x="0" y="37" width="230" height="10" uuid="9463b6fb-b28a-4793-9bc1-1c24749e48c4"/>
+				<textElement>
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{GeneralInformation}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="0" y="26" width="230" height="11" uuid="e834b965-7821-4998-ac78-82c63301b2e1">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="6" isBold="true"/>
+				</textElement>
+				<text><![CDATA[]]></text>
+			</staticText>
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="26" width="230" height="11" uuid="e8e72f34-6553-41ad-a3cd-75273b060f24">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="6" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{GeneralInformationLabel}]]></textFieldExpression>
+			</textField>
+			<subreport>
+				<reportElement x="260" y="24" width="233" height="21" isPrintWhenDetailOverflows="true" uuid="9fd65c2b-a447-43f1-88f6-9a41a9ca02be">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<dataSourceExpression><![CDATA[$P{ExclusionOfLiabilityDataSource}]]></dataSourceExpression>
+				<subreportExpression><![CDATA["exclusion_of_liability.jasper"]]></subreportExpression>
+			</subreport>
+			<textField>
+				<reportElement positionType="Float" x="0" y="52" width="230" height="10" uuid="85c6358a-de30-4b2c-a2b4-15d2925ed1e1">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="6" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{BaseDataLabel}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement positionType="Float" x="0" y="62" width="230" height="10" uuid="684f53e7-19a1-4d70-9d04-82bf62c78d03">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{BaseData}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="10">
+			<line>
+				<reportElement x="0" y="0" width="493" height="1" uuid="f8baaac4-0124-4f50-b8bb-fd8e8451dea7">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.8"/>
+				</graphicElement>
+			</line>
+			<textField>
+				<reportElement x="0" y="1" width="281" height="8" uuid="b78ad76c-e391-4edd-a0ab-2ebed93889cd">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Footer}]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Master" isBlankWhenNull="true">
+				<reportElement x="385" y="1" width="108" height="8" uuid="b4dfa216-323b-41b9-8811-ade5ada8995a">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[String.format($R{PageLabel}, $V{MASTER_CURRENT_PAGE}, $V{MASTER_TOTAL_PAGES})]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -213,6 +213,8 @@ templates:
             PLRCadastreAuthority_Number: !string {}
             PLRCadastreAuthority_PostalCode: !string {}
             PLRCadastreAuthority_City: !string {}
+            MultiPageTOC: !boolean
+                default: true
 
             northArrow: !northArrow
                 size: 17

--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -214,7 +214,7 @@ templates:
             PLRCadastreAuthority_PostalCode: !string {}
             PLRCadastreAuthority_City: !string {}
             MultiPageTOC: !boolean
-                default: true
+                default: false
 
             northArrow: !northArrow
                 size: 17

--- a/print/print-apps/oereb/multiPageTOC.jrxml
+++ b/print/print-apps/oereb/multiPageTOC.jrxml
@@ -244,6 +244,27 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$F{label}]]></textFieldExpression>
 			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="LocalAnchor">
+				<reportElement positionType="Float" stretchType="RelativeToTallestObject" x="232" y="0" width="261" height="20" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="45d42da5-0ce8-4efe-981d-3bb452ac3715">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<printWhenExpression><![CDATA[!($P{isReduced})]]></printWhenExpression>
+				</reportElement>
+				<box topPadding="5" bottomPadding="4">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Middle">
+					<font size="9" isBold="false"/>
+					<paragraph leftIndent="0"/>
+				</textElement>
+				<textFieldExpression><![CDATA[String.join("\n", (List<String>)$P{TOC_Appendices}.get( $F{label}))]]></textFieldExpression>
+			</textField>
 		</band>
 	</detail>
 	<pageFooter>

--- a/print/print-apps/oereb/multiPageTOC.jrxml
+++ b/print/print-apps/oereb/multiPageTOC.jrxml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="TocReport main" pageWidth="595" pageHeight="842" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" whenResourceMissingType="Empty" uuid="6e74177b-d551-4a75-ae51-6cdde3f284ce">
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+	<property name="net.sf.jasperreports.print.create.bookmarks" value="true"/>
+	<style name="Default" isDefault="true" fontName="Cadastra" fontSize="8"/>
+	<style name="Title" hTextAlign="Right" hImageAlign="Right" fontSize="32">
+		<box>
+			<topPen lineWidth="1.0"/>
+		</box>
+	</style>
+	<style name="Heading1" style="Default" fontSize="16" isBold="true">
+		<box>
+			<bottomPen lineWidth="0.5" lineStyle="Dashed"/>
+		</box>
+	</style>
+	<style name="HeadingLabel1" style="Heading1"/>
+	<style name="HeadingIndex1" style="Heading1"/>
+	<style name="Heading2" style="Default" fontSize="16">
+		<box>
+			<bottomPen lineWidth="0.5" lineStyle="Dashed"/>
+		</box>
+	</style>
+	<style name="HeadingLabel2" style="Heading2"/>
+	<style name="HeadingIndex2" style="Heading2"/>
+	<style name="Heading3" style="Default" fontSize="12">
+		<box>
+			<bottomPen lineWidth="0.0" lineStyle="Dashed"/>
+		</box>
+	</style>
+	<style name="HeadingLabel3" style="Heading3"/>
+	<style name="HeadingIndex3" style="Heading3"/>
+	<parameter name="SUBREPORT_DIR" class="java.lang.String"/>
+	<parameter name="BookmarkDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="isReduced" class="java.lang.Boolean"/>
+	<parameter name="ExtractIdentifier" class="java.lang.String"/>
+	<parameter name="CreationDate" class="java.lang.String"/>
+	<parameter name="Footer" class="java.lang.String"/>
+	<parameter name="FederalLogo" class="java.lang.String"/>
+	<parameter name="FederalLogoRef" class="java.lang.String"/>
+	<parameter name="CantonalLogo" class="java.lang.String"/>
+	<parameter name="CantonalLogoRef" class="java.lang.String"/>
+	<parameter name="MunicipalityLogo" class="java.lang.String"/>
+	<parameter name="MunicipalityLogoRef" class="java.lang.String"/>
+	<parameter name="LogoPLRCadastre" class="java.lang.String"/>
+	<parameter name="LogoPLRCadastreRef" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_UID" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Name" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_OfficeAtWeb" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Line1" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Line2" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Street" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_Number" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_PostalCode" class="java.lang.String"/>
+	<parameter name="PLRCadastreAuthority_City" class="java.lang.String"/>
+	<parameter name="Signature" class="java.lang.String"/>
+	<parameter name="BaseData" class="java.lang.String"/>
+	<parameter name="GeneralInformation" class="java.lang.String"/>
+	<parameter name="ExclusionOfLiabilityDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="ConcernedThemeDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="NotConcernedThemeDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="ThemeWithoutDataDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<parameter name="QRCode" class="java.lang.String"/>
+	<parameter name="QRCodeRef" class="java.lang.String"/>
+	<parameter name="RealEstate_Number" class="java.lang.String"/>
+	<parameter name="RealEstate_EGRID" class="java.lang.String"/>
+	<parameter name="RealEstate_Municipality" class="java.lang.String"/>
+	<parameter name="RealEstate_FosNr" class="java.lang.String"/>
+	<parameter name="RealEstate_LandRegistryArea" class="java.lang.String"/>
+	<parameter name="RealEstate_SubunitOfLandRegister" class="java.lang.String"/>
+	<parameter name="TOC_Appendices" class="java.util.Map"/>
+	<field name="level" class="java.lang.Integer"/>
+	<field name="label" class="java.lang.String"/>
+	<field name="pageIndex" class="java.lang.Integer"/>
+	<pageHeader>
+		<band height="60">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<image scaleImage="RetainShape" hAlign="Center">
+				<reportElement x="0" y="0" width="124" height="40" uuid="cf244674-e3aa-4c26-a00a-d6e9ecce9958">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="local_mesure_unity" value="mm"/>
+					<property name="local_mesure_unitwidth" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+					<property name="local_mesure_unitheight" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{FederalLogoRef}]]></imageExpression>
+			</image>
+			<image hAlign="Center">
+				<reportElement x="170" y="0" width="85" height="28" uuid="4e47be90-0b29-4b21-9927-be7e17a08e66">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{CantonalLogoRef}]]></imageExpression>
+			</image>
+			<image hAlign="Center" onErrorType="Blank">
+				<reportElement x="269" y="0" width="85" height="28" uuid="61c41ba3-9b96-48ac-b21a-e8c44dd887b5">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{MunicipalityLogoRef}]]></imageExpression>
+			</image>
+			<textField>
+				<reportElement stretchType="RelativeToTallestObject" x="269" y="29" width="85" height="15" uuid="31fc5499-78b7-4ae1-880e-e93d48c7c9a2">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Center">
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{RealEstate_Municipality}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement x="0" y="54" width="493" height="1" uuid="2c7bc46a-93be-4dfe-b2ea-273b4e077203">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.2" lineStyle="Solid"/>
+				</graphicElement>
+			</line>
+			<image hAlign="Center">
+				<reportElement x="394" y="0" width="99" height="28" uuid="8192d808-4d37-4eb7-adce-086d5702197f">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="com.jaspersoft.studio.unit.x" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{LogoPLRCadastreRef}]]></imageExpression>
+			</image>
+		</band>
+	</pageHeader>
+	<columnHeader>
+		<band height="143">
+			<textField>
+				<reportElement x="0" y="60" width="493" height="22" uuid="596ac5cd-c22b-45eb-aa46-4891db028f3d">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="15" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{TableofContentLabel}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement x="0" y="98" width="493" height="15" uuid="b5873402-580f-4219-a7d4-aa511fd2b1b6">
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="9" isBold="true"/>
+					<paragraph spacingAfter="3"/>
+				</textElement>
+				<textFieldExpression><![CDATA[String.format($R{Topicsaffectingtherealestate_ofthemunicipalityof_}, $P{RealEstate_Number}, $P{RealEstate_Municipality})]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				<reportElement stretchType="RelativeToTallestObject" x="0" y="118" width="492" height="10" uuid="74048771-76de-4810-825e-77d4e5643dd3">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="7" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{TOCPageLabel}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement x="232" y="118" width="261" height="10" uuid="0bae6376-40d3-4a91-ada1-04236d63c54c">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<printWhenExpression><![CDATA[!($P{isReduced})]]></printWhenExpression>
+				</reportElement>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="7" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{AppendicesLabel}]]></textFieldExpression>
+			</textField>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="20">
+			<textField evaluationTime="Auto" isBlankWhenNull="false" hyperlinkType="LocalAnchor">
+				<reportElement x="0" y="0" width="20" height="20" uuid="c4c33f13-674c-43d9-b0a4-b1d489a41f41">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<printWhenExpression><![CDATA[$F{level} == 1]]></printWhenExpression>
+				</reportElement>
+				<box topPadding="5" leftPadding="0" bottomPadding="4"/>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="9" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$V{PAGE_NUMBER} + $F{pageIndex} + 2]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="LocalAnchor">
+				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="493" height="20" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="b931dcd1-5c4d-401c-a409-9fb85e4250c1">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<printWhenExpression><![CDATA[$F{level} == 1]]></printWhenExpression>
+				</reportElement>
+				<box topPadding="5" bottomPadding="4">
+					<bottomPen lineWidth="0.2"/>
+				</box>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra" size="9" isBold="false"/>
+					<paragraph lineSpacing="Single" leftIndent="19" rightIndent="0"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{label}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<pageFooter>
+		<band height="10">
+			<line>
+				<reportElement x="0" y="0" width="493" height="1" uuid="f8baaac4-0124-4f50-b8bb-fd8e8451dea7">
+					<property name="com.jaspersoft.studio.unit.height" value="mm"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="0.8"/>
+				</graphicElement>
+			</line>
+			<textField>
+				<reportElement x="0" y="1" width="281" height="8" uuid="b78ad76c-e391-4edd-a0ab-2ebed93889cd">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<textElement>
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{Footer}]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Master" isBlankWhenNull="true">
+				<reportElement x="385" y="1" width="108" height="8" uuid="b4dfa216-323b-41b9-8811-ade5ada8995a">
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<textElement textAlignment="Right">
+					<font fontName="Cadastra" size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[String.format($R{PageLabel}, $V{MASTER_CURRENT_PAGE}, $V{MASTER_TOTAL_PAGES})]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+</jasperReport>

--- a/print/print-apps/oereb/pdfextract.jrxml
+++ b/print/print-apps/oereb/pdfextract.jrxml
@@ -57,6 +57,7 @@
 	<parameter name="RealEstate_RestrictionOnLandownershipDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<parameter name="GlossaryDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<parameter name="Certification" class="java.lang.String"/>
+	<parameter name="MultiPageTOC" class="java.lang.Boolean"/>
 	<variable name="TOC_Appendices" class="java.util.Map">
 		<variableExpression><![CDATA[new java.util.HashMap()]]></variableExpression>
 	</variable>
@@ -171,6 +172,7 @@
 			</part>
 			<part evaluationTime="Report" uuid="1e51d81b-2bac-4806-a6ab-2d666891cc25">
 				<property name="net.sf.jasperreports.bookmarks.data.source.parameter" value="BookmarkDataSource"/>
+				<printWhenExpression><![CDATA[!($P{MultiPageTOC})]]></printWhenExpression>
 				<p:subreportPart xmlns:p="http://jasperreports.sourceforge.net/jasperreports/parts" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/parts http://jasperreports.sourceforge.net/xsd/parts.xsd">
 					<subreportParameter name="REPORT_CONNECTION">
 						<subreportParameterExpression><![CDATA[$P{REPORT_CONNECTION}]]></subreportParameterExpression>
@@ -251,6 +253,176 @@
 						<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
 					</subreportParameter>
 					<subreportExpression><![CDATA["toc.jasper"]]></subreportExpression>
+				</p:subreportPart>
+			</part>
+			<part evaluationTime="Report" uuid="1e51d81b-2bac-4806-a6ab-2d666891cc25">
+				<property name="net.sf.jasperreports.bookmarks.data.source.parameter" value="REPORT_DATA_SOURCE"/>
+				<printWhenExpression><![CDATA[$P{MultiPageTOC}]]></printWhenExpression>
+				<p:subreportPart xmlns:p="http://jasperreports.sourceforge.net/jasperreports/parts" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/parts http://jasperreports.sourceforge.net/xsd/parts.xsd">
+					<subreportParameter name="REPORT_CONNECTION">
+						<subreportParameterExpression><![CDATA[$P{REPORT_CONNECTION}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="isReduced">
+						<subreportParameterExpression><![CDATA[$P{isReduced}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ExtractIdentifier">
+						<subreportParameterExpression><![CDATA[$P{ExtractIdentifier}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="CreationDate">
+						<subreportParameterExpression><![CDATA[$P{CreationDate}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="Footer">
+						<subreportParameterExpression><![CDATA[$P{Footer}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="FederalLogo">
+						<subreportParameterExpression><![CDATA[$P{FederalLogo}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="CantonalLogo">
+						<subreportParameterExpression><![CDATA[$P{CantonalLogo}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="LogoPLRCadastre">
+						<subreportParameterExpression><![CDATA[$P{LogoPLRCadastre}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="MunicipalityLogo">
+						<subreportParameterExpression><![CDATA[$P{MunicipalityLogo}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="FederalLogoRef">
+						<subreportParameterExpression><![CDATA[$P{FederalLogoRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="CantonalLogoRef">
+						<subreportParameterExpression><![CDATA[$P{CantonalLogoRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="MunicipalityLogoRef">
+						<subreportParameterExpression><![CDATA[$P{MunicipalityLogoRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="LogoPLRCadastreRef">
+						<subreportParameterExpression><![CDATA[$P{LogoPLRCadastreRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_Municipality">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_Municipality}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_EGRID">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_EGRID}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_Number">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_Number}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_IdentDN">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_IdentDN}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ConcernedThemeDataSource">
+						<subreportParameterExpression><![CDATA[$P{ConcernedThemeDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="NotConcernedThemeDataSource">
+						<subreportParameterExpression><![CDATA[$P{NotConcernedThemeDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ThemeWithoutDataDataSource">
+						<subreportParameterExpression><![CDATA[$P{ThemeWithoutDataDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ExclusionOfLiabilityDataSource">
+						<subreportParameterExpression><![CDATA[$P{ExclusionOfLiabilityDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="GeneralInformation">
+						<subreportParameterExpression><![CDATA[$P{GeneralInformation}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="BaseData">
+						<subreportParameterExpression><![CDATA[$P{BaseData}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="REPORT_DATA_SOURCE">
+						<subreportParameterExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource()]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="TOC_Appendices">
+						<subreportParameterExpression><![CDATA[$V{TOC_Appendices}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="REPORT_RESOURCE_BUNDLE">
+						<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportExpression><![CDATA["multiPageTOC.jasper"]]></subreportExpression>
+				</p:subreportPart>
+			</part>
+			<part uuid="1e51d81b-2bac-4806-a6ab-2d666891cc25">
+				<property name="net.sf.jasperreports.bookmarks.data.source.parameter" value="BookmarkDataSource"/>
+				<printWhenExpression><![CDATA[$P{MultiPageTOC}]]></printWhenExpression>
+				<p:subreportPart xmlns:p="http://jasperreports.sourceforge.net/jasperreports/parts" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports/parts http://jasperreports.sourceforge.net/xsd/parts.xsd">
+					<subreportParameter name="REPORT_CONNECTION">
+						<subreportParameterExpression><![CDATA[$P{REPORT_CONNECTION}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="isReduced">
+						<subreportParameterExpression><![CDATA[$P{isReduced}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ExtractIdentifier">
+						<subreportParameterExpression><![CDATA[$P{ExtractIdentifier}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="CreationDate">
+						<subreportParameterExpression><![CDATA[$P{CreationDate}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="Footer">
+						<subreportParameterExpression><![CDATA[$P{Footer}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="FederalLogo">
+						<subreportParameterExpression><![CDATA[$P{FederalLogo}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="CantonalLogo">
+						<subreportParameterExpression><![CDATA[$P{CantonalLogo}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="LogoPLRCadastre">
+						<subreportParameterExpression><![CDATA[$P{LogoPLRCadastre}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="MunicipalityLogo">
+						<subreportParameterExpression><![CDATA[$P{MunicipalityLogo}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="FederalLogoRef">
+						<subreportParameterExpression><![CDATA[$P{FederalLogoRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="CantonalLogoRef">
+						<subreportParameterExpression><![CDATA[$P{CantonalLogoRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="MunicipalityLogoRef">
+						<subreportParameterExpression><![CDATA[$P{MunicipalityLogoRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="LogoPLRCadastreRef">
+						<subreportParameterExpression><![CDATA[$P{LogoPLRCadastreRef}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_Municipality">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_Municipality}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_EGRID">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_EGRID}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_Number">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_Number}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="RealEstate_IdentDN">
+						<subreportParameterExpression><![CDATA[$P{RealEstate_IdentDN}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ConcernedThemeDataSource">
+						<subreportParameterExpression><![CDATA[$P{ConcernedThemeDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="NotConcernedThemeDataSource">
+						<subreportParameterExpression><![CDATA[$P{NotConcernedThemeDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ThemeWithoutDataDataSource">
+						<subreportParameterExpression><![CDATA[$P{ThemeWithoutDataDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="ExclusionOfLiabilityDataSource">
+						<subreportParameterExpression><![CDATA[$P{ExclusionOfLiabilityDataSource}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="GeneralInformation">
+						<subreportParameterExpression><![CDATA[$P{GeneralInformation}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="BaseData">
+						<subreportParameterExpression><![CDATA[$P{BaseData}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="REPORT_DATA_SOURCE">
+						<subreportParameterExpression><![CDATA[new net.sf.jasperreports.engine.JREmptyDataSource()]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="TOC_Appendices">
+						<subreportParameterExpression><![CDATA[$V{TOC_Appendices}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="REPORT_RESOURCE_BUNDLE">
+						<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportExpression><![CDATA["additionalInfoMultipageTOC.jasper"]]></subreportExpression>
 				</p:subreportPart>
 			</part>
 		</groupHeader>

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -86,6 +86,10 @@ class Renderer(JsonRenderer):
             'display_certification', True
         )
 
+        extract_as_dict['MultiPageTOC'] = print_config.get(
+            'multi_page_TOC', False
+        )
+
         spec = {
             'layout': Config.get('print', {})['template_name'],
             'outputFormat': 'pdf',

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -85,12 +85,16 @@ pyramid_oereb:
     # Whether to display the RealEstate_SubunitOfLandRegister (Grundbuchkreis) in the pdf extract or not.
     # Default to true.
     display_real_estate_subunit_of_land_register: true
-    # whether to display the "Certification" section in the pdf extract or not.
+    # Whether to display the Certification section in the pdf extract or not.
     # Default to true
     display_certification: true
     # Split themes up, so that each sub theme gets its own page
     # Disabled by default.
     split_sub_themes: false
+    # Determine if a multiple page table of content (TOC) is used with a slightly different layout but
+    # better page numbering. If it is known that the TOC is very long and runs over more than one page it
+    # is preferred to set this to true.
+    multi_page_TOC: false
     # Specify any additional URL parameters that the print shall use for WMS calls
     wms_url_params:
       TRANSPARENT: 'true'


### PR DESCRIPTION
This is a suggestion of how to correctly show the page numbers for more complex page numbers.
@jwkaltz and @pfirpfel can you take a look at this option and give me some input of whether this can be used.

TODO:

- ~~Add a proper variable in the Docker config.yaml to decide which TOC to use the simple or the complex~~
- ~~Check that the the spacing of the elements in the new TOC are kept as closely to the intended template.~~
- ~~Add the `Full` version of the TOC which allows attachments~~

TO TEST:
Enable this feature here: https://github.com/openoereb/pyramid_oereb/blob/76229720f3393f418de91f6534c136396d2551c5/docker/config.yaml#L98