### PR TITLE
Optional cache for Oereblex integration

### DIFF
--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -76,8 +76,6 @@ class OEREBlexSource(Base):
             params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             geolink_id (int): The geoLink ID.
         """
-        log.debug("read() start")
-
         # Request documents
         url = '{host}/api/{version}geolinks/{id}.xml'.format(
             host=self._parser.host_url,
@@ -88,7 +86,7 @@ class OEREBlexSource(Base):
         request_params = {
             'locale': language
         }
-        log.debug("read() getting documents, url: {}, parser: {}".format(url, self._parser))
+        log.debug("read() getting documents for geolink_id {}, url: {}, parser: {}".format(geolink_id, url, self._parser))
         documents = self._parser.from_url(url, request_params, proxies=self._proxies, auth=self._auth)
         log.debug("read() got documents")
 

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -86,7 +86,8 @@ class OEREBlexSource(Base):
         request_params = {
             'locale': language
         }
-        log.debug("read() getting documents for geolink_id {}, url: {}, parser: {}".format(geolink_id, url, self._parser))
+        log.debug("read() getting documents for geolink_id {}, url: {}, parser: {}"
+                  .format(geolink_id, url, self._parser))
         documents = self._parser.from_url(url, request_params, proxies=self._proxies, auth=self._auth)
         log.debug("read() got documents")
 

--- a/pyramid_oereb/contrib/sources/oereblex_cache.py
+++ b/pyramid_oereb/contrib/sources/oereblex_cache.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class OEREBlexCache(object):
+    """
+    A cache for Oereblex records
+    """
+    _cache_dict = {}
+
+    @staticmethod
+    def get_records(lexlink):
+        """
+        Returns the records for a specified lexlink, if they are in the cache
+        """
+        records = OEREBlexCache._cache_dict.get(lexlink)
+        if records:
+            log.debug("CACHE HIT on lexlink {} return {} records from cache".format(lexlink, len(records)))
+        else:
+            log.debug("CACHE MISS on lexlink {}".format(lexlink))
+        return records
+
+    @staticmethod
+    def add_records(lexlink, records):
+        """
+        Add records for a given lexlink
+        """
+        if records:
+            log.debug("CACHE putting lexlink {}, with {} records".format(lexlink, len(records)))
+            OEREBlexCache._cache_dict[lexlink] = records
+        else:
+            log.debug("CACHE called with null records for lexlink {}, ignoring".format(lexlink))


### PR DESCRIPTION
One pyramid_oereb user, who uses Oereblex, has analyzed that most of the time spent in generating the data extracts is spent in requesting data from Oereblex, whereas the same data is requested many times, even within the same data extract.

This pull request proposes a cache for the oereblex records, which can be used optionally. This has been tested for one (real) pyramid_oereb project, on an average data extract:
* without cache, the extract is consistently generated within 5 seconds,
* with cache activated, the extract is generated in 3 seconds on the first call, and 1.5 seconds on subsequent calls.

The more (repeating) geolinks an oereb service has, the more the performance improvement will be relevant.

Note: if the cache approach is validated and found useful, more subtle cache mechanisms might be implemented in the future (notably, an expiry date for cache entries, because otherwise the Oereblex data will always stay the same as long as the oereb server is not restarted).

C2C reference: GEO-2686