### PR TITLE
Grouping LegalProvisions GEO-2555

### DIFF
--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -107,6 +107,10 @@ vars:
       # Split themes up, so that each sub theme gets its own page
       # Disabled by default.
       split_sub_themes: true
+      # Setting this to true (default is false):
+      # list elements of "LegalProvision" with the same "Title.Text" are grouped together
+      # if more than one element exists with the same "Title.Text".
+      group_legal_provisions: true
       # Determine if a multiple page table of content (TOC) is used with a slightly different layout but
       # better page numbering. If it is known that the TOC is very long and runs over more than one page it
       # is preferred to set this to true.

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -110,7 +110,7 @@ vars:
       # Setting this to true (default is false):
       # list elements of "LegalProvision" with the same "Title.Text" are grouped together
       # if more than one element exists with the same "Title.Text".
-      group_legal_provisions: true
+      group_legal_provisions: false
       # Determine if a multiple page table of content (TOC) is used with a slightly different layout but
       # better page numbering. If it is known that the TOC is very long and runs over more than one page it
       # is preferred to set this to true.

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -108,7 +108,7 @@ vars:
       # Disabled by default.
       split_sub_themes: true
       # Setting this to true (default is false):
-      # list elements of "LegalProvision" with the same "Title.Text" are grouped together
+      # list elements of "LegalProvision" and "Hints" with the same "Title.Text" are grouped together
       # if more than one element exists with the same "Title.Text".
       group_legal_provisions: false
       # Determine if a multiple page table of content (TOC) is used with a slightly different layout but

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -107,9 +107,8 @@ vars:
       # Split themes up, so that each sub theme gets its own page
       # Disabled by default.
       split_sub_themes: true
-      # Setting this to true (default is false):
-      # list elements of "LegalProvision" and "Hints" with the same "Title.Text" are grouped together
-      # if more than one element exists with the same "Title.Text".
+      # Group elements of "LegalProvision" and "Hints" with the same "Title.Text" together yes/no
+      # Disabled by default.
       group_legal_provisions: false
       # Determine if a multiple page table of content (TOC) is used with a slightly different layout but
       # better page numbering. If it is known that the TOC is very long and runs over more than one page it

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -405,9 +405,9 @@ class Renderer(JsonRenderer):
 
                 # Group legal provisions and hints which have the same title.
                 if (
-                        (Config.get('print', {}).get('group_legal_provisions', False)) and
-                        (element == 'LegalProvisions' or element == 'Hints')
-                    ):
+                       (Config.get('print', {}).get('group_legal_provisions', False)) and
+                       (element == 'LegalProvisions' or element == 'Hints')
+                   ):
                     restriction_on_landownership[element] = \
                         self.group_legal_provisions(restriction_on_landownership[element])
 

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -403,8 +403,9 @@ class Renderer(JsonRenderer):
                 if element == 'LegalProvisions':
                     pdf_to_join.update([legal_provision['TextAtWeb'] for legal_provision in values])
                     # Group legal Provisions with the same title
