### PR TITLE
In PDFs, always use geometry

### DIFF
--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -261,16 +261,23 @@ class PlrWebservice(object):
 
         # With geometry?
         with_geometry = False
+        user_requested_geometry = False
         if self._request.matchdict.get('param1').lower() == 'geometry':
             with_geometry = True
+            user_requested_geometry = True
 
         # Check for invalid combinations
         if extract_flavour in ['full', 'signed'] and extract_format != 'pdf':
             raise HTTPBadRequest('The flavours full and signed are only available for format PDF.')
         if extract_flavour == 'embeddable' and extract_format == 'pdf':
             raise HTTPBadRequest('The flavour embeddable is not available for format PDF.')
-        if extract_format == 'pdf' and with_geometry:
+        if extract_format == 'pdf' and user_requested_geometry:
             raise HTTPBadRequest('Geometry is not available for format PDF.')
+
+        # If PDF is to be produced, always include geometry
+        # (even though the URL shall not contain geometry parameter)
+        if extract_format == 'pdf':
+            with_geometry = True
 
         # With images?
         with_images = self._request.params.get('WITHIMAGES') is not None
@@ -278,7 +285,7 @@ class PlrWebservice(object):
         params = Parameter(extract_flavour, extract_format, with_geometry, with_images)
 
         # Get id
-        if with_geometry:
+        if user_requested_geometry:
             id_param_1 = 'param2'
             id_param_2 = 'param3'
         else:

--- a/tests/webservice/test_getextractbyid.py
+++ b/tests/webservice/test_getextractbyid.py
@@ -62,7 +62,7 @@ def test_invalid_flavour(params):
         }, {
             'flavour': 'signed',
             'format': 'pdf',
-            'geometry': False,
+            'geometry': True,
             'images': False,
             'egrid': 'SomeEGRID'
         }
@@ -76,7 +76,7 @@ def test_invalid_flavour(params):
         }, {
             'flavour': 'full',
             'format': 'pdf',
-            'geometry': False,
+            'geometry': True,
             'images': False,
             'identdn': 'SomeIdent',
             'number': 'SomeNumber'


### PR DESCRIPTION
When a user requests a pdf explicitly with geometry, pyramid_oereb produces an error. This is consistent with the federal specification (see chapter "Übersicht der möglichen Kombinationen").

However, when a pdf is actually to be produced by a call to the xml2pdf service, the extract data needs to contain geometry data in order for the pdf to be complete.

Therefore, this pull request proposes to
* when a PDF is to be generated, always produce the data with geometry data.
* still throw an error when the user explicitly requested pdf/geometry -> no change in behaviour.

Note:
* this was tested with usage of the XML2PDF service, in the Kanton Zug implementation
* the changes do not directly affect MapFish-Print, but you need to update your templates when using MapFish-Print (see https://github.com/openoereb/pyramid_oereb_mfp/pull/14), to remove unused configuration which otherwise causes side-effects.