### PR TITLE
add oereb statistics functionnalities

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,3 +2,4 @@ exclude_paths:
   - 'tests/**'
   - 'sample_data/**.json'
   - 'Dockerfile'
+  - 'pyramid_oereb/contrib/stats/scripts/**'

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 /doc/source/standard/models/index.rst
 /doc/source/contrib/sources.rst
 /doc/source/contrib/print_proxy.rst
+/doc/source/contrib/stats.rst
 /doc/source/api.rst
 /doc/build/
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ recursive-include pyramid_oereb/standard *.jpg
 recursive-include pyramid_oereb/standard *.xml
 recursive-include pyramid_oereb/lib/renderer *.xml
 recursive-include pyramid_oereb/contrib/templates *.mako
+recursive-include pyramid_oereb/contrib/stats/scripts *.*
 recursive-exclude tests *.*

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,6 +79,11 @@ with open('contrib/print_proxy.rst', 'w') as sources:
         '../../.venv/bin/mako-render' if os.path.exists('../../.venv/bin/mako-render') else 'mako-render',
         'contrib/print_proxy.rst.mako']).decode('utf-8'))
 
+with open('contrib/stats.rst', 'w') as sources:
+    sources.write(subprocess.check_output([
+        '../../.venv/bin/mako-render' if os.path.exists('../../.venv/bin/mako-render') else 'mako-render',
+        'contrib/stats.rst.mako']).decode('utf-8'))
+
 files = glob.glob('../../pyramid_oereb/standard/models/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files

--- a/doc/source/contrib/index.rst
+++ b/doc/source/contrib/index.rst
@@ -2,8 +2,7 @@ Contribution
 ============
 
 The contribution part of this project is the place where bindings to useful pieces are provided. In the
-moment, some sources and one print proxy are provided here. In future versions,
-some common used code snippets may be provided here as well.
+moment, some sources, print proxies, and a statistic functionality are provided here.
 
 Would you like to contribute to the project? Please see :ref:`contributing`.
 
@@ -12,4 +11,5 @@ Would you like to contribute to the project? Please see :ref:`contributing`.
 
    sources
    print_proxy
+   stats
    contributing

--- a/doc/source/contrib/stats.rst.mako
+++ b/doc/source/contrib/stats.rst.mako
@@ -1,0 +1,69 @@
+.. _contrib-stats:
+
+Statistics
+----------
+
+The statistics functionality allows you to gather usage information within pyramid_oereb
+itself. The data gathered will be persisted in configured database,
+allowing the operator or owner of the application to query at any time
+the usage statistics for that database.
+
+The functionality is configured via the server's ini file; see the project repository for a
+complete example of such an ini file.
+
+Example of a configuration:
+
+.. code-block:: python
+
+    args = ({'url':'postgresql://postgres:password@oereb-db:5432/oereb_stats','tablename':'logs','tableargs': {'schema':'oereb_logs'}},'healthcheck')
+
+
+<%! import glob, inspect, re, sys %>
+<%
+modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
+files = glob.glob('../../pyramid_oereb/contrib/stats/*.py')
+modules = [
+    re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
+]
+
+modules.sort()
+delete_modules = []
+for i, module in enumerate(modules):
+    try:
+        __import__(module)
+    except ImportError:
+        delete_modules.append(i)
+delete_modules.reverse()
+for i in delete_modules:
+    del modules[i]
+
+classes = {}
+for module in modules:
+    classes[module] = []
+    for name, obj in inspect.getmembers(sys.modules[module]):
+        if inspect.isclass(obj) and obj.__module__ == module:
+            classes[module].append(name)
+
+underline = ['^', '`', '\'', '.', '~', '*']
+%>
+
+%for module in modules:
+.. _api-${module.replace('.', '-').lower()}:
+
+.. automodule:: ${module}
+
+
+%for cls in classes[module]:
+.. _api-${module.replace('.', '-').lower()}-${cls.lower()}:
+
+*${module.split('.')[-1].title().replace('_', ' ')} ${cls}*
+${re.sub('.', underline[0], module.split('.')[-1] + '   ' + cls)}
+
+.. autoclass:: ${module}.${cls}
+   :members:
+   :inherited-members:
+
+   .. automethod:: __init__
+
+%endfor
+%endfor

--- a/docker/production.ini
+++ b/docker/production.ini
@@ -36,10 +36,10 @@ reload = true
 ###
 
 [loggers]
-keys = root, pyramid_oereb, sqlalchemy
+keys = root, pyramid_oereb, sqlalchemy, json
 
 [handlers]
-keys = console
+keys = console, sqlalchemylogger
 
 [formatters]
 keys = generic
@@ -52,6 +52,12 @@ handlers = console
 level = WARN
 handlers =
 qualname = pyramid_oereb
+
+[logger_json]
+level = INFO
+handlers = console, sqlalchemylogger
+qualname = JSON
+propagate = 0
 
 [logger_sqlalchemy]
 level = WARN
@@ -66,6 +72,13 @@ class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
 formatter = generic
+
+[handler_sqlalchemylogger]
+class = c2cwsgiutils.sqlalchemylogger.handlers.SQLAlchemyHandler
+args = ({'url':'postgresql://postgres:password@oereb-db:5432/oereb_stats','tablename':'logs','tableargs': {'schema':'oereb_logs'}},'healthcheck')
+level = NOTSET
+formatter = generic
+propagate = 0
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s

--- a/pyramid_oereb/contrib/stats/decorators.py
+++ b/pyramid_oereb/contrib/stats/decorators.py
@@ -1,0 +1,63 @@
+import logging
+import json
+
+LOG = logging.getLogger('JSON')
+
+
+def log_response(wrapped):
+    def wrapper(context, request):
+        response = wrapped(context, request)
+        ret_dict = _serialize_response(response)
+        ret_dict.update(_serialize_request(request))
+        LOG.info(json.dumps(ret_dict))
+        return response
+    return wrapper
+
+
+def _serialize_response(response):
+    x = {}
+    x['status_code'] = response.status_code
+    x['headers'] = dict(response.headers)
+    x['extras'] = response.extras if hasattr(response, 'extras') else None
+    return {'response': x}
+
+
+def _serialize_request(request):
+    x = {}
+    x['headers'] = dict(request.headers)
+    x['traversed'] = str(request.traversed)
+    x['parameters'] = dict(request.GET)
+    x['path'] = str(request.path)
+    x['view_name'] = str(request.view_name)
+    return {'request': x}
+
+
+class OerebStats(dict):
+    """
+    class OerebStats(dict)
+    this class is used to provide a serializable object that can be
+    used to provide insight of application usage in the logs.
+    """
+    def __init__(self,
+                 service=None,
+                 output_format=None,
+                 params=None):
+        super(OerebStats, self).__init__(service=service,
+                                         output_format=output_format,
+                                         params=params)
+        self.itemlist = super(OerebStats, self).keys()
+
+    def __setitem__(self, key, value):
+        super(OerebStats, self).__setitem__(key, value)
+
+    def __iter__(self):
+        return iter(self.itemlist)
+
+    def keys(self):
+        return self.itemlist
+
+    def values(self):
+        return [self[key] for key in self]
+
+    def itervalues(self):
+        return (self[key] for key in self)

--- a/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
+++ b/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
@@ -35,7 +35,7 @@ def create_stats_tables():
         default='args',
         help='subsection in the ini-file. Default = "args"'
     )
