### PR TITLE
Fix `TextAtWeb` links GSPOE-29

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -405,7 +405,6 @@ class Renderer(JsonRenderer):
                 values = list(restriction_on_landownership[element].values())
                 self.lpra_flatten(values)
                 restriction_on_landownership[element] = values
-                # FIXME This is not working any more with the new structure of TextAtWeb!!!
                 if element == 'LegalProvisions':
                     # TESTME --> This line is not thoroughly tested for the full extract as it is not
                     #            possible to run this mode for PDF extract!
@@ -517,7 +516,7 @@ class Renderer(JsonRenderer):
                 continue
 
             # join the the existing list with the new one
-            existing_element['TextAtWeb'] = [*existing_element['TextAtWeb'], *element['TextAtWeb']]
+            existing_element['TextAtWeb'].extend(element['TextAtWeb'])
         return merged_provision if len(merged_provision) > 0 else legal_provisions
 
     def _flatten_array_object(self, parent, array_name, object_name):

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -406,8 +406,12 @@ class Renderer(JsonRenderer):
                 self.lpra_flatten(values)
                 restriction_on_landownership[element] = values
                 # FIXME This is not working any more with the new structure of TextAtWeb!!!
-                #if element == 'LegalProvisions':
-                #    pdf_to_join.update([legal_provision['TextAtWeb'] for legal_provision in values])
+                if element == 'LegalProvisions':
+                    # TESTME --> This line is not thoroughly tested for the full extract as it is not
+                    #            possible to run this mode for PDF extract!
+                    # This adds the first URL of TextAtWeb to the pdf_to_join set. At this point of the code
+                    # there should only be one URL as the grouping takes place only after this if statement.
+                    pdf_to_join.update([legal_provision['TextAtWeb'][0]['URL'] for legal_provision in values])
 
                 # Group legal provisions and hints which have the same title.
                 if (
@@ -690,22 +694,14 @@ class Renderer(JsonRenderer):
         Returns:
             sorted list of legend dictionaries
         """
-        # FIXME when sorting on TextAtWeb this throws an exception!!!
-        try:
-          return sorted(legend_list, key=sort_keys)
-        except:
-            log.warning('not possible to sort this list:')
-            log.warning(legend_list)
-            log.warning(sort_keys)
-            log.warning('-----------------------')
+        return sorted(legend_list, key=sort_keys)
 
     @staticmethod
     def sort_legal_provision(elem):
         """
         Provides the sort key for the supplied legal provision element as a tuple consisting of:
             * title
-            * Office number
-            * Text at web
+            * Official number
         Args:
             elem (dict): one element of the legal provision list
 
@@ -714,10 +710,8 @@ class Renderer(JsonRenderer):
         """
 
         sort_title = elem['Title'] if 'Title' in elem else ''
-        sort_Number = elem['OfficialNumber'] if 'OfficialNumber' in elem else None
-        # FIXME
-        # sort_Web = elem['TextAtWeb']['URL'] if 'TextAtWeb' in elem else None
-        return sort_title, sort_Number, sort_Web
+        sort_number = elem['OfficialNumber'] if 'OfficialNumber' in elem else None
+        return sort_title, sort_number
 
     @staticmethod
     def sort_hints(elem):

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -406,8 +406,6 @@ class Renderer(JsonRenderer):
                 self.lpra_flatten(values)
                 restriction_on_landownership[element] = values
                 if element == 'LegalProvisions':
-                    # TESTME --> This line is not thoroughly tested for the full extract as it is not
-                    #            possible to run this mode for PDF extract!
                     # This adds the first URL of TextAtWeb to the pdf_to_join set. At this point of the code
                     # there should only be one URL as the grouping takes place only after this if statement.
                     pdf_to_join.update([legal_provision['TextAtWeb'][0]['URL'] for legal_provision in values])

--- a/tests/contrib/print_proxy/resources/expected_getspec_extract.json
+++ b/tests/contrib/print_proxy/resources/expected_getspec_extract.json
@@ -13,7 +13,7 @@
           "Title": "RRB Nr. 1484 vom 23.09.2003",
           "DocumentType": "LegalProvision",
           "Canton": "BL",
-          "TextAtWeb": "https://oereblex.bl.ch/api/attachments/403",
+          "TextAtWeb": [{"URL": "https://oereblex.bl.ch/api/attachments/403"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
         },
@@ -24,7 +24,7 @@
           "Title": "Zonenreglement Siedlung (Stand 30.03.2010)",
           "DocumentType": "LegalProvision",
           "Canton": "BL",
-          "TextAtWeb": "https://oereblex.bl.ch/api/attachments/1471",
+          "TextAtWeb": [{"URL": "https://oereblex.bl.ch/api/attachments/1471"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Gemeindeverwaltung"
         },
@@ -36,7 +36,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "RBG",
-          "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1964?locale=de",
+          "TextAtWeb": [{"URL": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1964?locale=de"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
         },
@@ -47,7 +47,7 @@
           "Title": "RRB Nr. 429 vom 01.04.2008",
           "DocumentType": "LegalProvision",
           "Canton": "BL",
-          "TextAtWeb": "https://oereblex.bl.ch/api/attachments/2537",
+          "TextAtWeb": [{"URL": "https://oereblex.bl.ch/api/attachments/2537"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Gemeindeverwaltung"
         },
@@ -58,7 +58,7 @@
           "Title": "RRB Nr. 1484 vom 23.09.2003",
           "DocumentType": "LegalProvision",
           "Canton": "BL",
-          "TextAtWeb": "https://oereblex.bl.ch/api/attachments/2916",
+          "TextAtWeb": [{"URL": "https://oereblex.bl.ch/api/attachments/2916"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
         },
@@ -70,7 +70,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "RBV",
-          "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/2032?locale=de",
+          "TextAtWeb": [{"URL": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/2032?locale=de"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
         },
@@ -82,7 +82,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "Raumplanungsgesetz, RPG",
-          "TextAtWeb": "http://www.lexfind.ch/dtah/155346/2",
+          "TextAtWeb": [{"URL": "http://www.lexfind.ch/dtah/155346/2"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
         }
@@ -274,7 +274,7 @@
           "Lawstatus_Code": "inForce",
           "Title": "Ersteintrag in den KbS: 09.12.2016",
           "ResponsibleOffice_OfficeAtWeb": "http://www.aue.bl.ch",
-          "TextAtWeb": "https://www.baselland.ch/politik-und-behorden/direktionen/bau-und-umweltschutzdirektion/umweltschutz-energie/altlasten/kataster",
+          "TextAtWeb": [{"URL": "https://www.baselland.ch/politik-und-behorden/direktionen/bau-und-umweltschutzdirektion/umweltschutz-energie/altlasten/kataster"}],
           "Lawstatus_Text": "in Kraft",
           "DocumentType": "LegalProvision",
           "ResponsibleOffice_Name": "Amt f\u00fcr Umweltschutz und Energie BL"
@@ -287,7 +287,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "Umweltschutzgesetz, USG",
-          "TextAtWeb": "http://www.lexfind.ch/dtah/155395/2",
+          "TextAtWeb": [{"URL": "http://www.lexfind.ch/dtah/155395/2"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
         },
@@ -299,7 +299,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "Altlasten-Verordnung, AltlV",
-          "TextAtWeb": "http://www.lexfind.ch/dtah/147568/2",
+          "TextAtWeb": [{"URL": "http://www.lexfind.ch/dtah/147568/2"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
         },
@@ -307,7 +307,7 @@
           "Lawstatus_Code": "inForce",
           "Title": "Ersteintrag in den KbS: 16.04.2015",
           "ResponsibleOffice_OfficeAtWeb": "http://www.aue.bl.ch",
-          "TextAtWeb": "https://www.baselland.ch/politik-und-behorden/direktionen/bau-und-umweltschutzdirektion/umweltschutz-energie/altlasten/kataster",
+          "TextAtWeb": [{"URL": "https://www.baselland.ch/politik-und-behorden/direktionen/bau-und-umweltschutzdirektion/umweltschutz-energie/altlasten/kataster"}],
           "Lawstatus_Text": "in Kraft",
           "DocumentType": "LegalProvision",
           "ResponsibleOffice_Name": "Amt f\u00fcr Umweltschutz und Energie BL"
@@ -320,7 +320,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "USG BL",
-          "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1337?locale=de",
+          "TextAtWeb": [{"URL": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1337?locale=de"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
         },
@@ -332,7 +332,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "USV",
-          "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/273?locale=de",
+          "TextAtWeb": [{"URL": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/273?locale=de"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
         }
@@ -450,7 +450,7 @@
           "Title": "RRB Nr. 429 vom 01.04.2008",
           "DocumentType": "LegalProvision",
           "Canton": "BL",
-          "TextAtWeb": "https://oereblex.bl.ch/api/attachments/2798",
+          "TextAtWeb": [{"URL": "https://oereblex.bl.ch/api/attachments/2798"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Gemeindeverwaltung"
         },
@@ -462,7 +462,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "USG BL",
-          "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1337?locale=de",
+          "TextAtWeb": [{"URL": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1337?locale=de"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
         },
@@ -474,7 +474,7 @@
           "DocumentType": "LegalProvision",
           "Canton": "BL",
           "Abbreviation": "LSV",
-          "TextAtWeb": "http://www.lexfind.ch/dtah/147569/2",
+          "TextAtWeb": [{"URL": "http://www.lexfind.ch/dtah/147569/2"}],
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
         }

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -313,7 +313,7 @@ def test_get_sorted_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
             "Title": "Baugesetz"
         }, {
             "Canton": "BL",
@@ -324,7 +324,7 @@ def test_get_sorted_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
             "Title": "Baugesetz"
         }, {
             "Canton": "BL",
@@ -335,7 +335,7 @@ def test_get_sorted_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/214"}],
             "Title": "Revision Ortsplanung"
         }, {
             "Canton": "BL",
@@ -346,7 +346,7 @@ def test_get_sorted_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/213"}],
             "Title": "Revision Ortsplanung"
         }
     ]
@@ -359,7 +359,7 @@ def test_get_sorted_legal_provisions():
            "OfficialNumber": "07.447",
            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
            "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-           "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
+           "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/214"}],
            "Title": "Revision Ortsplanung"
         }, {
             "Canton": "BL",
@@ -370,7 +370,7 @@ def test_get_sorted_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
             "Title": "Baugesetz"
         }, {
             "Canton": "BL",
@@ -381,7 +381,7 @@ def test_get_sorted_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/213"}],
             "Title": "Revision Ortsplanung"
         }, {
             "Canton": "BL",
@@ -392,7 +392,7 @@ def test_get_sorted_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
             "Title": "Baugesetz"
         }
     ]
@@ -409,7 +409,7 @@ def test_get_sorted_hints():
         "OfficialNumber": "3891.100",
         "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
         "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+        "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
         "Title": "Revision Ortsplanung"
     }, {
         "Canton": "BL",
@@ -419,7 +419,7 @@ def test_get_sorted_hints():
         "OfficialNumber": "3891.100",
         "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
         "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198"
+        "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
     }, {
         "Canton": "BL",
         "DocumentType": "LegalProvision",
@@ -428,7 +428,7 @@ def test_get_sorted_hints():
         "OfficialNumber": "3891.100",
         "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
         "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+        "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
         "Title": "Baugesetz"
 
     }]
@@ -441,7 +441,7 @@ def test_get_sorted_hints():
         "OfficialNumber": "3891.100",
         "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
         "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198"
+        "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
     }, {
         "Canton": "BL",
         "DocumentType": "LegalProvision",
@@ -450,7 +450,7 @@ def test_get_sorted_hints():
         "OfficialNumber": "3891.100",
         "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
         "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+        "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
         "Title": "Baugesetz"
     }, {
         "Canton": "BL",
@@ -460,7 +460,7 @@ def test_get_sorted_hints():
         "OfficialNumber": "3891.100",
         "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
         "ResponsibleOffice_OfficeAtWeb": "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-        "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+        "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
         "Title": "Revision Ortsplanung"
     }]
 
@@ -472,7 +472,7 @@ def test_get_sorted_law():
     test_law = [
         {
             'DocumentType': 'Law',
-            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_01.html',
+            'TextAtWeb': [{'URL': 'http://www.admin.ch/ch/d/sr/c814_01.html'}],
             'Title': 'Raumplanungsverordnung für den Kanton Graubünden',
             'Abbreviation': 'KRVO',
             'OfficialNumber': 'BR 801.110',
@@ -484,7 +484,7 @@ def test_get_sorted_law():
                 'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2934?locale=de'
         }, {
             'DocumentType': u'Law',
-            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
             'Abbreviation': u'KRG',
             'Canton': u'GR',
@@ -495,7 +495,7 @@ def test_get_sorted_law():
                 u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
         }, {
             'DocumentType': u'Law',
-            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': u'Raumplanungsgesetz für den Kanton Graubünden2',
             'Abbreviation': u'KRG',
             'OfficialNumber': u'BR 801.100',
@@ -507,7 +507,7 @@ def test_get_sorted_law():
                 u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
         }, {
             'DocumentType': 'Law',
-            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': 'Bundesgesetz über die Raumplanung',
             'Abbreviation': 'RPG',
             'OfficialNumber': 'SR 700',
@@ -518,7 +518,7 @@ def test_get_sorted_law():
             'ResponsibleOffice_OfficeAtWeb': 'http://www.lexfind.ch/dtah/167348/2'
         }, {
             'DocumentType': u'Law',
-            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
             'Abbreviation': u'KRG',
             'OfficialNumber': u'BR 801.100',
@@ -534,7 +534,7 @@ def test_get_sorted_law():
     expected_result = [
         {
             'DocumentType': u'Law',
-            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
             'Abbreviation': u'KRG',
             'OfficialNumber': u'BR 801.100',
@@ -546,7 +546,7 @@ def test_get_sorted_law():
                 u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
         }, {
             'DocumentType': u'Law',
-            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': u'Raumplanungsgesetz für den Kanton Graubünden2',
             'Abbreviation': u'KRG',
             'OfficialNumber': u'BR 801.100',
@@ -558,7 +558,7 @@ def test_get_sorted_law():
                 u'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2936?locale=de'
         }, {
             'DocumentType': 'Law',
-            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_01.html',
+            'TextAtWeb': [{'URL': 'http://www.admin.ch/ch/d/sr/c814_01.html'}],
             'Title': 'Raumplanungsverordnung für den Kanton Graubünden',
             'Abbreviation': 'KRVO',
             'OfficialNumber': 'BR 801.110',
@@ -570,7 +570,7 @@ def test_get_sorted_law():
                 'https://www.gr-lex.gr.ch/frontend/versions/pdf_file_with_annex/2934?locale=de'
         }, {
             'DocumentType': 'Law',
-            'TextAtWeb': 'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': 'Bundesgesetz über die Raumplanung',
             'Abbreviation': 'RPG',
             'OfficialNumber': 'SR 700',
@@ -581,7 +581,7 @@ def test_get_sorted_law():
             'ResponsibleOffice_OfficeAtWeb': 'http://www.lexfind.ch/dtah/167348/2'
         }, {
             'DocumentType': u'Law',
-            'TextAtWeb': u'http://www.admin.ch/ch/d/sr/c814_680.html',
+            'TextAtWeb': [{'URL': u'http://www.admin.ch/ch/d/sr/c814_680.html'}],
             'Title': u'Raumplanungsgesetz für den Kanton Graubünden',
             'Abbreviation': u'KRG',
             'Canton': u'GR',
@@ -608,7 +608,7 @@ def test_group_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
             "Title": "Baugesetz"
         }, {
             "Canton": "BL",
@@ -619,7 +619,7 @@ def test_group_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
             "Title": "Baugesetz"
         }, {
             "Canton": "BL",
@@ -630,7 +630,7 @@ def test_group_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/213"}],
             "Title": "Revision Ortsplanung"
         }, {
             "Canton": "BL",
@@ -641,7 +641,7 @@ def test_group_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/214",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/214"}],
             "Title": "Revision Ortsplanung"
         }
     ]
@@ -655,8 +655,10 @@ def test_group_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/197\n" +
-                         "https://oereb-gr-preview.000.ch/api/attachments/198",
+            "TextAtWeb": [
+                {"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"},
+                {"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"},
+            ],
             "Title": "Baugesetz"
         }, {
             "Canton": "BL",
@@ -667,8 +669,10 @@ def test_group_legal_provisions():
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
-            "TextAtWeb": "https://oereb-gr-preview.000.ch/api/attachments/213\n" +
-                         "https://oereb-gr-preview.000.ch/api/attachments/214",
+            "TextAtWeb": [
+                {"URL": "https://oereb-gr-preview.000.ch/api/attachments/213"},
+                {"URL": "https://oereb-gr-preview.000.ch/api/attachments/214"},
+            ],
             "Title": "Revision Ortsplanung"
         }
     ]


### PR DESCRIPTION
This PR changes the data structure of `TextAtWeb` in to an array of dictionaries such that it is possible to group the `TextAtWeb` from multiple legal provisions with the same title. The structure in the JSON  is now as follows:

```
...
'TextAtWeb': [
    { 'URL': 'https://www.<URL1>'}
    { 'URL': 'https://www.<URL2>'}
    ...
]
...
```

TOTEST:
To be able to test the templates the PR https://github.com/openoereb/pyramid_oereb_mfp/pull/44 is needed.