### PR TITLE
Pass extract parameters to all readers and sources

### DIFF
--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -157,7 +157,7 @@ vars:
     oereblex:
       # OEREBlex host
       host: https://oereblex.bl.ch
-      # Language of returned values
+      # Default language of returned values
       language: de
       # Value for canton attribute
       canton: BL

--- a/pyramid_oereb/contrib/sources/address.py
+++ b/pyramid_oereb/contrib/sources/address.py
@@ -37,11 +37,12 @@ class AddressGeoAdminSource(AddressBaseSource):
         else:
             self._origins = 'address'
 
-    def read(self, street_name, zip_code, street_number):
+    def read(self, params, street_name, zip_code, street_number):
         """
         Queries an address using the federal GeoAdmin API location search.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             street_name (unicode): The name of the street for the desired address.
             zip_code (int): The postal zipcode for the desired address.
             street_number (unicode): The house or so called street number of the desired address.
@@ -51,12 +52,17 @@ class AddressGeoAdminSource(AddressBaseSource):
             headers.update({
                 'Referer': self._referer
             })
-        params = {
+        request_params = {
             'type': self._type,
             'origins': self._origins,
             'searchText': u'{0} {1} {2}'.format(zip_code, street_name, street_number)
         }
-        response = requests.get(self._geoadmin_url, params=params, proxies=self._proxies, headers=headers)
+        response = requests.get(
+            self._geoadmin_url,
+            params=request_params,
+            proxies=self._proxies,
+            headers=headers
+        )
         if response.status_code == requests.codes.ok:
             rp = Reprojector()
             srid = Config.get('srid')

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -57,13 +57,16 @@ class OEREBlexSource(Base):
             self._auth = None
 
         self._language = str(kwargs.get('language')).lower()
-        assert self._language is not None and len(self._language) == 2
+        if not (isinstance(self._language, str) and len(self._language) == 2):
+            raise AssertionError('language has to be string of two characters, e.g. "de" or "fr"')
 
         self._canton = kwargs.get('canton')
-        assert self._canton is not None and len(self._canton) == 2
+        if not (isinstance(self._canton, str) and len(self._canton) == 2):
+            raise AssertionError('canton has to be string of two characters, e.g. "BL" or "NE"')
 
         self._parser = XML(host_url=kwargs.get('host'), version=self._version)
-        assert self._parser.host_url is not None
+        if self._parser.host_url is None:
+            raise AssertionError('host_url has to be defined')
 
     def read(self, params, geolink_id):
         """
@@ -131,9 +134,12 @@ class OEREBlexSource(Base):
             return []
 
         # Check mandatory attributes
-        assert document.title is not None
-        assert document.enactment_date is not None
-        assert document.authority is not None
+        if document.title is None:
+            raise AssertionError('Missing title for document #{0}'.format(document.id))
+        if document.enactment_date is None:
+            raise AssertionError('Missing enactment_date for document #{0}'.format(document.id))
+        if document.authority is None:
+            raise AssertionError('Missing authority for document #{0}'.format(document.id))
 
         # Get document type
         if document.doctype == 'decree':
@@ -196,7 +202,8 @@ class OEREBlexSource(Base):
                     return {language: value} if language else value
         return None
 
-    def _get_document_title(self, document, current_file, language):
+    @staticmethod
+    def _get_document_title(document, current_file, language):
         """
         Returns the title of the document/file. Extracting this logic allows
         easier customization of the file title.

--- a/pyramid_oereb/contrib/sources/plr_oereblex.py
+++ b/pyramid_oereb/contrib/sources/plr_oereblex.py
@@ -36,18 +36,19 @@ class DatabaseOEREBlexSource(DatabaseSource):
         super(DatabaseOEREBlexSource, self).__init__(**kwargs)
         self._oereblex_source = OEREBlexSource(**Config.get_oereblex_config())
 
-    def get_document_records(self, public_law_restriction_from_db):
+    def get_document_records(self, params, public_law_restriction_from_db):
         """
         Override the parent's get_document_records method to obtain the oereblex document instead.
         """
-        return self.document_records_from_oereblex(public_law_restriction_from_db.geolink)
+        return self.document_records_from_oereblex(params, public_law_restriction_from_db.geolink)
 
-    def document_records_from_oereblex(self, lexlink):
+    def document_records_from_oereblex(self, params, lexlink):
         """
         Create document records parsed from the OEREBlex response with the specified geoLink ID and appends
         them to the current public law restriction.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             lexlink (int): The ID of the geoLink to request the documents for.
 
         Returns:
@@ -55,7 +56,7 @@ class DatabaseOEREBlexSource(DatabaseSource):
                 The documents created from the parsed OEREBlex response.
         """
         log.debug("document_records_from_oereblex() start")
-        self._oereblex_source.read(lexlink)
+        self._oereblex_source.read(params, lexlink)
         log.debug("document_records_from_oereblex() returning {} records"
                   .format(len(self._oereblex_source.records)))
         return self._oereblex_source.records

--- a/pyramid_oereb/lib/processor.py
+++ b/pyramid_oereb/lib/processor.py
@@ -280,12 +280,12 @@ class Processor(object):
             pyramid_oereb.lib.records.extract.ExtractRecord: The generated extract record.
         """
         log.debug("process() start")