-    options, args = parser.parse_args()
+    options = parser.parse_args()
     if not options.configfile:
         parser.error('No configfile set')
     _create_views(config_file=options.configfile,
@@ -46,7 +46,7 @@ def create_stats_tables():
 def _create_views(config_file,
                   config_section='handler_sqlalchemylogger',
                   config_sql_args='args'):
-    config = configparser.ConfigParser()
+    config, _ = configparser.ConfigParser()
     config.read(config_file)
     schema_name = ast.literal_eval(config[config_section][config_sql_args])[0]['tableargs']['schema']
     tablename = ast.literal_eval(config[config_section][config_sql_args])[0]['tablename']

--- a/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
+++ b/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from c2cwsgiutils.sqlalchemylogger.handlers import SQLAlchemyHandler
+import configparser
+import ast
+from mako.template import Template
+import os
+import optparse
+
+SCRIPT_FOLDER = os.path.dirname(os.path.abspath(__file__))
+
+
+def create_stats_tables():
+    parser = optparse.OptionParser(
+        usage='usage: %prog [options]',
+        description='creates database and views for sqlalchemylogger'
+    )
+    parser.add_option(
+        '-c', '--config',
+        dest='configfile',
+        metavar='INI_FILE',
+        type='string',
+        help='The same config .ini file used to initialize the sqlalchemylogger handler'
+    )
+    parser.add_option(
+        '-s', '--section',
+        dest='config_section',
+        metavar='SECTION_NAME',
+        default='handler_sqlalchemylogger',
+        help='section in the ini-file. Default = "handler_sqlalchemylogger"'
+    )
+    parser.add_option(
+        '-a', '--args',
+        dest='config_sql_args',
+        metavar='SUBSECTION',
+        default='args',
+        help='subsection in the ini-file. Default = "args"'
+    )
+    options, args = parser.parse_args()
+    if not options.configfile:
+        parser.error('No configfile set')
+    _create_views(config_file=options.configfile,
+                  config_section=options.config_section,
+                  config_sql_args=options.config_sql_args)
+
+
+def _create_views(config_file,
+                  config_section='handler_sqlalchemylogger',
+                  config_sql_args='args'):
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    schema_name = ast.literal_eval(config[config_section][config_sql_args])[0]['tableargs']['schema']
+    tablename = ast.literal_eval(config[config_section][config_sql_args])[0]['tablename']
+    fake_handler = SQLAlchemyHandler(ast.literal_eval(config[config_section][config_sql_args])[0])
+    fake_handler.create_db()
+    create_view_sql = Template(filename='{}/templates/views.sql.mako'.format(SCRIPT_FOLDER))
+    fake_handler.session.execute(create_view_sql.render(schema_name=schema_name, tablename=tablename))
+    fake_handler.session.commit()

--- a/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
+++ b/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
@@ -35,7 +35,7 @@ def create_stats_tables():
         default='args',
         help='subsection in the ini-file. Default = "args"'
     )
