### PR TITLE
Update Postgres version in Docker example

### DIFF
--- a/test-db/Dockerfile
+++ b/test-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/postgres:9.5
+FROM camptocamp/postgres:10
 
 LABEL maintainer Camptocamp "info@camptocamp.com"
 


### PR DESCRIPTION
Update Postgres version in Docker example

Note: you need to delete the database image before testing, they are not compatible.