### PR TITLE
test data: add additional typecode

### DIFF
--- a/sample_data/plr119/forest_perimeters/geometry.json
+++ b/sample_data/plr119/forest_perimeters/geometry.json
@@ -6,5 +6,13 @@
     "law_status": "inForce",
     "geom": "SRID=2056;LINESTRING(2608906.85 1261915.2, 2608887.35 1261815.76)",
     "public_law_restriction_id": 402
+  },
+  {
+    "office_id": 1,
+    "published_from": "2020-01-02",
+    "id": 1299,
+    "law_status": "inForce",
+    "geom": "SRID=2056;LINESTRING(2608906.85 1261915.2, 2608887.35 1261815.76)",
+    "public_law_restriction_id": 403
   }
 ]

--- a/sample_data/plr119/forest_perimeters/legend_entry.json
+++ b/sample_data/plr119/forest_perimeters/legend_entry.json
@@ -11,5 +11,18 @@
     "view_service_id": 1,
     "symbol": "iVBORw0KGgoAAAANSUhEUgAAAEgAAAAkAgMAAABXtZT1AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEWpy/5Tlv4AZv////8CA41OAAAAAWJLR0QDEQxM8gAAAAd0SU1FB+MEHQwnDaaZ3bIAAAAcSURBVCjPYxANRQMhDFmr0MDKUaFRIXoLYSZMAIgsmUho/kyPAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTA0LTI5VDE0OjM5OjEzKzAyOjAwWzeaVwAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wNC0yOVQxNDozOToxMyswMjowMCpqIusAAAAASUVORK5CYII=",
     "topic": "ForestPerimeters"
+  },
+  {
+    "legend_text": {
+      "fr": "Pollué, ne nécessite ni surveillance ni assainissement",
+      "de": "Belastet, weder überwachungs- noch sanierungsbedürftig",
+      "it": "Inquinato, non deve essere né sorvegliato né risanato"
+    },
+    "type_code": "StaoTyp1",
+    "id": 17,
+    "type_code_list": "https://models.geo.admin.ch/BAFU/KbS_Codetexte_V1_3.xml",
+    "view_service_id": 1,
+    "symbol": "iVBORw0KGgoAAAANSUhEUgAAAEgAAAAkAgMAAABXtZT1AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAADFBMVEX+7an+3FP/zAD////0ncVSAAAAAWJLR0QDEQxM8gAAAAd0SU1FB+MEHQwdC2pTpv4AAAAcSURBVCjPYxANRQMhDFmr0MDKUaFRIXoLYSZMAIgsmUho/kyPAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTA0LTI5VDE0OjI5OjExKzAyOjAwDSZUvgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wNC0yOVQxNDoyOToxMSswMjowMHx77AIAAAAASUVORK5CYII=",
+    "topic": "ForestPerimeters"
   }
 ]

--- a/sample_data/plr119/forest_perimeters/public_law_restriction.json
+++ b/sample_data/plr119/forest_perimeters/public_law_restriction.json
@@ -13,5 +13,20 @@
       "fr": "Pollué, pas d?atteinte nuisible ou incommodante à attendre"
     },
     "topic": "ForestPerimeters"
+  },
+  {
+    "office_id": 1,
+    "published_from": "2020-01-01",
+    "type_code": "StaoTyp1",
+    "id": 403,
+    "type_code_list": "",
+    "law_status": "inForce",
+    "view_service_id": 1,
+    "information": {
+      "fr": "Pollué, ne nécessite ni surveillance ni assainissement",
+      "de": "Belastet, weder überwachungs- noch sanierungsbedürftig",
+      "it": "Inquinato, non deve essere né sorvegliato né risanato"
+    },
+    "topic": "ForestPerimeters"
   }
 ]

--- a/sample_data/plr119/forest_perimeters/public_law_restriction_document.json
+++ b/sample_data/plr119/forest_perimeters/public_law_restriction_document.json
@@ -33,5 +33,10 @@
     "id": 408,
     "document_id": 8106,
     "public_law_restriction_id": 402
+  },
+     {
+    "id": 409,
+    "document_id": 8100,
+    "public_law_restriction_id": 403
   }
 ]


### PR DESCRIPTION
In the test data, add an additional typecode in the ForestPerimeters, to be able to test more variations in extracts