-    options = parser.parse_args()
+    options, _ = parser.parse_args()
     if not options.configfile:
         parser.error('No configfile set')
     _create_views(config_file=options.configfile,
@@ -46,7 +46,7 @@ def create_stats_tables():
 def _create_views(config_file,
                   config_section='handler_sqlalchemylogger',
                   config_sql_args='args'):
-    config, _ = configparser.ConfigParser()
+    config = configparser.ConfigParser()
     config.read(config_file)
     schema_name = ast.literal_eval(config[config_section][config_sql_args])[0]['tableargs']['schema']
     tablename = ast.literal_eval(config[config_section][config_sql_args])[0]['tablename']

--- a/pyramid_oereb/contrib/stats/scripts/templates/views.sql.mako
+++ b/pyramid_oereb/contrib/stats/scripts/templates/views.sql.mako
@@ -1,26 +1,26 @@
 /*GetVersions view*/
-DROP VIEW IF EXISTS ${schema_name}.stats_get_versions;
-CREATE OR REPLACE VIEW ${schema_name}.stats_get_versions AS
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_versions;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_versions AS
     SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
            cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
            cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
            created_at,
            cast(msg AS json) -> 'request' ->> 'path' AS path
-    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetVersions';
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetVersions';
 
 /*GetCapabilities view*/
-DROP VIEW IF EXISTS ${schema_name}.stats_get_capabilities;
-CREATE OR REPLACE VIEW ${schema_name}.stats_get_capabilities AS
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_capabilities;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_capabilities AS
     SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
            cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
            cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
            created_at,
            cast(msg AS json) -> 'request' ->> 'path' AS path
-    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetCapabilities';
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetCapabilities';
 
 /*GetEgridCoord view*/
-DROP VIEW IF EXISTS ${schema_name}.stats_get_egrid_coord;
-CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_coord AS
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_egrid_coord;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_egrid_coord AS
     SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
            cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
            cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
@@ -28,11 +28,11 @@ CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_coord AS
            cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'gnss' AS gnss,
            created_at,
            cast(msg AS json) -> 'request' ->> 'path' AS path
-    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridCoord';
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridCoord';
 
 /*GetEgridIdent view*/
-DROP VIEW IF EXISTS ${schema_name}.stats_get_egrid_ident;
-CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_ident AS
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_egrid_ident;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_egrid_ident AS
     SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
            cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
            cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
@@ -40,11 +40,11 @@ CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_ident AS
            cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'number' AS number,
            created_at,
            cast(msg AS json) -> 'request' ->> 'path' AS path
-    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridIdent';
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridIdent';
 
 /*GetEgridAddress view*/
-DROP VIEW IF EXISTS ${schema_name}.stats_get_egrid_address;
-CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_address AS
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_egrid_address;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_egrid_address AS
     SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
            cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
            cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
@@ -53,11 +53,11 @@ CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_address AS
            cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'number' AS number,
            created_at,
            cast(msg AS json) -> 'request' ->> 'path' AS path
-    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridAddress';
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridAddress';
 
 /*GetExtractById view*/
-DROP VIEW IF EXISTS ${schema_name}.stats_get_extract_by_id CASCADE;
-CREATE OR REPLACE VIEW ${schema_name}.stats_get_extract_by_id AS
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_extract_by_id CASCADE;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_extract_by_id AS
     SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
            cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
            cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
@@ -67,11 +67,11 @@ CREATE OR REPLACE VIEW ${schema_name}.stats_get_extract_by_id AS
            cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__number__' AS number,
            created_at,
            cast(msg AS json) -> 'request' ->> 'path' AS path
-    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetExtractById';
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetExtractById';
 
 /*stats_daily_extract_by_id*/
-DROP VIEW IF EXISTS ${schema_name}.stats_daily_extract_by_id;
-CREATE OR REPLACE VIEW ${schema_name}.stats_daily_extract_by_id AS
+DROP VIEW IF EXISTS ${schema_name|u}.stats_daily_extract_by_id;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_daily_extract_by_id AS
     SELECT
         date_trunc('day', created_at) AS day,
         COUNT(1) AS nb_requests,
@@ -82,5 +82,5 @@ CREATE OR REPLACE VIEW ${schema_name}.stats_daily_extract_by_id AS
         COUNT(1) FILTER (WHERE flavour = 'full') AS flavour_full,
         COUNT(1) FILTER (WHERE flavour = 'embeddable') AS flavour_embeddable,
         COUNT(1) FILTER (WHERE flavour = 'reduced') AS flavour_reduced
-    FROM ${schema_name}.stats_get_extract_by_id WHERE cast(status_code as INTEGER) = 200
+    FROM ${schema_name|u}.stats_get_extract_by_id WHERE cast(status_code as INTEGER) = 200
     GROUP BY 1;

--- a/pyramid_oereb/contrib/stats/scripts/templates/views.sql.mako
+++ b/pyramid_oereb/contrib/stats/scripts/templates/views.sql.mako
@@ -1,0 +1,86 @@
+/*GetVersions view*/
+DROP VIEW IF EXISTS ${schema_name}.stats_get_versions;
+CREATE OR REPLACE VIEW ${schema_name}.stats_get_versions AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetVersions';
+
+/*GetCapabilities view*/
+DROP VIEW IF EXISTS ${schema_name}.stats_get_capabilities;
+CREATE OR REPLACE VIEW ${schema_name}.stats_get_capabilities AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetCapabilities';
+
+/*GetEgridCoord view*/
+DROP VIEW IF EXISTS ${schema_name}.stats_get_egrid_coord;
+CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_coord AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'xy' AS xy,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'gnss' AS gnss,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridCoord';
+
+/*GetEgridIdent view*/
+DROP VIEW IF EXISTS ${schema_name}.stats_get_egrid_ident;
+CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_ident AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'identdn' AS identdn,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'number' AS number,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridIdent';
+
+/*GetEgridAddress view*/
+DROP VIEW IF EXISTS ${schema_name}.stats_get_egrid_address;
+CREATE OR REPLACE VIEW ${schema_name}.stats_get_egrid_address AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'postalcode' AS postalcode,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'localisation' AS localisation,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'number' AS number,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridAddress';
+
+/*GetExtractById view*/
+DROP VIEW IF EXISTS ${schema_name}.stats_get_extract_by_id CASCADE;
+CREATE OR REPLACE VIEW ${schema_name}.stats_get_extract_by_id AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__flavour__' AS flavour,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__egrid__' AS egrid,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__identdn__' AS identdn,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__number__' AS number,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name}.${tablename} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetExtractById';
+
+/*stats_daily_extract_by_id*/
+DROP VIEW IF EXISTS ${schema_name}.stats_daily_extract_by_id;
+CREATE OR REPLACE VIEW ${schema_name}.stats_daily_extract_by_id AS
+    SELECT
+        date_trunc('day', created_at) AS day,
+        COUNT(1) AS nb_requests,
+        COUNT(1) FILTER (WHERE  output_format = 'pdf') AS format_pdf,
+        COUNT(1) FILTER (WHERE  output_format = 'json') AS format_json,
+        COUNT(1) FILTER (WHERE  output_format = 'xml') AS format_xml,
+        COUNT(1) FILTER (WHERE flavour = 'signed') AS flavour_signed,
+        COUNT(1) FILTER (WHERE flavour = 'full') AS flavour_full,
+        COUNT(1) FILTER (WHERE flavour = 'embeddable') AS flavour_embeddable,
+        COUNT(1) FILTER (WHERE flavour = 'reduced') AS flavour_reduced
+    FROM ${schema_name}.stats_get_extract_by_id WHERE cast(status_code as INTEGER) = 200
+    GROUP BY 1;

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from pyramid_oereb import route_prefix
 from pyramid_oereb.views.webservice import PlrWebservice, Symbol, Logo, Municipality, Sld
