### PR TITLE
Display `NrOfPoints` GSPOE-19

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -487,7 +487,7 @@ class Renderer(JsonRenderer):
             extract_dict['RealEstate_LandRegistryArea']
         )
 
-        # Reformat AreaShare, LengthShare and part in percent values
+        # Reformat AreaShare, LengthShare, NrOfPoints and part in percent values
         for restriction in extract_dict['RealEstate_RestrictionOnLandownership']:
             for legend in restriction['Legend']:
                 if 'LengthShare' in legend:

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -324,7 +324,7 @@ class Renderer(JsonRenderer):
             'Information', 'Lawstatus_Code', 'Lawstatus_Text', 'SymbolRef', 'TypeCode'
         ]
         legend_element = [
-            'TypeCode', 'TypeCodelist', 'AreaShare', 'PartInPercent', 'LengthShare',
+            'TypeCode', 'TypeCodelist', 'AreaShare', 'PartInPercent', 'LengthShare', 'NrOfPoints',
             'SymbolRef', 'Information'
         ]
         split_sub_themes = Config.get('print', {}).get('split_sub_themes', False)
@@ -496,6 +496,8 @@ class Renderer(JsonRenderer):
                     legend['AreaShare'] = u'{0} m²'.format(legend['AreaShare'])
                 if 'PartInPercent' in legend:
                     legend['PartInPercent'] = '{0}%'.format(round(legend['PartInPercent'], 2))
+                if 'NrOfPoints' in legend:
+                    legend['NrOfPoints'] = '{0}'.format(legend['NrOfPoints'])
 
         log.debug("After transformation, extract_dict is {}".format(extract_dict))
         return extract_dict

--- a/sample_data/plr119/contaminated_public_transport_sites/geometry.json
+++ b/sample_data/plr119/contaminated_public_transport_sites/geometry.json
@@ -34,5 +34,12 @@
     "law_status": "inForce",
     "geom": "SRID=2056;GEOMETRYCOLLECTION(POINT(2608838.15 1261846.96))",
     "public_law_restriction_id": 400
+  }, {
+    "office_id": 1,
+    "published_from": "2016-02-25",
+    "id": 1297,
+    "law_status": "inForce",
+    "geom": "SRID=2056;GEOMETRYCOLLECTION(POINT(2608838.14 1261846.96))",
+    "public_law_restriction_id": 400
   }
 ]

--- a/sample_data/plr119/contaminated_public_transport_sites/public_law_restriction.json
+++ b/sample_data/plr119/contaminated_public_transport_sites/public_law_restriction.json
@@ -94,5 +94,24 @@
       "de": "SubTheme2 - de",
       "fr": "SubTheme2 - fr"
     }
+  }, {
+    "office_id": 1,
+    "published_from": "2016-02-25",
+    "type_code": "StaoTyp1",
+    "id": 401,
+    "type_code_list": "",
+    "law_status": "inForce",
+    "view_service_id": 1,
+    "information": {
+      "it": "Inquinato, non sono prevedibili effetti dannosi o molesti",
+      "de": "Belastet, keine schädlichen oder lästigen Einwirkungen zu erwarten",
+      "fr": "Pollué, pas d?atteinte nuisible ou incommodante à attendre"
+    },
+    "topic": "ContaminatedPublicTransportSites",
+    "sub_theme": {
+      "it": "SubTheme2 - it",
+      "de": "SubTheme2 - de",
+      "fr": "SubTheme2 - fr"
+    }
   }
 ]

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -231,6 +231,7 @@ def test_get_sorted_legend():
             'TypeCode': u'StaoTyp1',
             'Geom_Type': u'NrOfPoints',
             'TypeCodelist': '',
+            'NrOfPoints': 2,
             'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
                         ContaminatedPublicTransportSites/1/StaoTyp1',
             'Information': u'Belastet, keine schädlichen oder lästigen Einwirkungen zu erwarten'
@@ -293,6 +294,7 @@ def test_get_sorted_legend():
             'TypeCode': u'StaoTyp1',
             'Geom_Type': u'NrOfPoints',
             'TypeCodelist': '',
+            'NrOfPoints': 2,
             'SymbolRef': u'http://localhost:6543/oereb/image/symbol/\
                         ContaminatedPublicTransportSites/1/StaoTyp1',
             'Information': u'Belastet, keine schädlichen oder lästigen Einwirkungen zu erwarten'


### PR DESCRIPTION
Fix #912 
What this PR does:
- Add `NrOfPoints` in the the legend json
- Format `NrOfPoints` to a string in the print json
- Add a variable `NrOfPoints` that is accessible in the print  templates (see PR https://github.com/openoereb/pyramid_oereb_mfp/pull/40)
- Add test data to be able to test this in the pdf extract.

To test and get an actual result an adaption in the templates was necessary -> https://github.com/openoereb/pyramid_oereb_mfp/pull/40