### PR TITLE
Add sorting for LegalProvisionig, Hints and Laws

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -404,7 +404,7 @@ class Renderer(JsonRenderer):
         # sort legal provisioning, hints and laws
         restriction_on_landownership['LegalProvisions'] = self.sort_dict_list(
             restriction_on_landownership['LegalProvisions'],
-            self.sort_legal_provisioning
+            self.sort_legal_provision
         )
         restriction_on_landownership['Laws'] = self.sort_dict_list(
             restriction_on_landownership['Laws'],
@@ -650,14 +650,14 @@ class Renderer(JsonRenderer):
         return sorted(legend_list, key=sort_keys)
 
     @staticmethod
-    def sort_legal_provisioning(elem):
+    def sort_legal_provision(elem):
         """
-        Provides the sort key for the supplied legal provisioning element as a tuple consisting of:
+        Provides the sort key for the supplied legal provision element as a tuple consisting of:
             * title
             * Office number
             * Text at web
         Args:
-            elem (dict): one element of the legal provisioning list
+            elem (dict): one element of the legal provision list
 
         Returns:
              sort key (tuple)
@@ -674,7 +674,7 @@ class Renderer(JsonRenderer):
         Provides the sort key for the supplied hint element as a tuple consisting of:
          * Title
         Args:
-            elem (dict): one element of the legal provisioning list
+            elem (dict): one element of the hints list
 
         Returns:
              sort key (tuple)
@@ -688,7 +688,7 @@ class Renderer(JsonRenderer):
          * OfficialNumber (if this attribute is empty the element will be placed at the end of the list)
          * Title
         Args:
-            elem (dict): one element of the legal provisioning list
+            elem (dict): one element of the legal laws list
 
         Returns:
              sort key (tuple)

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -637,11 +637,13 @@ class Renderer(JsonRenderer):
     def sort_dict_list(legend_list, sort_keys):
         """
         Sorts list of dictionaries by one or more sort keys.
-        This function makes it possible to run test on the sorted list and assure the correctness of the soring.
+        This function makes it possible to run test on the sorted list and assure the
+        correctness of the soring.
 
         Args:
             legend_list (list(dict): list of legend dictionaries
-            sort_keys (tuple/any): tuple of keys according to which the list of dictionaries will be sorted (at least one is needed)
+            sort_keys (tuple/any): tuple of keys according to which the list of dictionaries will be
+            sorted (at least one is needed)
         Returns:
             sorted list of legend dictionaries
         """
@@ -660,12 +662,11 @@ class Renderer(JsonRenderer):
         Returns:
              sort key (tuple)
         """
-        if type(elem) is dict:
-            sort_title = elem['Title'] if 'Title' in elem else ''
-            sort_Number = elem['OfficialNumber'] if 'OfficialNumber' in elem else None
-            sort_Web = elem['TextAtWeb'] if 'TextAtWeb' in elem else None
-            return sort_title, sort_Number, sort_Web
-        return elem
+
+        sort_title = elem['Title'] if 'Title' in elem else ''
+        sort_Number = elem['OfficialNumber'] if 'OfficialNumber' in elem else None
+        sort_Web = elem['TextAtWeb'] if 'TextAtWeb' in elem else None
+        return sort_title, sort_Number, sort_Web
 
     @staticmethod
     def sort_hints(elem):

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -253,7 +253,7 @@ def test_get_sorted_legend():
             'Information': u'Belastet, untersuchungsbedürftig'
         }
     ]
-    sorted_list = renderer._get_sorted_legend(test_legend_list)
+    sorted_list = renderer.sort_dict_list(test_legend_list, renderer.sort_legend_elem)
     expected_result = [
         {
             'TypeCode': u'StaoTyp2',
@@ -299,3 +299,291 @@ def test_get_sorted_legend():
         }
     ]
     assert sorted_list == expected_result