-        municipalities = self._municipality_reader_.read()
-        exclusions_of_liability = self._exclusion_of_liability_reader_.read()
-        glossaries = self._glossary_reader_.read()
+        municipalities = self._municipality_reader_.read(params)
+        exclusions_of_liability = self._exclusion_of_liability_reader_.read(params)
+        glossaries = self._glossary_reader_.read(params)
         for municipality in municipalities:
             if municipality.fosnr == real_estate.fosnr:
-                extract_raw = self._extract_reader_.read(real_estate, municipality, params)
+                extract_raw = self._extract_reader_.read(params, real_estate, municipality)
                 extract = self.plr_tolerance_check(extract_raw)
 
                 # the selection of view services is done after the tolerance check. This enables us to take

--- a/pyramid_oereb/lib/readers/address.py
+++ b/pyramid_oereb/lib/readers/address.py
@@ -24,7 +24,7 @@ class AddressReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self, street_name, zip_code, street_number):
+    def read(self, params, street_name, zip_code, street_number):
         """
         The read method of this reader. There we invoke the read method of the bound source.
 
@@ -34,6 +34,7 @@ class AddressReader(object):
             works would be broken.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             street_name (unicode): The name of the street for the desired address.
             zip_code (int): The postal zipcode for the desired address.
             street_number (str): The house or so called street number of the desired address.
@@ -42,5 +43,5 @@ class AddressReader(object):
             list of pyramid_oereb.lib.records.address.AddressRecord:
                 The list of found records filtered by the passed criteria.
         """
-        self._source_.read(street_name, zip_code, street_number)
+        self._source_.read(params, street_name, zip_code, street_number)
         return self._source_.records

--- a/pyramid_oereb/lib/readers/exclusion_of_liability.py
+++ b/pyramid_oereb/lib/readers/exclusion_of_liability.py
@@ -24,7 +24,7 @@ class ExclusionOfLiabilityReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self):
+    def read(self, params):
         """
         The read method of this reader. There we invoke the read method of the bound source.
 
@@ -33,10 +33,13 @@ class ExclusionOfLiabilityReader(object):
             :ref:`api-pyramid_oereb-lib-records-availability-availabilityrecord`. Otherwise the API like way
             the server works would be broken.
 
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
+
         Returns:
             list of pyramid_oereb.lib.records.exclusion_of_liability.ExclusionOfLiabilityRecord:
                 The list of found records. Since these are not filtered by any criteria the list simply
                 contains all records delivered by the source.
         """
-        self._source_.read()
+        self._source_.read(params)
         return self._source_.records

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -76,7 +76,7 @@ class ExtractReader(object):
         """
         return self._certification_at_web
 
-    def read(self, real_estate, municipality, params):
+    def read(self, params, real_estate, municipality):
         """
         This method finally creates the extract.
 
@@ -86,12 +86,11 @@ class ExtractReader(object):
             works would be broken.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             real_estate (pyramid_oereb.lib.records.real_estate.RealEstateRecord): The real
                 estate for which the report should be generated
             municipality (pyramid_oereb.lib.records.municipiality.MunicipalityRecord): The municipality
                 record.
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract
-                request.
 
         Returns:
             pyramid_oereb.lib.records.extract.ExtractRecord:
@@ -113,7 +112,7 @@ class ExtractReader(object):
             for position, plr_source in enumerate(self._plr_sources_, start=1):
                 if not params.skip_topic(plr_source.info.get('code')):
                     log.debug("read() going to read from plr_source {}".format(plr_source))
-                    plr_source.read(real_estate, bbox, position)
+                    plr_source.read(params, real_estate, bbox, position)
                     log.debug("read() done reading from plr_source {}".format(plr_source))
                     for ds in plr_source.datasource:
                         if not params.skip_topic(ds.theme.code):

--- a/pyramid_oereb/lib/readers/glossary.py
+++ b/pyramid_oereb/lib/readers/glossary.py
@@ -24,7 +24,7 @@ class GlossaryReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self):
+    def read(self, params):
         """
         The central read accessor method to get all desired records from configured source.
 
@@ -33,10 +33,12 @@ class GlossaryReader(object):
             :ref:`api-pyramid_oereb-lib-records-glossary-glossaryrecord`. Otherwise the API like way
             the server works would be broken.
 
+        params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
+
         Returns:
             list of pyramid_oereb.lib.records.glossary.GlossaryRecord:
                 The list of found records. Since these are not filtered by any criteria the list simply
                 contains all records delivered by the source.
         """
-        self._source_.read()
+        self._source_.read(params)
         return self._source_.records

--- a/pyramid_oereb/lib/readers/municipality.py
+++ b/pyramid_oereb/lib/readers/municipality.py
@@ -24,7 +24,7 @@ class MunicipalityReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self):
+    def read(self, params):
         """
         The central read accessor method to get all desired records from configured source.
 
@@ -33,10 +33,13 @@ class MunicipalityReader(object):
             :ref:`api-pyramid_oereb-lib-records-municipality-municipalityrecord`. Otherwise the API like way
             the server works would be broken.
 
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
+
         Returns:
             list of pyramid_oereb.lib.records.municipality.MunicipalityRecord:
             The list of all found records. Since these are not filtered by any criteria the list simply
             contains all records delivered by the source.
         """
-        self._source_.read()
+        self._source_.read(params)
         return self._source_.records

