### PR TITLE
avoid connection error

### DIFF
--- a/pyramid_oereb/lib/adapter.py
+++ b/pyramid_oereb/lib/adapter.py
@@ -29,7 +29,7 @@ class DatabaseAdapter(object):
                 connection
         """
         if connection_string not in self._connections_:
-            engine = create_engine(connection_string)
+            engine = create_engine(connection_string, pool_recycle=30)
             session = orm.scoped_session(orm.sessionmaker(bind=engine))
             self._connections_[connection_string] = {
                 'engine': engine,


### PR DESCRIPTION
Fixes #953

If a connection has not been used in the last 30 seconds, recycle it before using it for a new request to the database.

Tested successfully locally (see instructions in #953)