+from pyramid_oereb.contrib.stats.decorators import log_response
 
 
 def includeme(config):  # pragma: no cover
@@ -12,25 +13,29 @@ def includeme(config):  # pragma: no cover
     """
 
     # Service for logo images
-    config.add_route('{0}/image/logo'.format(route_prefix), '/image/logo/{logo}/{language}.{extension}')
+    config.add_route('{0}/image/logo'.format(route_prefix),
+                     '/image/logo/{logo}/{language}.{extension}')
     config.add_view(Logo, attr='get_image', route_name='{0}/image/logo'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Service for municipality images
-    config.add_route('{0}/image/municipality'.format(route_prefix), '/image/municipality/{fosnr}.{extension}')
-    config.add_view(Municipality, attr='get_image', route_name='{0}/image/municipality'.format(route_prefix),
-                    request_method='GET')
+    config.add_route('{0}/image/municipality'.format(route_prefix),
+                     '/image/municipality/{fosnr}.{extension}')
+    config.add_view(Municipality,
+                    attr='get_image',
+                    route_name='{0}/image/municipality'.format(route_prefix),
+                    request_method='GET', decorator=log_response)
 
     # Service for symbol images
     config.add_route('{0}/image/symbol'.format(route_prefix),
                      '/image/symbol/{theme_code}/{view_service_id}/{type_code}.{extension}')
     config.add_view(Symbol, attr='get_image', route_name='{0}/image/symbol'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Service for sld creation on egrid input
     config.add_route('{0}/sld'.format(route_prefix), '/sld')
     config.add_view(Sld, attr='get_sld', route_name='{0}/sld'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Get versions
     config.add_route('{0}/versions/'.format(route_prefix), '/versions/{format}')
@@ -38,7 +43,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get version - Can be removed if backward compatibility no longer required.
@@ -47,21 +53,24 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/versions'.format(route_prefix), '/versions')
     config.add_view(
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/versions_old/'.format(route_prefix), '/versions/')
     config.add_view(
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions_old/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get capabilities
@@ -70,7 +79,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get capabilities - Can be removed if backward compatibility no longer required.
@@ -79,73 +89,87 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/capabilities'.format(route_prefix), '/capabilities')
     config.add_view(
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/capabilities_old'.format(route_prefix), '/capabilities/')
     config.add_view(
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities_old'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get egrid
-    config.add_route('{0}/getegrid_coord/'.format(route_prefix), '/getegrid/{format}/')
-    config.add_route('{0}/getegrid_ident/'.format(route_prefix), '/getegrid/{format}/{identdn}/{number}')
+    config.add_route('{0}/getegrid_coord/'.format(route_prefix),
+                     '/getegrid/{format}/')
+    config.add_route('{0}/getegrid_ident/'.format(route_prefix),
+                     '/getegrid/{format}/{identdn}/{number}')
     config.add_route('{0}/getegrid_address/'.format(route_prefix),
                      '/getegrid/{format}/{postalcode}/{localisation}/{number}')
     config.add_view(
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_address',
         route_name='{0}/getegrid_address/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get egrid - Can be removed if backward compatibility no longer required.
-    config.add_route('{0}/getegrid_coord.json'.format(route_prefix), '/getegrid.json')
-    config.add_route('{0}/getegrid_ident.json'.format(route_prefix), '/getegrid/{identdn}/{number}.json')
+    config.add_route('{0}/getegrid_coord.json'.format(route_prefix),
+                     '/getegrid.json')
+    config.add_route('{0}/getegrid_ident.json'.format(route_prefix),
+                     '/getegrid/{identdn}/{number}.json')
     config.add_route('{0}/getegrid_address.json'.format(route_prefix),
                      '/getegrid/{postalcode}/{localisation}/{number}.json')
     config.add_view(
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_address',
         route_name='{0}/getegrid_address.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/getegrid_coord'.format(route_prefix), '/getegrid')
     config.add_route('{0}/getegrid_ident'.format(route_prefix), '/getegrid/{identdn}/{number}')
-    # This legacy route (old specification) can't work anymore because of the one with {format} so it's
+    # This legacy route (old specification) can't work anymore
+    # because of the one with {format} so it's
     # commented and the view removed.
     # config.add_route('{0}/getegrid_address'.format(route_prefix),
     #                 '/getegrid/{postalcode}/{localisation}/{number}')
@@ -153,13 +177,15 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     config.add_route('{0}/getegrid_coord_old/'.format(route_prefix), '/getegrid/')
@@ -167,7 +193,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord_old/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get extract by id
@@ -181,19 +208,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_1'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_2'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_3'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/extract_1/'.format(route_prefix),
                      '/extract/{flavour}/{format}/{param1}/')
@@ -205,19 +235,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_1/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_2/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_3/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Commit config

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -17,6 +17,8 @@ from pyreproj import Reprojector
 from pyramid_oereb.lib.readers.address import AddressReader
 from timeit import default_timer as timer
 
+from pyramid_oereb.contrib.stats.decorators import OerebStats
+
 log = logging.getLogger(__name__)
 
 
@@ -73,14 +75,14 @@ class PlrWebservice(object):
         # Try - catch for backward compatibility with old specification.
         try:
             output_format = self.__validate_format_param__(['xml', 'json'])
-            renderer_name = 'json' if output_format == 'json' else 'pyramid_oereb_versions_xml'
         except HTTPBadRequest:
-            renderer_name = 'json' if self._is_json() else 'pyramid_oereb_versions_xml'
+            output_format = None
             log.warn('Deprecated way to specify the format. Use "/versions/{format}" instead')
-
+        renderer_name = 'json' if output_format == 'json' or self._is_json() else 'pyramid_oereb_versions_xml'
         response = render_to_response(renderer_name, versions, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
+        response.extras = OerebStats(service='GetVersions', output_format=output_format)
         return response
 
     def get_capabilities(self):
@@ -117,14 +119,14 @@ class PlrWebservice(object):
         # Try - catch for backward compatibility with old specification.
         try:
             output_format = self.__validate_format_param__(['xml', 'json'])
-            renderer_name = 'json' if output_format == 'json' else 'pyramid_oereb_capabilities_xml'
         except HTTPBadRequest:
-            renderer_name = 'json' if self._is_json() else 'pyramid_oereb_capabilities_xml'
+            output_format = None
             log.warn('Deprecated way to specify the format. Use "/capabilities/{format}" instead')
-
+        renderer_name = 'json' if output_format == 'json' or self._is_json() else 'pyramid_oereb_capabilities_xml'  # noqa: E501
         response = render_to_response(renderer_name, capabilities, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
+        response.extras = OerebStats(service='GetCapabilities', output_format=output_format)
         return response
 
     def get_egrid_coord(self):
@@ -136,17 +138,26 @@ class PlrWebservice(object):
         """
         xy = self._params.get('XY')
         gnss = self._params.get('GNSS')