--- a/pyramid_oereb/lib/readers/real_estate.py
+++ b/pyramid_oereb/lib/readers/real_estate.py
@@ -28,7 +28,7 @@ class RealEstateReader(object):
         source_class = DottedNameResolver().resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self, nb_ident=None, number=None, egrid=None, geometry=None):
+    def read(self, params, nb_ident=None, number=None, egrid=None, geometry=None):
         """
         The central read accessor method to get all desired records from configured source.
 
@@ -38,6 +38,7 @@ class RealEstateReader(object):
             server works would be broken.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             nb_ident (int or None): The identification number of the desired real estate. This
                 parameter is directly related to the number parameter and both must be set!
                 Combination will deliver only one result or crashes.
@@ -68,7 +69,7 @@ class RealEstateReader(object):
             plan_for_land_register_main_page_config.get('layer_opacity')
         )
 
-        self._source_.read(nb_ident=nb_ident, number=number, egrid=egrid, geometry=geometry)
+        self._source_.read(params, nb_ident=nb_ident, number=number, egrid=egrid, geometry=geometry)
         for r in self._source_.records:
             if isinstance(r, RealEstateRecord):
                 r.set_view_service(real_estate_view_service)

--- a/pyramid_oereb/lib/sources/address.py
+++ b/pyramid_oereb/lib/sources/address.py
@@ -13,12 +13,13 @@ class AddressBaseSource(Base):
     """
     _record_class_ = AddressRecord
 
-    def read(self, street_name, zip_code, street_number):
+    def read(self, params, street_name, zip_code, street_number):
         """
         Every address source has to implement a read method. This method must accept the three parameters. If
         you want adapt to your own source for addresses, this is the point where to hook in.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             street_name (unicode): The name of the street for the desired address.
             zip_code (int): The postal zipcode for the desired address.
             street_number (str): The house or so called street number of the desired address.

--- a/pyramid_oereb/lib/sources/exclusion_of_liability.py
+++ b/pyramid_oereb/lib/sources/exclusion_of_liability.py
@@ -13,10 +13,13 @@ class ExclusionOfLiabilityBaseSource(Base):
     """
     _record_class_ = ExclusionOfLiabilityRecord
 
-    def read(self):
+    def read(self, params):
         """
         Every exclusion of liability source has to implement a read method. This method must accept no
         parameters. Because it should deliver all items available.
         If you want adapt to your own source for exclusion of liabilities, this is the point where to hook in.
+
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/lib/sources/glossary.py
+++ b/pyramid_oereb/lib/sources/glossary.py
@@ -12,10 +12,13 @@ class GlossaryBaseSource(Base):
     """
     _record_class_ = GlossaryRecord
 
-    def read(self):
+    def read(self, params):
         """
         Every glossary source has to implement a read method. This method must accept no parameters. Because
         it should deliver all items available.
         If you want adapt to your own source for glossaries, this is the point where to hook in.
+
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/lib/sources/legend.py
+++ b/pyramid_oereb/lib/sources/legend.py
@@ -4,4 +4,21 @@ from pyramid_oereb.lib.records.view_service import LegendEntryRecord
 
 
 class LegendBaseSource(Base):
+    """
+    Base class for exclusion of liability sources.
+
+    Attributes:
+        records (list of pyramid_oereb.lib.records.view_service.LegendEntryRecord): List of legend entry
+            records.
+    """
     _record_class_ = LegendEntryRecord
+
+    def read(self, params):
+        """
+        Every legend entry source has to implement a read method. If you want adapt to your own source for
+        legend entries, this is the point where to hook in.
+
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
+        """
+        pass  # pragma: no cover

--- a/pyramid_oereb/lib/sources/legend.py
+++ b/pyramid_oereb/lib/sources/legend.py
@@ -13,12 +13,13 @@ class LegendBaseSource(Base):
     """
     _record_class_ = LegendEntryRecord
 
-    def read(self, params):
+    def read(self, params, **kwargs):
         """
         Every legend entry source has to implement a read method. If you want adapt to your own source for
         legend entries, this is the point where to hook in.
 
         Args:
             params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
+            (kwargs): Arbitrary keyword arguments.
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/lib/sources/municipality.py
+++ b/pyramid_oereb/lib/sources/municipality.py
@@ -13,10 +13,13 @@ class MunicipalityBaseSource(Base):
     """
     _record_class_ = MunicipalityRecord
 
-    def read(self):
+    def read(self, params):
         """
         Every municipality source has to implement a read method. This method must accept no parameters.
         Because it should deliver all items available.
         If you want adapt to your own source for municipalities, this is the point where to hook in.
+
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/lib/sources/plr.py
+++ b/pyramid_oereb/lib/sources/plr.py
@@ -70,13 +70,14 @@ class PlrBaseSource(Base):
         """
         return self._plr_info
 
-    def read(self, real_estate, bbox, position=None):
+    def read(self, params, real_estate, bbox, position=None):
         """
         Every public law restriction source has to implement a read method. This method must accept the two
         key word parameters. If you want adapt to your own source for real estates, this is the point where
         to hook in.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             real_estate (pyramid_oereb.lib.records.real_estate.RealEstateRecord): The real estate which is
                 used as filter to find all related public law restrictions.
             bbox (shapely.geometry.base.BaseGeometry): The bounding box which is used as a pre-filter to find

--- a/pyramid_oereb/lib/sources/real_estate.py
+++ b/pyramid_oereb/lib/sources/real_estate.py
@@ -12,12 +12,13 @@ class RealEstateBaseSource(Base):
     """
     _record_class_ = RealEstateRecord
 