+
+
+def test_get_sorted_legal_provisions():
+    renderer = Renderer(DummyRenderInfo())
+    expected_result = [
+        {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+            "Title": "Baugesetz"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "Title": "Baugesetz"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "07.447",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
+            "Title": "Revision Ortsplanung"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "07.447",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
+            "Title": "Revision Ortsplanung"
+        }
+    ]
+    test_legal_provisions = [
+        {
+           "Canton": "BL",
+           "DocumentType": "LegalProvision",
+           "Lawstatus_Code": "inForce",
+           "Lawstatus_Text": "in Kraft",
+           "OfficialNumber": "07.447",
+           "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+           "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+           "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
+           "Title": "Revision Ortsplanung"
+        },{
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+            "Title": "Baugesetz"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "07.447",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
+            "Title": "Revision Ortsplanung"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "Title": "Baugesetz"
+        }
+    ]
+    assert expected_result == renderer.sort_dict_list(test_legal_provisions, renderer.sort_legal_provisioning)
+
+
+def test_get_sorted_hints():
+    renderer = Renderer(DummyRenderInfo())
+    test_hints = [{
+        "Canton": "BL",
+        "DocumentType": "LegalProvision",
+        "Lawstatus_Code": "inForce",
+        "Lawstatus_Text": "in Kraft",
+        "OfficialNumber": "3891.100",
+        "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+        "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+        "Title": "Revision Ortsplanung"
+    }, {
+        "Canton": "BL",
+        "DocumentType": "LegalProvision",
+        "Lawstatus_Code": "inForce",
+        "Lawstatus_Text": "in Kraft",
+        "OfficialNumber": "3891.100",
+        "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+        "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198"
+    }, {
+        "Canton": "BL",
+        "DocumentType": "LegalProvision",
+        "Lawstatus_Code": "inForce",
+        "Lawstatus_Text": "in Kraft",
+        "OfficialNumber": "3891.100",
+        "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+        "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+        "Title": "Baugesetz"
+
+    }]
+
+    expected_result = [{
+        "Canton": "BL",
+        "DocumentType": "LegalProvision",
+        "Lawstatus_Code": "inForce",
+        "Lawstatus_Text": "in Kraft",
+        "OfficialNumber": "3891.100",
+        "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+        "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198"
+    }, {
+        "Canton": "BL",
+        "DocumentType": "LegalProvision",
+        "Lawstatus_Code": "inForce",
+        "Lawstatus_Text": "in Kraft",
+        "OfficialNumber": "3891.100",
+        "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+        "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+        "Title": "Baugesetz"
+    }, {
+        "Canton": "BL",
+        "DocumentType": "LegalProvision",
+        "Lawstatus_Code": "inForce",
+        "Lawstatus_Text": "in Kraft",
+        "OfficialNumber": "3891.100",
+        "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+        "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+        "Title": "Revision Ortsplanung"
+    }]
+
+    assert expected_result == renderer.sort_dict_list(test_hints, renderer.sort_hints)
+
+
+def test_get_sorted_law():
+    renderer = Renderer(DummyRenderInfo())
+    test_law = [
+        {
+            'DocumentType': 'Law',
+            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_01.html',
+            'Title': 'Raumplanungsverordnung für den Kanton Graubünden',
+            'Abbreviation': 'KRVO',
+            'OfficialNumber': 'BR 801.110',
+            'Canton': 'GR',
+            'Lawstatus_Code': 'inForce',
+            'Lawstatus_Text': 'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2934?locale=de'
+        }, {
+            'DocumentType': u'Law',
+            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
+            'Abbreviation': u'KRG',
+            'Canton': u'GR',
+            'Lawstatus_Code': u'inForce',
+            'Lawstatus_Text': u'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
+        }, {
+            'DocumentType': u'Law',
+            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': u'Raumplanungsgesetz für den Kanton Graubünden2',
+            'Abbreviation': u'KRG',
+            'OfficialNumber': u'BR 801.100',
+            'Canton': u'GR',
+            'Lawstatus_Code': u'inForce',
+            'Lawstatus_Text': u'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
+        }, {
+            'DocumentType': 'Law',
+            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': 'Bundesgesetz über die Raumplanung',
+            'Abbreviation': 'RPG',
+            'OfficialNumber': 'SR 700',
+            'Canton': 'GR',
+            'Lawstatus_Code': 'inForce',
+            'Lawstatus_Text': 'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb': 'http://www.lexfind.ch/dtah/167348/2'
+        }, {
+            'DocumentType': u'Law',
+            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
+            'Abbreviation': u'KRG',
+            'OfficialNumber': u'BR 801.100',
+            'Canton': u'GR',
+            'Lawstatus_Code': u'inForce',
+            'Lawstatus_Text': u'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
+        }
+    ]
+
+    expected_result = [
+        {
+            'DocumentType': u'Law',
+            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
+            'Abbreviation': u'KRG',
+            'OfficialNumber': u'BR 801.100',
+            'Canton': u'GR',
+            'Lawstatus_Code': u'inForce',
+            'Lawstatus_Text': u'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
+        }, {
+            'DocumentType': u'Law',
+            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': u'Raumplanungsgesetz für den Kanton Graubünden2',
+            'Abbreviation': u'KRG',
+            'OfficialNumber': u'BR 801.100',
+            'Canton': u'GR',
+            'Lawstatus_Code': u'inForce',
+            'Lawstatus_Text': u'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
+        }, {
+            'DocumentType': 'Law',
+            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_01.html',
+            'Title': 'Raumplanungsverordnung für den Kanton Graubünden',
+            'Abbreviation': 'KRVO',
+            'OfficialNumber': 'BR 801.110',
+            'Canton': 'GR',
+            'Lawstatus_Code': 'inForce',
+            'Lawstatus_Text': 'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2934?locale=de'
+        }, {
+            'DocumentType': 'Law',
+            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': 'Bundesgesetz über die Raumplanung',
+            'Abbreviation': 'RPG',
+            'OfficialNumber': 'SR 700',
+            'Canton': 'GR',
+            'Lawstatus_Code': 'inForce',
+            'Lawstatus_Text': 'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb': 'http://www.lexfind.ch/dtah/167348/2'
+        }, {
+            'DocumentType': u'Law',
+            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
+            'Abbreviation': u'KRG',
+            'Canton': u'GR',
+            'Lawstatus_Code': u'inForce',
+            'Lawstatus_Text': u'in Kraft',
+            'ResponsibleOffice_Name': u'Bundesamt für Verkehr BAV',
+            'ResponsibleOffice_OfficeAtWeb':
+                u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
+
+        }
+    ]
+    assert expected_result == renderer.sort_dict_list(test_law, renderer.sort_laws)

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -396,7 +396,7 @@ def test_get_sorted_legal_provisions():
             "Title": "Baugesetz"
         }
     ]