-        if xy or gnss:
-            geom_wkt = 'SRID={0};{1}'
-            if xy:
-                geom_wkt = geom_wkt.format(Config.get('srid'),
-                                           self.__parse_xy__(xy, buffer_dist=1.0).wkt)
-            elif gnss:
-                geom_wkt = geom_wkt.format(Config.get('srid'), self.__parse_gnss__(gnss).wkt)
-            records = self._real_estate_reader.read(**{'geometry': geom_wkt})
-            return self.__get_egrid_response__(records)
-        else:
-            raise HTTPBadRequest('XY or GNSS must be defined.')
+        try:
+            if xy or gnss:
+                geom_wkt = 'SRID={0};{1}'
+                if xy:
+                    geom_wkt = geom_wkt.format(Config.get('srid'),
+                                               self.__parse_xy__(xy, buffer_dist=1.0).wkt)
+                elif gnss:
+                    geom_wkt = geom_wkt.format(Config.get('srid'), self.__parse_gnss__(gnss).wkt)
+                records = self._real_estate_reader.read(**{'geometry': geom_wkt})
+                response = self.__get_egrid_response__(records)
+            else:
+                raise HTTPBadRequest('XY or GNSS must be defined.')
+        except HTTPNoContent as err:
+            response = HTTPNoContent('{}'.format(err))
+        except HTTPBadRequest as err:
+            response = HTTPBadRequest('{}'.format(err))
+        response.extras = OerebStats(service='GetEgridCoord',
+                                     params={'xy': xy,
+                                             'gnss': gnss})
+        return response
 
     def get_egrid_ident(self):
         """
@@ -157,14 +168,23 @@ class PlrWebservice(object):
         """
         identdn = self._request.matchdict.get('identdn')
         number = self._request.matchdict.get('number')
