### PR TITLE
restrict pytest to a python2 compatible version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest==4.6.3
+pytest==4.6.4 # rq.filter: < 5.0.0
 pytest-cov==2.7.1
 pytest-ordering==0.6
 pyflakes==2.1.1


### PR DESCRIPTION
restrict pytest to a python2 compatible version, as long as we support python2

replacement PR for #878 