### PR TITLE
use longer names in the docker example file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ volumes: {}
 
 services:
 
-  db:
+  oereb-db:
     build: test-db
     image: camptocamp/oereb-db-dev
 
-  wsgi:
+  oereb-server:
     networks:
     - default
     - print-network
@@ -17,11 +17,11 @@ services:
     ports:
     - 6543:8080
     environment:
-    - PRINT_SERVICE_HOST=print
+    - PRINT_SERVICE_HOST=oereb-print
     - PRINT_SERVICE_PORT=8080
     - POSTGRES_SERVICE_USER=postgres
     - POSTGRES_SERVICE_PASS=password
-    - POSTGRES_SERVICE_HOST=db
+    - POSTGRES_SERVICE_HOST=oereb-db
     - POSTGRES_SERVICE_PORT=5432
     - POSTGRES_SERVICE_DATABASE=pyramid_oereb
 


### PR DESCRIPTION
Goes along with https://github.com/openoereb/pyramid_oereb_mfp/pull/4

Names are (hopefully) clearer, and use a pattern that is accepted by all Tomcat versions.