-        if identdn and number:
-            records = self._real_estate_reader.read(**{
-                'nb_ident': identdn,
-                'number': number
-            })
-            return self.__get_egrid_response__(records)
-        else:
-            raise HTTPBadRequest('IDENTDN and NUMBER must be defined.')
+        try:
+            if identdn and number:
+                records = self._real_estate_reader.read(**{
+                    'nb_ident': identdn,
+                    'number': number
+                })
+                response = self.__get_egrid_response__(records)
+            else:
+                raise HTTPBadRequest('IDENTDN and NUMBER must be defined.')
+        except HTTPNoContent as err:
+            response = HTTPNoContent('{}'.format(err))
+        except HTTPBadRequest as err:
+            response = HTTPBadRequest('{}'.format(err))
+        response.extras = OerebStats(service='GetEgridIdent',
+                                     params={'identdn': identdn,
+                                             'number': number})
+        return response
 
     def get_egrid_address(self):
         """
@@ -176,19 +196,30 @@ class PlrWebservice(object):
         postalcode = self._request.matchdict.get('postalcode')
         localisation = self._request.matchdict.get('localisation')
         number = self._request.matchdict.get('number')
-        if postalcode and localisation and number:
-            reader = AddressReader(
-                Config.get_address_config().get('source').get('class'),
-                **Config.get_address_config().get('source').get('params')
-            )
-            addresses = reader.read(localisation, int(postalcode), number)
-            if len(addresses) == 0:
-                return HTTPNoContent()
-            geometry = 'SRID={srid};{wkt}'.format(srid=Config.get('srid'), wkt=addresses[0].geom.wkt)
-            records = self._real_estate_reader.read(**{'geometry': geometry})
-            return self.__get_egrid_response__(records)
-        else:
-            raise HTTPBadRequest('POSTALCODE, LOCALISATION and NUMBER must be defined.')
+        try:
+            if postalcode and localisation and number:
+                reader = AddressReader(
+                    Config.get_address_config().get('source').get('class'),
+                    **Config.get_address_config().get('source').get('params')
+                )
+                addresses = reader.read(localisation, int(postalcode), number)
+                if len(addresses) == 0:
+                    raise HTTPNoContent()
+                geometry = 'SRID={srid};{wkt}'.format(srid=Config.get('srid'),
+                                                      wkt=addresses[0].geom.wkt)
+                records = self._real_estate_reader.read(**{'geometry': geometry})
+                response = self.__get_egrid_response__(records)
+            else:
+                raise HTTPBadRequest('POSTALCODE, LOCALISATION and NUMBER must be defined.')
+        except HTTPNoContent as err:
+            response = HTTPNoContent('{}'.format(err))
+        except HTTPBadRequest as err:
+            response = HTTPBadRequest('{}'.format(err))
+        response.extras = OerebStats(service='GetEgridAddress',
+                                     params={'postalcode': postalcode,
+                                             'localisation': localisation,
+                                             'number': number})
+        return response
 
     def get_extract_by_id(self):
         """
@@ -199,55 +230,73 @@ class PlrWebservice(object):
         """
         start_time = timer()
         log.debug("get_extract_by_id() start")
-        params = self.__validate_extract_params__()
-        processor = self._request.pyramid_oereb_processor
-        # read the real estate from configured source by the passed parameters
-        real_estate_reader = processor.real_estate_reader
-        if params.egrid:
-            real_estate_records = real_estate_reader.read(egrid=params.egrid)
-        elif params.identdn and params.number:
-            real_estate_records = real_estate_reader.read(
-                nb_ident=params.identdn,
-                number=params.number
-            )
-        else:
-            raise HTTPBadRequest("Missing required argument")
-
-        # check if result is strictly one (we queried with primary keys)
-        if len(real_estate_records) == 1:
-            extract = processor.process(
-                real_estate_records[0],
-                params,
-                self._request.route_url('{0}/sld'.format(route_prefix))
-            )
-            if params.format == 'json':
-                log.debug("get_extract_by_id() calling json")
-                response = render_to_response(
-                    'pyramid_oereb_extract_json',
-                    (extract, params),
-                    request=self._request
-                )
-            elif params.format == 'xml':
-                log.debug("get_extract_by_id() calling xml")
-                response = render_to_response(
-                    'pyramid_oereb_extract_xml',
-                    (extract, params),
-                    request=self._request
-                )
-            elif params.format == 'pdf':
-                log.debug("get_extract_by_id() calling pdf")
-                response = render_to_response(
-                    'pyramid_oereb_extract_print',
-                    (extract, params),
-                    request=self._request
+        try:
+            params = self.__validate_extract_params__()
+            processor = self._request.pyramid_oereb_processor
+            # read the real estate from configured source by the passed parameters
+            real_estate_reader = processor.real_estate_reader
+            if params.egrid:
+                real_estate_records = real_estate_reader.read(egrid=params.egrid)
+            elif params.identdn and params.number:
+                real_estate_records = real_estate_reader.read(
+                    nb_ident=params.identdn,
+                    number=params.number
                 )
             else:
-                raise HTTPBadRequest("The format '{}' is wrong".format(params.format))
-            end_time = timer()
-            log.debug("DONE with extract, time spent: {} seconds".format(end_time - start_time))
-            return response
-        else:
-            return HTTPNoContent("No real estate found")
+                raise HTTPBadRequest("Missing required argument")
+            # check if result is strictly one (we queried with primary keys)
+            if len(real_estate_records) == 1:
+                extract = processor.process(
+                    real_estate_records[0],
+                    params,
+                    self._request.route_url('{0}/sld'.format(route_prefix))
+                )
+                if params.format == 'json':
+                    log.debug("get_extract_by_id() calling json")
+                    response = render_to_response(
+                        'pyramid_oereb_extract_json',
+                        (extract, params),
+                        request=self._request
+                    )
+                elif params.format == 'xml':
+                    log.debug("get_extract_by_id() calling xml")
+                    response = render_to_response(
+                        'pyramid_oereb_extract_xml',
+                        (extract, params),
+                        request=self._request
+                    )
+                elif params.format == 'pdf':
+                    log.debug("get_extract_by_id() calling pdf")
+                    response = render_to_response(
+                        'pyramid_oereb_extract_print',
+                        (extract, params),
+                        request=self._request
+                    )
+                else:
+                    raise HTTPBadRequest("The format '{}' is wrong".format(params.format))
+                end_time = timer()
+                log.debug("DONE with extract, time spent: {} seconds".format(end_time - start_time))
+            else:
+                raise HTTPNoContent("No real estate found")
+        except HTTPNoContent as err:
+            response = HTTPNoContent('{}'.format(err))
+        except HTTPBadRequest as err:
+            response = HTTPBadRequest('{}'.format(err))
+        try:
+            response.extras = OerebStats(service='GetExtractById',
+                                         output_format=params.format,
+                                         params=vars(params))
+        except UnboundLocalError:
+            response.extras = OerebStats(service='GetExtractById', params={'error': response.message})
+        except Exception:
+            # if params is not set we get UnboundLocalError
+            # or we could get ValueError
+            # in any case, the logging should never crash the response delivery
+            try:
+                response.extras = OerebStats(service='GetExtractById', params={'error': response.message})
+            except AttributeError:
+                response.extras = OerebStats(service='GetExtractById')
+        return response
 
     def __validate_extract_params__(self):
         """
