### PR TITLE
synchronize configuration files of docker and non-docker world

### DIFF
--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -73,7 +73,7 @@ vars:
       token: 24ba4328-a306-4832-905d-b979388d4cab
       use_wms: "true"
       validate: "false"
-      # The following parameters are not used by xml2pdf, but we need to keep them until issue #873 is solved
+      # The following parameters are not used by xml2pdf, but might be in the fure (see issue #873)
       buffer: 30
       basic_map_size: [493, 280]
       pdf_dpi: 300
@@ -204,8 +204,8 @@ vars:
       # The logo representing the swiss confederation. You can use it as is because it is provided in this
       # repository, but if you need to change it for any reason: Feel free...
       confederation: logo_confederation.png
-      # The logo representing the oereb extract CI (you can use it as is cause it is provided in this
-      # repository). But if you need to change it for any reason: Feel free...
+      # The logo representing the oereb extract CI. You can use it as is because it is provided in this
+      # repository, but if you need to change it for any reason: Feel free...
       oereb:
         de: logo_oereb_de.png
         fr: logo_oereb_fr.png
@@ -394,12 +394,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -434,12 +432,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -474,12 +470,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -514,12 +508,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -554,12 +546,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -594,12 +584,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -634,12 +622,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -674,12 +660,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -715,12 +699,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -755,12 +737,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -795,12 +775,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -835,12 +813,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -868,15 +844,16 @@ vars:
       law_status:
         in_force: inForce
         running_modifications: runningModifications
-      sub_themes:
-        sorter:
-          module: pyramid_oereb.contrib.print_proxy.sub_themes.sorting
-          class_name: ListSort
-          params:
-            list:
-              - SubTheme3
-              - SubTheme2
-              - SubTheme1
+      # Example of how sub_themes sorting can be activated (uncomment to enable):
+      #sub_themes:
+      #  sorter:
+      #    module: pyramid_oereb.contrib.print_proxy.sub_themes.sorting
+      #    class_name: ListSort
+      #    params:
+      #      list:
+      #        - SubTheme3
+      #        - SubTheme2
+      #        - SubTheme1
 
     - name: plr131
       code: GroundwaterProtectionZones
@@ -884,12 +861,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -924,12 +899,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -964,12 +937,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -1004,12 +975,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:
@@ -1044,12 +1013,10 @@ vars:
       thresholds:
         length:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm'
           precision: 2
         area:
           limit: 1.0
-          # Unit used internally only until now!
           unit: 'm²'
           precision: 2
         percentage:

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -162,6 +162,7 @@ pyramid_oereb:
     canton: BL
     # Mapping for other optional attributes
     mapping:
+      municipality: subtype
       official_number: number
       abbreviation: abbreviation
     # Handle related decree also as main document
@@ -392,8 +393,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Nutzungsplanung (kantonal/kommunal)
         fr: Plans d'affectation (cantonaux/communaux)
@@ -424,8 +431,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Projektierungszonen Nationalstrassen
         fr: Zones réservées des routes nationales
@@ -456,8 +469,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Baulinien Nationalstrassen
         fr: Alignements des routes nationales
@@ -488,8 +507,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Baulinien Eisenbahnanlagen
         fr: Alignements des installations ferroviaires
@@ -520,8 +545,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Projektierungszonen Eisenbahnanlagen
         fr: Zones réservées des installations ferroviaires
@@ -552,8 +583,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Projektierungszonen Flughafenanlagen
         fr: Zones réservées des installations aéroportuaires
@@ -584,8 +621,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Baulinien Flughafenanlagen
         fr: Alignements des installations aéroportuaires
@@ -616,8 +659,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Sicherheitszonenplan
         fr: Plan de la zone de sécurité
@@ -649,8 +698,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Kataster der belasteten Standorte
         fr: Cadastre des sites pollués
@@ -681,8 +736,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Kataster der belasteten Standorte im Bereich des Militärs
         fr: Cadastre des sites pollués - domaine militaire
@@ -713,8 +774,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Kataster der belasteten Standorte im Bereich der zivilen Flugplätze
         fr: Cadastre des sites pollués - domaine des aérodromes civils
@@ -745,8 +812,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs
         fr: Cadastre des sites pollués - domaine des transports publics
@@ -770,6 +843,16 @@ pyramid_oereb:
       law_status:
         in_force: inForce
         running_modifications: runningModifications
+      # Example of how sub_themes sorting can be activated (uncomment to enable):
+      #sub_themes:
+      #  sorter:
+      #    module: pyramid_oereb.contrib.print_proxy.sub_themes.sorting
+      #    class_name: ListSort
+      #    params:
+      #      list:
+      #        - SubTheme3
+      #        - SubTheme2
+      #        - SubTheme1
 
     - name: plr131
       code: GroundwaterProtectionZones
@@ -777,8 +860,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Grundwasserschutzzonen
         fr: Zones de protection des eaux souterraines
@@ -809,8 +898,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Grundwasserschutzareale
         fr: Périmètres de protection des eaux souterraines
@@ -841,8 +936,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Lärmempfindlichkeitsstufen (in Nutzungszonen)
         fr: Degré de sensibilité au bruit (dans les zones d'affectation)
@@ -873,8 +974,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Statische Waldgrenzen
         fr: Limites forestières statiques
@@ -905,8 +1012,14 @@ pyramid_oereb:
       thresholds:
         length:
           limit: 1.0
+          unit: 'm'
+          precision: 2
         area:
           limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
       text:
         de: Waldabstandslinien
         fr: Distances par rapport à la forêt


### PR DESCRIPTION
synchronize standard/default configuration files of docker and non-docker world.
It should make future evolutions and understanding of configurations a bit easier

(there are still some differences regarding Mako variable usage that can probably be harmonized, but I did not have time within this PR to do that)