-    def read(self, nb_ident=None, number=None, egrid=None, geometry=None):
+    def read(self, params, nb_ident=None, number=None, egrid=None, geometry=None):
         """
         Every real estate source has to implement a read method. This method must accept the four key word
         parameters. If you want adapt to your own source for real estates, this is the point where to hook in.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             nb_ident (int or None): The identification number of the desired real estate. This
                 parameter is directly related to the number parameter and both must be set!
                 Combination must deliver only one result or must raise an error.

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -156,7 +156,7 @@ pyramid_oereb:
   oereblex:
     # OEREBlex host
     host: https://oereblex.bl.ch
-    # Language of returned values
+    # Default language of returned values
     language: de
     # Value for canton attribute
     canton: BL

--- a/pyramid_oereb/standard/sources/address.py
+++ b/pyramid_oereb/standard/sources/address.py
@@ -9,13 +9,14 @@ from pyramid_oereb.lib.sources.address import AddressBaseSource
 
 class DatabaseSource(BaseDatabaseSource, AddressBaseSource):
 
-    def read(self, street_name, zip_code, street_number):
+    def read(self, params, street_name, zip_code, street_number):
         """
         The read method to access the standard database structure. It uses SQL-Alchemy for querying. It tries
         to find the items via passed arguments. If there was no result found it goes on with assigning an
         empty list as records instance attribute.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             street_name (unicode): The name of the street for the desired address.
             zip_code (int): The postal zipcode for the desired address.
             street_number (str): The house or so called street number of the desired address.

--- a/pyramid_oereb/standard/sources/exclusion_of_liability.py
+++ b/pyramid_oereb/standard/sources/exclusion_of_liability.py
@@ -5,11 +5,14 @@ from pyramid_oereb.lib.sources.exclusion_of_liability import ExclusionOfLiabilit
 
 class DatabaseSource(BaseDatabaseSource, ExclusionOfLiabilityBaseSource):
 
-    def read(self):
+    def read(self, params):
         """
         The read method to access the standard database structure. It uses SQL-Alchemy for querying. It does
         not accept any parameters nor it applies any filter on the database query. It simply loads all
         content from the configured model.
+
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         session = self._adapter_.get_session(self._key_)
         try:

--- a/pyramid_oereb/standard/sources/glossary.py
+++ b/pyramid_oereb/standard/sources/glossary.py
@@ -5,9 +5,12 @@ from pyramid_oereb.lib.sources.glossary import GlossaryBaseSource
 
 class DatabaseSource(BaseDatabaseSource, GlossaryBaseSource):
 
-    def read(self):
+    def read(self, params):
         """
         Central method to read all glossary entries.
+
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         session = self._adapter_.get_session(self._key_)
         try:

--- a/pyramid_oereb/standard/sources/legend.py
+++ b/pyramid_oereb/standard/sources/legend.py
@@ -6,11 +6,12 @@ from pyramid_oereb.lib.sources.legend import LegendBaseSource
 
 class DatabaseSource(BaseDatabaseSource, LegendBaseSource):
 
-    def read(self, **kwargs):
+    def read(self, params, **kwargs):
         """
         Central method to read one legend entry.
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             (kwargs): Arbitrary keyword arguments. It must contain the key 'type_code'.
         """
         session = self._adapter_.get_session(self._key_)

--- a/pyramid_oereb/standard/sources/municipality.py
+++ b/pyramid_oereb/standard/sources/municipality.py
@@ -12,9 +12,12 @@ from pyramid_oereb.lib.sources.municipality import MunicipalityBaseSource
 
 class DatabaseSource(BaseDatabaseSource, MunicipalityBaseSource):
 
-    def read(self):
+    def read(self, params):
         """
         Central method to read a municipality by it's id_bfs identifier.
+
+        Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         session = self._adapter_.get_session(self._key_)
         try:

--- a/pyramid_oereb/standard/sources/real_estate.py
+++ b/pyramid_oereb/standard/sources/real_estate.py
@@ -9,11 +9,12 @@ from pyramid_oereb.lib.sources.real_estate import RealEstateBaseSource
 
 class DatabaseSource(BaseDatabaseSource, RealEstateBaseSource):
 
-    def read(self, nb_ident=None, number=None, egrid=None, geometry=None):
+    def read(self, params, nb_ident=None, number=None, egrid=None, geometry=None):
         """
         Central method to read all plrs (geometry input) or explicitly one plr (nb_ident+number/egrid input).
 
         Args:
+            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             nb_ident (int or None): The identification number of the desired real estate. This
                 parameter is directly related to the number parameter and both must be set!
                 Combination will deliver only one result or crashes.

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -466,13 +466,13 @@ class PlrWebservice(object):
 
 
 class Parameter(object):
-    def __init__(self, format, flavour=None, with_geometry=False, images=False, identdn=None, number=None,
-                 egrid=None, language=None, topics=None):
+    def __init__(self, response_format, flavour=None, with_geometry=False, images=False, identdn=None,
+                 number=None, egrid=None, language=None, topics=None):
         """
         Creates a new parameter instance.
 
         Args:
-            format (str): The extract format.
+            response_format (str): The extract format.
             flavour (str): The extract flavour.
             with_geometry (bool): Extract with/without geometry.
             images (bool): Extract with/without images.
@@ -483,7 +483,7 @@ class Parameter(object):
             topics (list of str): The list of requested topics.
         """
         self.__flavour__ = flavour