-                    restriction_on_landownership[element] = \
-                        self.group_legal_provisions(restriction_on_landownership[element])
+                    if Config.get('print', {}).get('group_legal_provisions', False):
+                        restriction_on_landownership[element] = \
+                            self.group_legal_provisions(restriction_on_landownership[element])
 
             # sort legal provisioning, hints and laws
             restriction_on_landownership['LegalProvisions'] = self.sort_dict_list(
@@ -499,9 +500,8 @@ class Renderer(JsonRenderer):
             if not existing_element:
                 merged_provision.append(element)
                 continue
-            existing_element['TextAtWeb'] += '\n' + element['TextAtWeb'] # TODO merge the text here!
-            # https://stackoverflow.com/questions/25050326/find-and-update-a-value-of-a-dictionary-in-list-of-dictionaries
-        return merged_provision
+            existing_element['TextAtWeb'] += '\n' + element['TextAtWeb']
+        return merged_provision if len(merged_provision) > 0 else legal_provisions
 
     def _flatten_array_object(self, parent, array_name, object_name):
         if array_name in parent:

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -402,10 +402,14 @@ class Renderer(JsonRenderer):
                 restriction_on_landownership[element] = values
                 if element == 'LegalProvisions':
                     pdf_to_join.update([legal_provision['TextAtWeb'] for legal_provision in values])
-                    # Group legal Provisions with the same title
-                    if Config.get('print', {}).get('group_legal_provisions', False):
-                        restriction_on_landownership[element] = \
-                            self.group_legal_provisions(restriction_on_landownership[element])
+
+                # Group legal provisions and hints which have the same title.
+                if (
+                        (Config.get('print', {}).get('group_legal_provisions', False)) and
+                        (element == 'LegalProvisions' or element == 'Hints')
+                    ):
+                    restriction_on_landownership[element] = \
+                        self.group_legal_provisions(restriction_on_landownership[element])
 
             # sort legal provisioning, hints and laws
             restriction_on_landownership['LegalProvisions'] = self.sort_dict_list(

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -176,7 +176,8 @@ class Renderer(JsonRenderer):
             extract_dict: the oereb extract, will get converted by this function into a form
                             convenient for mapfish-print
             feature_geometry: the geometry for this extract, will get added to the extract information
-            pdf_to_join: a set of additional information for the pdf, will get filled by this function
+            pdf_to_join: a set of additional information for the pdf. Will get filled by this function.
+                         Used in the full extract only
         """
 
         log.debug("Starting transformation, extract_dict is {}".format(extract_dict))
@@ -401,6 +402,10 @@ class Renderer(JsonRenderer):
                 restriction_on_landownership[element] = values
                 if element == 'LegalProvisions':
                     pdf_to_join.update([legal_provision['TextAtWeb'] for legal_provision in values])
+                    # Group legal Provisions with the same title
+                    restriction_on_landownership[element] = \
+                        self.group_legal_provisions(restriction_on_landownership[element])
+
             # sort legal provisioning, hints and laws
             restriction_on_landownership['LegalProvisions'] = self.sort_dict_list(
                 restriction_on_landownership['LegalProvisions'],
@@ -484,6 +489,19 @@ class Renderer(JsonRenderer):
 
         log.debug("After transformation, extract_dict is {}".format(extract_dict))
         return extract_dict
+
+    @staticmethod
+    def group_legal_provisions(legal_provisions):
+        merged_provision = []
+        for element in legal_provisions:
+            # get element with same title if existing
+            existing_element = next((item for item in merged_provision if item['Title'] == element['Title']), None)
+            if not existing_element:
+                merged_provision.append(element)
+                continue
+            existing_element['TextAtWeb'] += '\n' + element['TextAtWeb'] # TODO merge the text here!
+            # https://stackoverflow.com/questions/25050326/find-and-update-a-value-of-a-dictionary-in-list-of-dictionaries
+        return merged_provision
 
     def _flatten_array_object(self, parent, array_name, object_name):
         if array_name in parent:

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -496,7 +496,8 @@ class Renderer(JsonRenderer):
         merged_provision = []
         for element in legal_provisions:
             # get element with same title if existing
-            existing_element = next((item for item in merged_provision if item['Title'] == element['Title']), None)
+            existing_element = \
+                next((item for item in merged_provision if item['Title'] == element['Title']), None)
             if not existing_element:
                 merged_provision.append(element)
                 continue

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -106,6 +106,10 @@ pyramid_oereb:
     # Split themes up, so that each sub theme gets its own page
     # Disabled by default.
     split_sub_themes: false
+    # Setting this to true (default is false):
+    # list elements of "LegalProvision" with the same "Title.Text" are grouped together
+    # if more than one element exists with the same "Title.Text".
+    group_legal_provisions: false
     # Determine if a multiple page table of content (TOC) is used with a slightly different layout but
     # better page numbering. If it is known that the TOC is very long and runs over more than one page it
     # is preferred to set this to true.

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -107,7 +107,7 @@ pyramid_oereb:
     # Disabled by default.
     split_sub_themes: false
     # Setting this to true (default is false):
-    # list elements of "LegalProvision" with the same "Title.Text" are grouped together
+    # list elements of "LegalProvision" and "Hints" with the same "Title.Text" are grouped together
     # if more than one element exists with the same "Title.Text".
     group_legal_provisions: false
     # Determine if a multiple page table of content (TOC) is used with a slightly different layout but

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -106,9 +106,8 @@ pyramid_oereb:
     # Split themes up, so that each sub theme gets its own page
     # Disabled by default.
     split_sub_themes: false
-    # Setting this to true (default is false):
-    # list elements of "LegalProvision" and "Hints" with the same "Title.Text" are grouped together
-    # if more than one element exists with the same "Title.Text".
+    # Group elements of "LegalProvision" and "Hints" with the same "Title.Text" together yes/no
+    # Disabled by default.
     group_legal_provisions: false
     # Determine if a multiple page table of content (TOC) is used with a slightly different layout but
     # better page numbering. If it is known that the TOC is very long and runs over more than one page it

--- a/sample_data/plr119/forest_perimeters/document.json
+++ b/sample_data/plr119/forest_perimeters/document.json
@@ -112,5 +112,35 @@
       "de": "Revision Ortsplanung, 07.447"
     },
     "official_number": ""
+  },
+  {
+    "office_id": 1,
+    "published_from": "2019-11-17",
+    "canton": "",
+    "id": 8104,
+    "document_type": "Hint",
+    "text_at_web": {
+      "de": "http://example.com/goodhint1"
+    },
+    "law_status": "inForce",
+    "title": {
+      "de": "Guter Ratschlag"
+    },
+    "official_number": ""
+  },
+  {
+    "office_id": 1,
+    "published_from": "2019-11-17",
+    "canton": "",
+    "id": 8105,
+    "document_type": "Hint",
+    "text_at_web": {
+      "de": "http://example.com/goodhint2"
+    },
+    "law_status": "inForce",
+    "title": {
+      "de": "Guter Ratschlag"
+    },
+    "official_number": ""
   }
 ]

--- a/sample_data/plr119/forest_perimeters/document_reference.json
+++ b/sample_data/plr119/forest_perimeters/document_reference.json
@@ -63,5 +63,5 @@
     "reference_document_id": 8002,
     "id": 2622,
     "document_id": 8105
-  } 
+  }
 ]

--- a/sample_data/plr119/forest_perimeters/document_reference.json
+++ b/sample_data/plr119/forest_perimeters/document_reference.json
@@ -47,5 +47,21 @@
     "reference_document_id": 8002,
     "id": 2618,
     "document_id": 8103
-  }
+  }, {
+    "reference_document_id": 8001,
+    "id": 2619,
+    "document_id": 8104
+  }, {
+    "reference_document_id": 8002,
+    "id": 2620,
+    "document_id": 8104
+  }, {
+    "reference_document_id": 8001,
+    "id": 2621,
+    "document_id": 8105
+  }, {
+    "reference_document_id": 8002,
+    "id": 2622,
+    "document_id": 8105
+  } 
 ]

--- a/sample_data/plr119/forest_perimeters/public_law_restriction_document.json
+++ b/sample_data/plr119/forest_perimeters/public_law_restriction_document.json
@@ -18,5 +18,15 @@
     "id": 405,
     "document_id": 8103,
     "public_law_restriction_id": 402
+  },
+   {
+    "id": 406,
+    "document_id": 8104,
+    "public_law_restriction_id": 402
+  },
+   {
+    "id": 407,
+    "document_id": 8105,
+    "public_law_restriction_id": 402
   }
 ]

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -594,3 +594,83 @@ def test_get_sorted_law():
         }
     ]
     assert expected_result == renderer.sort_dict_list(test_law, renderer.sort_laws)
+
+
+def test_group_legal_provisions():
+    renderer = Renderer(DummyRenderInfo())
+    test_legal_provisions = [
+        {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+            "Title": "Baugesetz"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "Title": "Baugesetz"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "07.447",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
+            "Title": "Revision Ortsplanung"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "07.447",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
+            "Title": "Revision Ortsplanung"
+        }
+    ]
+    expected_results = [
+        {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197\n" +
+                         "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "Title": "Baugesetz"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inForce",
+            "Lawstatus_Text": "in Kraft",
+            "OfficialNumber": "07.447",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213\n" +
+                         "https://oereb-gr-preview.000.ch/api/attachments/214",
+            "Title": "Revision Ortsplanung"
+        }
+    ]
+
+    assert expected_results == renderer.group_legal_provisions(test_legal_provisions)


### PR DESCRIPTION
The aim of this PR is to:

- [x] in the configuration: a new parameter "group_legal_provision" which activate the grouping logic if the parameter is set to "true". The parameter is set to `false` per default
- [x]  if grouping logic is active, then the list elements "LegalProvision" with the same "Title.Text" are grouped in the resulting PDF

Implements #819 

For testing set [`group_legal_provisions`](https://github.com/openoereb/pyramid_oereb/blob/ff20e7ef773ffe6c960dac322d2e33dc535deecd/docker/config.yaml.mako#L113) to `true`