### PR TITLE
nicer error message when model implementation inconsistent

### DIFF
--- a/pyramid_oereb/standard/sources/plr.py
+++ b/pyramid_oereb/standard/sources/plr.py
@@ -365,6 +365,10 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
     def get_document_records(self, public_law_restriction_from_db):
         documents_from_db = []
         article_numbers = []
+        if not hasattr(public_law_restriction_from_db, 'legal_provisions'):
+            raise AttributeError('The public_law_restriction implementation of type {} has no '
+                                 'legal_provisions attribute. Check the model implementation.'
+                                 .format(type(public_law_restriction_from_db)))
         for legal_provision in public_law_restriction_from_db.legal_provisions:
             documents_from_db.append(legal_provision.document)
             article_nrs = legal_provision.article_numbers.split('|') if legal_provision.article_numbers \


### PR DESCRIPTION
This PR proposes a small consistency check on the plr object, to get a nicer error message if it is not consistent.
Example when this error can arise: if a theme is configured as using the standard implementation, but the model actually follows oereblex logic.