-        self.__format__ = format
+        self.__format__ = response_format
         self.__with_geometry__ = with_geometry
         self.__images__ = images
         self.__identdn__ = identdn

--- a/tests/mockrequest.py
+++ b/tests/mockrequest.py
@@ -10,6 +10,12 @@ from pyramid_oereb import Processor
 from pyramid_oereb import RealEstateReader
 
 from pyramid_oereb.lib.config import Config
+from pyramid_oereb.views.webservice import Parameter
+
+
+class MockParameter(Parameter):
+    def __init__(self):
+        super(MockParameter, self).__init__('JSON', flavour='REDUCED', with_geometry=False, images=False)
 
 
 class MockRequest(DummyRequest):

--- a/tests/readers/test_address.py
+++ b/tests/readers/test_address.py
@@ -5,6 +5,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.records.address import AddressRecord
 from pyramid_oereb.lib.sources import Base
 from pyramid_oereb.lib.readers.address import AddressReader
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -26,7 +27,8 @@ def test_read(param, length):
         Config.get_address_config().get('source').get('class'),
         **Config.get_address_config().get('source').get('params')
     )
-    results = reader.read(param.get('street_name'), param.get('zip_code'), param.get('street_number'))
+    results = reader.read(MockParameter(), param.get('street_name'), param.get('zip_code'),
+                          param.get('street_number'))
     assert len(results) == length
     if length == 1:
         address = results[0]

--- a/tests/readers/test_exclusion_of_liability.py
+++ b/tests/readers/test_exclusion_of_liability.py
@@ -5,6 +5,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.sources import Base
 from pyramid_oereb.lib.readers.exclusion_of_liability import ExclusionOfLiabilityReader
 from pyramid_oereb.lib.records.exclusion_of_liability import ExclusionOfLiabilityRecord
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -22,7 +23,7 @@ def test_read():
         Config.get_exclusion_of_liability_config().get('source').get('class'),
         **Config.get_exclusion_of_liability_config().get('source').get('params')
     )
-    results = reader.read()
+    results = reader.read(MockParameter())
     assert isinstance(results, list)
     assert len(results) == 1
     assert isinstance(results[0], ExclusionOfLiabilityRecord)

--- a/tests/readers/test_glossary.py
+++ b/tests/readers/test_glossary.py
@@ -5,6 +5,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.sources import Base
 from pyramid_oereb.lib.readers.glossary import GlossaryReader
 from pyramid_oereb.lib.records.glossary import GlossaryRecord
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -22,7 +23,7 @@ def test_read():
         Config.get_glossary_config().get('source').get('class'),
         **Config.get_glossary_config().get('source').get('params')
     )
-    results = reader.read()
+    results = reader.read(MockParameter())
     assert isinstance(results, list)
     assert isinstance(results[0], GlossaryRecord)
     assert len(results) == 1

--- a/tests/readers/test_municipality.py
+++ b/tests/readers/test_municipality.py
@@ -5,6 +5,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.records.municipality import MunicipalityRecord
 from pyramid_oereb.lib.sources import Base
 from pyramid_oereb.lib.readers.municipality import MunicipalityReader
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -22,7 +23,7 @@ def test_read():
         Config.get_municipality_config().get('source').get('class'),
         **Config.get_municipality_config().get('source').get('params')
     )
-    results = reader.read()
+    results = reader.read(MockParameter())
     assert isinstance(results, list)
     assert len(results) == 1
     result = results[0]

--- a/tests/readers/test_real_estate.py
+++ b/tests/readers/test_real_estate.py
@@ -5,6 +5,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.records.real_estate import RealEstateRecord
 from pyramid_oereb.lib.sources import Base
 from pyramid_oereb.lib.readers.real_estate import RealEstateReader
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -27,7 +28,7 @@ def test_read(param):
         Config.get_real_estate_config().get('source').get('class'),
         **Config.get_real_estate_config().get('source').get('params')
     )
-    records = reader.read(**param)
+    records = reader.read(MockParameter(), **param)
     assert len(records) == 1
     record = records[0]
     assert isinstance(record, RealEstateRecord)

--- a/tests/renderer/test_json.py
+++ b/tests/renderer/test_json.py
@@ -35,7 +35,7 @@ def law_status():
 
 
 def default_param():
-    return Parameter('reduced', 'json', False, False, 'BL0200002829', '1000', 'CH775979211712', 'de')
+    return Parameter('json', 'reduced', False, False, 'BL0200002829', '1000', 'CH775979211712', 'de')
 
 
 @pytest.fixture()
