### PR TITLE
mapfish-print proxy: sort documents for PDF

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -401,20 +401,19 @@ class Renderer(JsonRenderer):
                 restriction_on_landownership[element] = values
                 if element == 'LegalProvisions':
                     pdf_to_join.update([legal_provision['TextAtWeb'] for legal_provision in values])
-
-        # sort legal provisioning, hints and laws
-        restriction_on_landownership['LegalProvisions'] = self.sort_dict_list(
-            restriction_on_landownership['LegalProvisions'],
-            self.sort_legal_provision
-        )
-        restriction_on_landownership['Laws'] = self.sort_dict_list(
-            restriction_on_landownership['Laws'],
-            self.sort_laws
-        )
-        restriction_on_landownership['Hints'] = self.sort_dict_list(
-            restriction_on_landownership['Hints'],
-            self.sort_hints
-        )
+            # sort legal provisioning, hints and laws
+            restriction_on_landownership['LegalProvisions'] = self.sort_dict_list(
+                restriction_on_landownership['LegalProvisions'],
+                self.sort_legal_provision
+            )
+            restriction_on_landownership['Laws'] = self.sort_dict_list(
+                restriction_on_landownership['Laws'],
+                self.sort_laws
+            )
+            restriction_on_landownership['Hints'] = self.sort_dict_list(
+                restriction_on_landownership['Hints'],
+                self.sort_hints
+            )
 
         restrictions = list(theme_restriction.values())
         for restriction in restrictions:

--- a/sample_data/plr119/contaminated_public_transport_sites/document.json
+++ b/sample_data/plr119/contaminated_public_transport_sites/document.json
@@ -49,6 +49,51 @@
   },
   {
     "office_id": 1,
+    "published_from": "2019-10-30",
+    "canton": "",
+    "id": 8002,
+    "document_type": "Law",
+    "text_at_web": {
+      "de": "http://www.lexfind.ch/dtah/167348/2"
+    },
+    "law_status": "inForce",
+    "abbreviation": {
+      "de": "AltlV"
+    },
+    "title": {
+      "de": "Bundesgesetz über die Raumplanung (Raumplanungsgesetz, RPG)"
+    },
+    "official_number": "SR 700"
+  }, {
+    "office_id": 1,
+    "published_from": "2019-10-30",
+    "canton": "GR",
+    "id": 8000,
+    "document_type": "LegalProvision",
+    "text_at_web": {
+      "de": "https://oereb-gr-preview.000.ch/api/attachments/213"
+    },
+    "law_status": "inForce",
+    "title": {
+      "de": "Revision Ortsplanung"
+    },
+    "official_number": "07.447"
+  }, {
+    "office_id": 1,
+    "published_from": "2019-10-30",
+    "canton": "GR",
+    "id": 8001,
+    "document_type": "LegalProvision",
+    "text_at_web": {
+      "de": "https://oereb-gr-preview.000.ch/api/attachments/214"
+    },
+    "law_status": "inForce",
+    "title": {
+      "de": "Revision Ortsplanung"
+    },
+    "official_number": "07.447"
+  }, {
+    "office_id": 1,
     "published_from": "2016-02-25",
     "canton": "BL",
     "id": 1292,

--- a/sample_data/plr119/contaminated_public_transport_sites/document_reference.json
+++ b/sample_data/plr119/contaminated_public_transport_sites/document_reference.json
@@ -1,6 +1,10 @@
 [
   {
     "reference_document_id": 1358,
+    "id": 1000,
+    "document_id": 8001
+  }, {
+    "reference_document_id": 1358,
     "id": 2583,
     "document_id": 1292
   }, {
@@ -39,5 +43,13 @@
     "reference_document_id": 1359,
     "id": 2602,
     "document_id": 1296
+  }, {
+    "reference_document_id": 1358,
+    "id": 2603,
+    "document_id": 8000
+  }, {
+    "reference_document_id": 1358,
+    "id": 2604,
+    "document_id": 8002
   }
 ]

--- a/sample_data/plr119/contaminated_public_transport_sites/public_law_restriction_document.json
+++ b/sample_data/plr119/contaminated_public_transport_sites/public_law_restriction_document.json
@@ -1,5 +1,9 @@
 [
   {
+    "id": 390,
+    "document_id": 8001,
+    "public_law_restriction_id": 396
+  }, {
     "id": 396,
     "document_id": 1292,
     "public_law_restriction_id": 396
@@ -19,5 +23,13 @@
     "id": 400,
     "document_id": 1296,
     "public_law_restriction_id": 400
+  }, {
+    "id": 401,
+    "document_id": 8000,
+    "public_law_restriction_id": 396
+  }, {
+    "id": 402,
+    "document_id": 8002,
+    "public_law_restriction_id": 396
   }
 ]


### PR DESCRIPTION
Fixes #818 

Follow-up to PR#925.
Order of dummy data before the fix:
![before-the-fix](https://user-images.githubusercontent.com/9261252/67935398-05283f00-fbca-11e9-860b-db3704feec4b.png)
After the fix:
![after-the-fix](https://user-images.githubusercontent.com/9261252/67935435-1709e200-fbca-11e9-8786-c4e038f60f44.png)