@@ -311,7 +360,8 @@ class PlrWebservice(object):
         if language not in Config.get_language() and self._params.get('LANG') is not \
                 None:
             raise HTTPBadRequest(
-                'Requested language is not available. Following languages are configured: {languages} The '
+                'Requested language is not available. Following languages are '
+                'configured: {languages} The '
                 'requested language was: {language}'.format(
                     languages=str(Config.get_language()),
                     language=language
@@ -324,7 +374,6 @@ class PlrWebservice(object):
         topics = self._params.get('TOPICS')
         if topics:
             params.set_topics(topics.split(','))
-
         return params
 
     def __validate_format_param__(self, accepted_formats):
@@ -344,8 +393,8 @@ class PlrWebservice(object):
 
     def __coord_transform__(self, coord, source_crs):
         """
-        Transforms the specified coordinates from the specified CRS to the configured target CRS and creates a
-        point geometry.
+        Transforms the specified coordinates from the specified CRS to the configured target
+        CRS and creates a point geometry.
 
         Args:
             coord (tuple): The coordinates to transform (x, y).
@@ -396,12 +445,14 @@ class PlrWebservice(object):
         response = render_to_response(renderer_name, egrid, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
+        response.extras = OerebStats(service='GetEGRID', output_format=output_format)
         return response
 
     def __parse_xy__(self, xy, buffer_dist=None):
         """
-        Parses the coordinates from the XY parameter, transforms them to target CRS and creates a point
-        geometry. If a buffer distance is defined, a buffer with the specified distance will be applied.
+        Parses the coordinates from the XY parameter, transforms them to target CRS
+        and creates a point geometry. If a buffer distance is defined, a buffer
+        with the specified distance will be applied.
 
         Args:
             xy (str): XY parameter from the getegrid request.
@@ -415,7 +466,8 @@ class PlrWebservice(object):
         coords = xy.split(',')
 
         if len(coords) != 2:
-            raise HTTPBadRequest('The parameter XY has to be a comma-separated pair of coordinates.')
+            raise HTTPBadRequest(
+                'The parameter XY has to be a comma-separated pair of coordinates.')
 
         x = float(coords[0])
         y = float(coords[1])
@@ -430,8 +482,8 @@ class PlrWebservice(object):
 
     def __parse_gnss__(self, gnss):
         """
-        Parses the coordinates from the GNSS parameter, transforms them to target CRS and creates a Point with
-        a 1 meter buffer.
+        Parses the coordinates from the GNSS parameter, transforms them to target CRS and
+        creates a Point with a 1 meter buffer.
 
         Args:
             gnss (str): GNSS parameter from the getegrid request.
@@ -443,7 +495,8 @@ class PlrWebservice(object):
         coords = gnss.split(',')
 
         if len(coords) != 2:
-            raise HTTPBadRequest('The parameter GNSS has to be a comma-separated pair of coordinates.')
+            raise HTTPBadRequest(
+                'The parameter GNSS has to be a comma-separated pair of coordinates.')
 
         # Coordinates provided as "latitude,longitude"
         lon = float(coords[1])
@@ -713,10 +766,11 @@ class Sld(object):
 
     def get_sld(self):
         """
-        Webservice which delivers an SLD file from parameter input. However this is a proxy pass through only.
-        We use it to call the real method configured in the dedicated yaml file and hope that this method is
-        accepting a pyramid.request.Request as input and is returning a pyramid.response.Response which
-        encapsulates a well designed SLD.
+        Webservice which delivers an SLD file from parameter input. However
+        this is a proxy pass through only. We use it to call the real method
+        configured in the dedicated yaml file and hope that this method is
+        accepting a pyramid.request.Request as input and is returning a
+        pyramid.response.Response which encapsulates a well designed SLD.
 
         .. note:: The config path to define this hook method is:
             *pyramid_oereb.real_estate.visualisation.method*
@@ -726,8 +780,8 @@ class Sld(object):
                 configuration
 
         Raises:
-            pyramid.httpexceptions.HTTPInternalServerError: When the return value of the hooked method was not
-                of type pyramid.response.Response
+            pyramid.httpexceptions.HTTPInternalServerError: When the return
+            value of the hooked method was not of type pyramid.response.Response
             pyramid.httpexceptions.HTTPNotFound: When the configured method was not found.
         """
         dnr = DottedNameResolver()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
             'create_standard_yaml = pyramid_oereb.standard.create_yaml:create_standard_yaml',
             'drop_standard_tables = pyramid_oereb.standard.drop_tables:drop_standard_tables',
             'create_legend_entries = pyramid_oereb.standard.load_legend_entries:run',
-            'import_federal_topic = pyramid_oereb.standard.import_federal_topic:run'
+            'import_federal_topic = pyramid_oereb.standard.import_federal_topic:run',
+            'create_stats_tables = pyramid_oereb.contrib.stats.scripts.create_stats_tables:create_stats_tables'  # noqa: E501
         ]
     }
 )

--- a/tests/webservice/test_getegrid.py
+++ b/tests/webservice/test_getegrid.py
@@ -18,8 +18,8 @@ from pyramid_oereb.views.webservice import PlrWebservice
 
 def test_getegrid_coord_missing_parameter():
     webservice = PlrWebservice(MockRequest())
-    with pytest.raises(HTTPBadRequest):
-        webservice.get_egrid_coord()
+    response = webservice.get_egrid_ident()
+    assert response.code == 400
 
 
 def test_getegrid_ident():
@@ -112,8 +112,8 @@ def test_getegrid_gnss():
 
 def test_getegrid_ident_missing_parameter():
     webservice = PlrWebservice(MockRequest())
-    with pytest.raises(HTTPBadRequest):
-        webservice.get_egrid_ident()
+    response = webservice.get_egrid_ident()
+    assert response.code == 400
 
 
 def test_getegrid_address():
@@ -146,8 +146,8 @@ def test_getegrid_address():
 
 def test_getegrid_address_missing_parameter():
     webservice = PlrWebservice(MockRequest())
-    with pytest.raises(HTTPBadRequest):
-        webservice.get_egrid_address()
+    response = webservice.get_egrid_address()
+    assert response.code == 400
 
 
 def test_get_egrid_response():


### PR DESCRIPTION
This PR implements the [following enhancement](https://github.com/openoereb/pyramid_oereb/issues/936)

What it does:
- It uses the new `sqlalchemylogger` in [c2cwsgiutils](https://github.com/camptocamp/c2cwsgiutils/) to push application logs based on the received requests in a postgresql database
- it adds a module `stats` in `pyramid_oereb/contrib` which provides a custom decorator that analyses the response and request objects, and serialize useful info as JSON. This JSON is then written in the DB using `sqlalchemylogger`
- it provides a couple of scripts to generate SQL tables which use the JSON strings to provide usage statistics of the OEREB services.
- it also provides a filter to avoid writing some regex-matching logs. This can be useful to avoid writing and accounting health-checks.

### How to test:
```shell
# ensure you have the most recent c2cwsgiutils version 3 image
docker pull camptocamp/c2cwsgiutils:3

# launch the app
make serve

# make a test curl request
curl -H "User-Agent: Firefox" localhost:6543/oereb/capabilities/json

# in another terminal, connect to the DB
docker exec -it pyramidoereb_oereb-db_1 psql -U postgres
# and then
postgres=# \c oereb_stats
stats=# SELECT * FROM oereb_logs.logs;

# make another request and see that it gets filtered out
curl -H "User-Agent: healthcheck" localhost:6543/oereb/capabilities/json

in psql again
stats=# SELECT * FROM oereb_logs.logs;

# the second request should appear in the console output of the app, but not in the sql logs

# to use the json field to filter out only errors:
stats=# SELECT cast(msg as json),created_at AS response FROM oereb_logs.logs WHERE cast( cast(msg as json) -> 'response' ->> 'status_code' AS INT) >= 400;

```

Here is an example of a view using the json fields:
```sql
CREATE VIEW stats_get_extract_by_id AS 
    SELECT cast(msg as json) -> 'response' -> 'extras' ->> 'service' AS service ,
           cast(msg as json) -> 'response' ->> 'status_code' AS status_code,
           cast(msg as json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
           cast(msg as json) -> 'response' -> 'extras' -> 'params' ->> '__flavour__' AS flavour,
           cast(msg as json) -> 'response' -> 'extras' -> 'params' ->> '__egrid__' AS egrid
    FROM oereb_logs.logs WHERE cast(msg as json) -> 'response' ->'extras' ->> 'service' = 'GetExtractById';

SELECT * FROM stats_get_extract_by_id;
```
which gives something like:
```
    service     | status_code | output_format |  flavour   |     egrid      
----------------+-------------+---------------+------------+----------------
 GetExtractById | 200         | json          | embeddable | CH113928077734
 GetExtractById | 200         | json          | reduced    | CH113928077734
(2 rows)

```

To create the views in the database, connect to the oereb-server container:
```bash
 docker exec -it pyramidoereb_oereb-server_1 bash
```
and then call the following script (inside the container):
```bash
create_stats_tables -c production.ini
```

To view the aggregated logs of extract_by_id as daily entries:
```sql
SELECT * FROM oereb_logs.stats_daily_extract_by_id;
```
which will give a similar output:
```
         day         | nb_requests | format_pdf | format_json | format_xml | flavour_signed
 | flavour_full | flavour_embeddable | flavour_reduced 
---------------------+-------------+------------+-------------+------------+---------------
-+--------------+--------------------+-----------------
 2019-11-28 00:00:00 |          11 |          0 |           1 |          9 |              0
 |            0 |                  4 |               6
(1 row)
```
