### PR TITLE
Limit numpy to versions <1.17.0, which drops python 2.7 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ requests==2.22.0
 geolink-formatter==1.3.1
 pyconizer==0.1.4
 tqdm==4.32.2
-numpy==1.16.4
+numpy==1.16.4  # rq.filter: <1.17.0
 defusedxml==0.6.0


### PR DESCRIPTION
This will stop requires.io suggesting updates, that are not supporting python 2.7.

Should be undone when python 2.7 support gets dropped, see #889 .