@@ -57,7 +57,7 @@ def glossary_expected():
 @pytest.mark.parametrize('parameter, glossaries_input, glossaries_expected', [
     (default_param(), glossary_input(), glossary_expected()),
     (default_param(), [], []),
-    (Parameter('reduced', 'json', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de'),
+    (Parameter('json', 'reduced', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de'),
      glossary_input(),
      glossary_expected()),
     (None, glossary_input(), glossary_expected()),
@@ -191,7 +191,8 @@ def test_format_real_estate():
     renderer = Renderer(DummyRenderInfo())
     renderer._language = u'de'
     renderer._params = Parameter(
-        'reduced', 'json', True, False, 'BL0200002829', '1000', 'CH775979211712', 'de')
+        'json', 'reduced', True, False, 'BL0200002829', '1000', 'CH775979211712', 'de'
+    )
     geometry = MultiPolygon([Polygon([(0, 0), (1, 1), (1, 0)])])
     view_service = ViewServiceRecord(u'http://geowms.bl.ch',
                                      1,
@@ -227,8 +228,8 @@ def test_format_real_estate():
 
 @pytest.mark.parametrize('parameter', [
     default_param(),
-    Parameter('reduced', 'json', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de'),
-    Parameter('full', 'json', False, False, 'BL0200002829', '1000', 'CH775979211712', 'de')
+    Parameter('json', 'reduced', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de'),
+    Parameter('json', 'full', False, False, 'BL0200002829', '1000', 'CH775979211712', 'de')
 ])
 def test_format_plr(parameter):
     with pyramid_oereb_test_config():
@@ -517,7 +518,7 @@ def test_format_map(params, legend_at_web, expected_legend_at_web):
 
 @pytest.mark.parametrize('parameter', [
     default_param(),
-    Parameter('reduced', 'json', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de')
+    Parameter('json', 'reduced', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de')
 ])
 def test_format_legend_entry(parameter):
     with pyramid_oereb_test_config():

--- a/tests/renderer/xml/test_legend_entry.py
+++ b/tests/renderer/xml/test_legend_entry.py
@@ -12,8 +12,8 @@ template = xml_templates().get_template('legend_entry.xml')
 
 def test_sub_theme():
     parameters = Parameter(
+        response_format='xml',
         flavour='reduced',
-        format='xml',
         with_geometry=False,
         images=True,
         identdn='BL0200002829',

--- a/tests/renderer/xml/test_public_law_restriction.py
+++ b/tests/renderer/xml/test_public_law_restriction.py
@@ -18,8 +18,8 @@ template = xml_templates().get_template('public_law_restriction.xml')
 
 def test_sub_theme():
     parameters = Parameter(
+        response_format='xml',
         flavour='reduced',
-        format='xml',
         with_geometry=False,
         images=True,
         identdn='BL0200002829',

--- a/tests/sources/test_address_database.py
+++ b/tests/sources/test_address_database.py
@@ -7,6 +7,7 @@ from pyramid_oereb.lib.adapter import DatabaseAdapter
 from pyramid_oereb.lib.records.address import AddressRecord
 from pyramid_oereb.standard.sources.address import DatabaseSource
 from pyramid_oereb.standard.models.main import Address
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -23,7 +24,7 @@ def test_init():
 ])
 def test_read(param, length):
     source = DatabaseSource(**Config.get_address_config().get('source').get('params'))
-    source.read(param.get('street_name'), param.get('zip_code'), param.get('street_number'))
+    source.read(MockParameter(), param.get('street_name'), param.get('zip_code'), param.get('street_number'))
     assert len(source.records) == length
     if length == 1:
         address = source.records[0]

--- a/tests/sources/test_address_geoadmin.py
+++ b/tests/sources/test_address_geoadmin.py
@@ -8,6 +8,8 @@ from shapely.geometry import Point
 
 from pyramid_oereb.lib.records.address import AddressRecord
 from pyramid_oereb.contrib.sources.address import AddressGeoAdminSource
+from tests.mockrequest import MockParameter
+
 if sys.version_info.major == 2:
     from urllib import urlencode
 else:
@@ -77,9 +79,11 @@ def test_read(status_code):
         m.get(url, json=response, status_code=status_code)
         if status_code == 400:
             with pytest.raises(HTTPError):
-                source.read(street_name=street_name, zip_code=zip_code, street_number=street_number)
+                source.read(MockParameter(), street_name=street_name, zip_code=zip_code,
+                            street_number=street_number)
         else:
-            source.read(street_name=street_name, zip_code=zip_code, street_number=street_number)
+            source.read(MockParameter(), street_name=street_name, zip_code=zip_code,
+                        street_number=street_number)
             assert len(source.records) == 1
             address = source.records[0]
             assert isinstance(address, AddressRecord)

--- a/tests/sources/test_document_oereblex.py
+++ b/tests/sources/test_document_oereblex.py
@@ -10,6 +10,7 @@ from requests.auth import HTTPBasicAuth
 from pyramid_oereb.contrib.sources.document import OEREBlexSource
 from pyramid_oereb.lib.records.documents import DocumentRecord, LegalProvisionRecord
 from pyramid_oereb.lib.records.office import OfficeRecord
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.parametrize('valid,cfg', [
@@ -40,18 +41,18 @@ def test_init(valid, cfg):
             OEREBlexSource(**cfg)
 
 
-@pytest.mark.parametrize('key,multilingual,result', [
-    ('official_title', False, None),
-    ('municipality', False, 'Liestal'),
-    ('municipality', True, {'de': 'Liestal'})
+@pytest.mark.parametrize('key,language,result', [
+    ('official_title', None, None),
+    ('municipality', None, 'Liestal'),
+    ('municipality', 'de', {'de': 'Liestal'})
 ])
-def test_get_mapped_value(key, multilingual, result):
+def test_get_mapped_value(key, language, result):
     file_ = File('Test', '/api/attachments/1', 'main')
     document = Document(id='test', title='Test', category='main', doctype='decree', files=[file_],
                         enactment_date=datetime.date.today(), subtype='Liestal', authority='Office')
     source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                             mapping={'municipality': 'subtype'})
-    assert source._get_mapped_value(document, key, multilingual) == result
+    assert source._get_mapped_value(document, key, language=language) == result
 
 
 @pytest.mark.parametrize('i,document', [
@@ -96,6 +97,7 @@ def test_get_mapped_value(key, multilingual, result):
     ))
 ])
 def test_get_document_records(i, document):
+    language = 'de'
     source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL')
     references = [
         Document(
@@ -111,11 +113,11 @@ def test_get_document_records(i, document):
 
     if i == 3:
         with pytest.raises(TypeError):
-            source._get_document_records(document, references)
+            source._get_document_records(document, language, references)
     elif i == 4:
-        assert source._get_document_records(document, references) == []
+        assert source._get_document_records(document, language, references) == []
     else:
-        records = source._get_document_records(document, references)
+        records = source._get_document_records(document, language, references)
         assert len(records) == i
         for idx, record in enumerate(records):
             if i == 1:
@@ -139,7 +141,7 @@ def test_read():
         with open('./tests/resources/geolink_v1.1.1.xml', 'rb') as f:
             m.get('http://oereblex.example.com/api/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL')
-        source.read(100)
+        source.read(MockParameter(), 100)
         assert len(source.records) == 2
         document = source.records[0]
         assert isinstance(document, DocumentRecord)
@@ -158,7 +160,7 @@ def test_read_related_decree_as_main():
             m.get('http://oereblex.example.com/api/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 related_decree_as_main=True)
-        source.read(100)
+        source.read(MockParameter(), 100)
         assert len(source.records) == 3
         document = source.records[0]
         assert isinstance(document, DocumentRecord)
@@ -177,7 +179,7 @@ def test_read_with_version_in_url():
             m.get('http://oereblex.example.com/api/1.1.1/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 pass_version=True)
-        source.read(100)
+        source.read(MockParameter(), 100)
         assert len(source.records) == 2
 
 
@@ -187,7 +189,7 @@ def test_read_with_specified_version():
             m.get('http://oereblex.example.com/api/1.0.0/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 pass_version=True, version='1.0.0')
-        source.read(100)
+        source.read(MockParameter(), 100)
         assert len(source.records) == 2
 
 

--- a/tests/sources/test_exclusion_of_liability_database.py
+++ b/tests/sources/test_exclusion_of_liability_database.py
@@ -6,6 +6,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.adapter import DatabaseAdapter
 from pyramid_oereb.standard.sources.exclusion_of_liability import DatabaseSource
 from pyramid_oereb.standard.models.main import ExclusionOfLiability
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -22,5 +23,5 @@ def test_read():
     source = DatabaseSource(
         **Config.get_exclusion_of_liability_config().get('source').get('params')
     )
-    source.read()
+    source.read(MockParameter())
     assert len(source.records) == 1

--- a/tests/sources/test_glossary_database.py
+++ b/tests/sources/test_glossary_database.py
@@ -5,6 +5,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.adapter import DatabaseAdapter
 from pyramid_oereb.standard.sources.glossary import DatabaseSource
 from pyramid_oereb.standard.models.main import Glossary
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -17,4 +18,4 @@ def test_init():
 @pytest.mark.run(order=2)
 def test_read():
     source = DatabaseSource(**Config.get_glossary_config().get('source').get('params'))
-    source.read()
+    source.read(MockParameter())

--- a/tests/sources/test_legend_database.py
+++ b/tests/sources/test_legend_database.py
@@ -5,6 +5,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.adapter import DatabaseAdapter
 from pyramid_oereb.standard.sources.legend import DatabaseSource
 from pyramid_oereb.standard.models.airports_building_lines import LegendEntry
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -25,5 +26,5 @@ def test_init(model):
 def test_read(model):
     db_url = Config.get('app_schema').get('db_connection')
     source = DatabaseSource(**{'db_connection': db_url, 'model': model})
-    source.read(**{'type_code': 'StaoTyp1'})
+    source.read(MockParameter(), **{'type_code': 'StaoTyp1'})
     assert len(source.records) == 0

--- a/tests/sources/test_municipality_database.py
+++ b/tests/sources/test_municipality_database.py
@@ -6,6 +6,7 @@ from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.adapter import DatabaseAdapter
 from pyramid_oereb.standard.sources.municipality import DatabaseSource
 from pyramid_oereb.standard.models.main import Municipality
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -17,5 +18,5 @@ def test_init():
 
 def test_read():
     source = DatabaseSource(**Config.get_municipality_config().get('source').get('params'))
-    source.read()
+    source.read(MockParameter())
     assert isinstance(source.records, list)

--- a/tests/sources/test_real_estate_database.py
+++ b/tests/sources/test_real_estate_database.py
@@ -6,6 +6,7 @@ from pyramid_oereb.lib.adapter import DatabaseAdapter
 from pyramid_oereb.lib.records.real_estate import RealEstateRecord
 from pyramid_oereb.standard.sources.real_estate import DatabaseSource
 from pyramid_oereb.standard.models.main import RealEstate
+from tests.mockrequest import MockParameter
 
 
 @pytest.mark.run(order=2)
@@ -23,7 +24,7 @@ def test_init():
 ])
 def test_read(param):
     source = DatabaseSource(**Config.get_real_estate_config().get('source').get('params'))
-    source.read(**param)
+    source.read(MockParameter(), **param)
     assert len(source.records) == 1
     record = source.records[0]
     assert isinstance(record, RealEstateRecord)
@@ -34,4 +35,4 @@ def test_read(param):
 def test_missing_parameter():
     source = DatabaseSource(**Config.get_real_estate_config().get('source').get('params'))
     with pytest.raises(AttributeError):
-        source.read()
+        source.read(MockParameter())

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -48,9 +48,9 @@ def test_process():
     request = MockRequest()
     request.matchdict.update(request_matchdict)
     processor = request.pyramid_oereb_processor
-    real_estate = processor.real_estate_reader.read(egrid=u'TEST')
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
+    real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
     extract = processor.process(real_estate[0], params, 'http://test.ch')
     assert isinstance(extract, ExtractRecord)
 
@@ -59,9 +59,9 @@ def test_process_geometry_testing():
     request = MockRequest()
     request.matchdict.update(request_matchdict)
     processor = request.pyramid_oereb_processor
-    real_estate = processor.real_estate_reader.read(egrid=u'TEST')
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
+    real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
     extract = processor.process(real_estate[0], params, 'http://test.ch')
     for plr in extract.real_estate.public_law_restrictions:
         for g in plr.geometries:
@@ -72,9 +72,9 @@ def test_filter_published_documents():
     request = MockRequest()
     request.matchdict.update(request_matchdict)
     processor = request.pyramid_oereb_processor
-    real_estate = processor.real_estate_reader.read(egrid=u'TEST')
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
+    real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
     extract = processor.process(real_estate[0], params, 'http://test.ch')
     for plr in extract.real_estate.public_law_restrictions:
         if plr.theme.code == u'MotorwaysBuildingLines':
@@ -90,9 +90,9 @@ def test_processor_with_images():
         'LANG': 'de'
     })
     processor = request.pyramid_oereb_processor
-    real_estate = processor.real_estate_reader.read(egrid=u'TEST')
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
+    real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
     extract = processor.process(real_estate[0], params, 'http://test.ch')
     assert extract.real_estate.plan_for_land_register.image is not None
     for plr in extract.real_estate.public_law_restrictions:
@@ -106,9 +106,9 @@ def test_processor_without_images():
         'LANG': 'de'
     })
     processor = request.pyramid_oereb_processor
-    real_estate = processor.real_estate_reader.read(egrid=u'TEST')
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
+    real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
     extract = processor.process(real_estate[0], params, 'http://test.ch')
     assert extract.real_estate.plan_for_land_register.image is None
     for plr in extract.real_estate.public_law_restrictions:

--- a/tests/webservice/test_getegrid.py
+++ b/tests/webservice/test_getegrid.py
@@ -17,7 +17,13 @@ from pyramid_oereb.views.webservice import PlrWebservice
 
 
 def test_getegrid_coord_missing_parameter():
-    webservice = PlrWebservice(MockRequest())
+    request = MockRequest(current_route_url='http://example.com/oereb/getegrid/json/')
+
+    # Add params to matchdict as the view will do it for /getegrid/{format}/
+    request.matchdict.update({
+        'format': u'json'
+    })
+    webservice = PlrWebservice(request)
     with pytest.raises(HTTPBadRequest):
         webservice.get_egrid_coord()
 
@@ -111,7 +117,15 @@ def test_getegrid_gnss():
 
 
 def test_getegrid_ident_missing_parameter():
-    webservice = PlrWebservice(MockRequest())
+    request = MockRequest(
+        current_route_url='http://example.com/oereb/getegrid/json/'
+    )
+
+    # Add params to matchdict as the view will do it for /getegrid/{format}/
+    request.matchdict.update({
+        'format': u'json'
+    })
+    webservice = PlrWebservice(request)
     with pytest.raises(HTTPBadRequest):
         webservice.get_egrid_ident()
 
@@ -145,7 +159,16 @@ def test_getegrid_address():
 
 
 def test_getegrid_address_missing_parameter():
-    webservice = PlrWebservice(MockRequest())
+    request = MockRequest(
+        current_route_url='http://example.com/oereb/getegrid/json/'
+    )
+
+    # Add params to matchdict as the view will do it for
+    # /getegrid/{format}/{postalcode}/{localisation}/{number}
+    request.matchdict.update({
+        'format': u'json'
+    })
+    webservice = PlrWebservice(request)
     with pytest.raises(HTTPBadRequest):
         webservice.get_egrid_address()
 

--- a/tests/webservice/test_parameter.py
+++ b/tests/webservice/test_parameter.py
@@ -4,7 +4,7 @@ from pyramid_oereb.views.webservice import Parameter
 
 
 def test_parameter():
-    params = Parameter('reduced', 'json', True, False)
+    params = Parameter('json', 'reduced', True, False)
     params.set_identdn('identdn')
     params.set_number('1000')
     params.set_egrid('EGRID')


### PR DESCRIPTION
Pass the `Parameter` object of the current request to all readers and sources to access its properties. This is needed to use the requested language when querying documents with the `OEREBlexSource`.

Closes #923 