-    assert expected_result == renderer.sort_dict_list(test_legal_provisions, renderer.sort_legal_provisioning)
+    assert expected_result == renderer.sort_dict_list(test_legal_provisions, renderer.sort_legal_provision)
 
 
 def test_get_sorted_hints():

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -311,7 +311,8 @@ def test_get_sorted_legal_provisions():
             "Lawstatus_Text": "in Kraft",
             "OfficialNumber": "3891.100",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
-            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
             "Title": "Baugesetz"
         }, {
@@ -321,7 +322,8 @@ def test_get_sorted_legal_provisions():
             "Lawstatus_Text": "in Kraft",
             "OfficialNumber": "3891.100",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
-            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
             "Title": "Baugesetz"
         }, {
@@ -331,7 +333,8 @@ def test_get_sorted_legal_provisions():
             "Lawstatus_Text": "in Kraft",
             "OfficialNumber": "07.447",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
-            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
             "Title": "Revision Ortsplanung"
         }, {
@@ -341,7 +344,8 @@ def test_get_sorted_legal_provisions():
             "Lawstatus_Text": "in Kraft",
             "OfficialNumber": "07.447",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
-            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
             "Title": "Revision Ortsplanung"
         }
@@ -357,14 +361,15 @@ def test_get_sorted_legal_provisions():
            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
            "Title": "Revision Ortsplanung"
-        },{
+        }, {
             "Canton": "BL",
             "DocumentType": "LegalProvision",
             "Lawstatus_Code": "inForce",
             "Lawstatus_Text": "in Kraft",
             "OfficialNumber": "3891.100",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
-            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
             "Title": "Baugesetz"
         }, {
@@ -374,7 +379,8 @@ def test_get_sorted_legal_provisions():
             "Lawstatus_Text": "in Kraft",
             "OfficialNumber": "07.447",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
-            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
             "Title": "Revision Ortsplanung"
         }, {
@@ -384,7 +390,8 @@ def test_get_sorted_legal_provisions():
             "Lawstatus_Text": "in Kraft",
             "OfficialNumber": "3891.100",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
-            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
             "Title": "Baugesetz"
         }


### PR DESCRIPTION
This PR sorts:
-  LegalProvisionig according to:
            - Title
            - Office number
            - Text at web
- Laws according to:
           - OfficialNumber (if this attribute is empty the element will be placed at the end of the list)
           - Title
- Hints according to:
         - Title
As described in https://jira.camptocamp.com/browse/GEO-2554

This PR addresses #818 