### PR TITLE
Add possibility to archive generated pdf (by MFP)

### DIFF
--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -81,6 +81,8 @@ vars:
   % else:
       # Configuration for MapFish-Print print service
       renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
+      # Set an archive path to keep a copy of each generated pdf.
+      # pdf_archive_path: /tmp
       # The minimum buffer in pixel at 72 DPI between the real estate and the map's border. If your print
       # system draws a margin around the feature (the real estate), you have to set your buffer
       # here accordingly.

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -9,7 +9,7 @@ import logging
 
 import time
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from shapely.geometry import mapping
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid_oereb import Config
@@ -160,8 +160,7 @@ class Renderer(JsonRenderer):
         pdf_archive_path = pdf_archive_path if pdf_archive_path[-1:] == '/' else pdf_archive_path + '/'
         log.debug('Start to archive pdf file at path: ' + pdf_archive_path)
 
-        utc_2 = timezone(timedelta(hours=2))
-        time_info = datetime.now(utc_2).strftime('%d-%m-%Y_%H-%M-%S')
+        time_info = (datetime.utcnow() + timedelta(hours=2)).strftime('%d-%m-%Y_%H-%M-%S')  # UTC+2
         egrid = extract_as_dict.get('RealEstate_EGRID', 'no_egrid')
         path_and_filename = pdf_archive_path + time_info + '_' + egrid + '.pdf'
 

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -160,7 +160,7 @@ class Renderer(JsonRenderer):
         pdf_archive_path = pdf_archive_path if pdf_archive_path[-1:] == '/' else pdf_archive_path + '/'
         log.debug('Start to archive pdf file at path: ' + pdf_archive_path)
 
-        time_info = (datetime.utcnow() + timedelta(hours=2)).strftime('%d-%m-%Y_%H-%M-%S')  # UTC+2
+        time_info = (datetime.utcnow() + timedelta(hours=2)).strftime('%Y%m%d%H%M%S')  # UTC+2
         egrid = extract_as_dict.get('RealEstate_EGRID', 'no_egrid')
         path_and_filename = pdf_archive_path + time_info + '_' + egrid + '.pdf'
 

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -80,6 +80,8 @@ pyramid_oereb:
 % else:
     # Configuration for MapFish-Print print service
     renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
+    # Set an archive path to keep a copy of each generated pdf.
+    # pdf_archive_path: /tmp
     # The minimum buffer in pixel at 72 DPI between the real estate and the map's border. If your print
     # system draws a margin around the feature (the real estate), you have to set your buffer
     # here accordingly.

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import json
 import codecs
 from pyramid_oereb.contrib.print_proxy.mapfish_print import Renderer
@@ -680,3 +681,10 @@ def test_group_legal_provisions():
     ]
 
     assert expected_results == renderer.group_legal_provisions(test_legal_provisions)
+
+
+def test_archive_pdf():
+    renderer = Renderer(DummyRenderInfo())
+    extract = {'RealEstate_EGRID': 'CH113928077734'}
+    path_and_filename = renderer.archive_pdf_file('/tmp', bytes(), extract)
+    assert os.path.isfile(path_and_filename)


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GEO-2823

The archived (stored, there is no compression or anything) file will have this name for instance:
`07-01-2020_10-11-17_CH113928077734.pdf`
(`day-month-year_hour-minute-seconds_egrid.pdf`)

As demanded, the timezone used for the filename is 'UTC+2'. That means the summer CH time.