### PR TITLE
add oereb statistics functionnalities (new PR)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,3 +2,4 @@ exclude_paths:
   - 'tests/**'
   - 'sample_data/**.json'
   - 'Dockerfile'
+  - 'pyramid_oereb/contrib/stats/scripts/**'

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 /doc/source/standard/models/index.rst
 /doc/source/contrib/sources.rst
 /doc/source/contrib/print_proxy.rst
+/doc/source/contrib/stats.rst
 /doc/source/api.rst
 /doc/build/
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ recursive-include pyramid_oereb/standard *.jpg
 recursive-include pyramid_oereb/standard *.xml
 recursive-include pyramid_oereb/lib/renderer *.xml
 recursive-include pyramid_oereb/contrib/templates *.mako
+recursive-include pyramid_oereb/contrib/stats/scripts *.*
 recursive-exclude tests *.*

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,6 +79,11 @@ with open('contrib/print_proxy.rst', 'w') as sources:
         '../../.venv/bin/mako-render' if os.path.exists('../../.venv/bin/mako-render') else 'mako-render',
         'contrib/print_proxy.rst.mako']).decode('utf-8'))
 
+with open('contrib/stats.rst', 'w') as sources:
+    sources.write(subprocess.check_output([
+        '../../.venv/bin/mako-render' if os.path.exists('../../.venv/bin/mako-render') else 'mako-render',
+        'contrib/stats.rst.mako']).decode('utf-8'))
+
 files = glob.glob('../../pyramid_oereb/standard/models/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files

--- a/doc/source/contrib/index.rst
+++ b/doc/source/contrib/index.rst
@@ -2,8 +2,8 @@ Contribution
 ============
 
 The contribution part of this project is the place where bindings to useful pieces are provided. In the
-moment, some sources and one print proxy are provided here. In future versions,
-some common used code snippets may be provided here as well.
+moment, some sources, print_proxies, and a statistic functionality are provided here.
+In future versions, some common used code snippets may be provided here as well.
 
 Would you like to contribute to the project? Please see :ref:`contributing`.
 
@@ -12,4 +12,5 @@ Would you like to contribute to the project? Please see :ref:`contributing`.
 
    sources
    print_proxy
+   stats
    contributing

--- a/doc/source/contrib/stats.rst.mako
+++ b/doc/source/contrib/stats.rst.mako
@@ -1,0 +1,69 @@
+.. _contrib-stats:
+
+Statistics
+----------
+
+The statistics functionality allows you to gather usage information within pyramid_oereb
+itself. The data gathered will be persisted in configured database,
+allowing the operator or owner of the application to query at any time
+the usage statistics for that database.
+
+The functionality is configured via the server's ini file; see the project repository for a
+complete example of such an ini file.
+
+Example of a configuration:
+
+.. code-block:: python
+
+    args = ({'url':'postgresql://postgres:password@oereb-db:5432/oereb_stats','tablename':'logs','tableargs': {'schema':'oereb_logs'}},'healthcheck')
+
+
+<%! import glob, inspect, re, sys %>
+<%
+modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
+files = glob.glob('../../pyramid_oereb/contrib/stats/*.py')
+modules = [
+    re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
+]
+
+modules.sort()
+delete_modules = []
+for i, module in enumerate(modules):
+    try:
+        __import__(module)
+    except ImportError:
+        delete_modules.append(i)
+delete_modules.reverse()
+for i in delete_modules:
+    del modules[i]
+
+classes = {}
+for module in modules:
+    classes[module] = []
+    for name, obj in inspect.getmembers(sys.modules[module]):
+        if inspect.isclass(obj) and obj.__module__ == module:
+            classes[module].append(name)
+
+underline = ['^', '`', '\'', '.', '~', '*']
+%>
+
+%for module in modules:
+.. _api-${module.replace('.', '-').lower()}:
+
+.. automodule:: ${module}
+
+
+%for cls in classes[module]:
+.. _api-${module.replace('.', '-').lower()}-${cls.lower()}:
+
+*${module.split('.')[-1].title().replace('_', ' ')} ${cls}*
+${re.sub('.', underline[0], module.split('.')[-1] + '   ' + cls)}
+
+.. autoclass:: ${module}.${cls}
+   :members:
+   :inherited-members:
+
+   .. automethod:: __init__
+
+%endfor
+%endfor

--- a/doc/source/contrib/stats.rst.mako
+++ b/doc/source/contrib/stats.rst.mako
@@ -38,7 +38,7 @@ The sql logger source code with its documentation can be found here: https://git
 The blacklist regex is any string compatible with the python module *re*. It will be compiled and used to avoid writing in the DB the logs that
 match the given regex. This is useful to avoid filling a DB with healtcheck access logs. For example, if the *user-agent* http header of an
 healthcheck is set to some particular string (e.g. 'healthcheck' like in the above example), then you should at least set 'healtcheck' explicitely
-and the logger will avoid writing any log containing the word healthcheck. Please bear in mind that anything within the log that matches the 
+and the logger will avoid writing any log containing the word healthcheck. Please bear in mind that anything within the log that matches the
 regex will prevent the log to be written. It is therefore discouraged to use regexes based on url path, which could match also user traffic
 requests, which should be accounted in the statistics instead.
 

--- a/doc/source/contrib/stats.rst.mako
+++ b/doc/source/contrib/stats.rst.mako
@@ -17,6 +17,31 @@ Example of a configuration:
 
     args = ({'url':'postgresql://postgres:password@oereb-db:5432/oereb_stats','tablename':'logs','tableargs': {'schema':'oereb_logs'}},'healthcheck')
 
+**args** is a tuple containing two elements:
+
+- a dictionnary: the db connection information
+- a string: the blacklist regex
+
+The db connection information is a dictionary containing:
+
+- *url* (mandatory): a db connection string compatible with sqlalchemy. Currently only sqlite and postgresql are supported
+- *tablename* (optionnal): if a special tablename has to be used within the database and will be mapped with *__tablename__* sqlalchemy class property
+- *tableargs* (optionnal): another usual sqlalchemy class property (*__tableargs__*). In the above example we use it mainly to set a particular schema
+
+The default values for the above optional arguments are:
+
+- tablename = 'logs'
+- tableargs = None (i.e. it will create the table in the *public* schema of the DB)
+
+The sql logger source code with its documentation can be found here: https://github.com/camptocamp/c2cwsgiutils/tree/master/c2cwsgiutils/sqlalchemylogger
+
+The blacklist regex is any string compatible with the python module *re*. It will be compiled and used to avoid writing in the DB the logs that
+match the given regex. This is useful to avoid filling a DB with healtcheck access logs. For example, if the *user-agent* http header of an
+healthcheck is set to some particular string (e.g. 'healthcheck' like in the above example), then you should at least set 'healtcheck' explicitely
+and the logger will avoid writing any log containing the word healthcheck. Please bear in mind that anything within the log that matches the 
+regex will prevent the log to be written. It is therefore discouraged to use regexes based on url path, which could match also user traffic
+requests, which should be accounted in the statistics instead.
+
 
 <%! import glob, inspect, re, sys %>
 <%

--- a/doc/source/contrib/stats.rst.mako
+++ b/doc/source/contrib/stats.rst.mako
@@ -1,10 +1,10 @@
 .. _contrib-stats:
 
 Statistics
-----------
+==========
 
 The statistics functionality allows you to gather usage information within pyramid_oereb
-itself. The data gathered will be persisted in configured database,
+itself. The data gathered will be persisted in user defined configured database,
 allowing the operator or owner of the application to query at any time
 the usage statistics for that database.
 
@@ -15,33 +15,50 @@ Example of a configuration:
 
 .. code-block:: python
 
+    [handler_sqlalchemylogger]
+    class = c2cwsgiutils.sqlalchemylogger.handlers.SQLAlchemyHandler
     args = ({'url':'postgresql://postgres:password@oereb-db:5432/oereb_stats','tablename':'logs','tableargs': {'schema':'oereb_logs'}},'healthcheck')
+    level = NOTSET
+    formatter = generic
+    propagate = 0
 
 **args** is a tuple containing two elements:
 
-- a dictionnary: the db connection information
+- a dictionary: the db connection information
 - a string: the blacklist regex
+
+db connection information
+-------------------------
 
 The db connection information is a dictionary containing:
 
 - *url* (mandatory): a db connection string compatible with sqlalchemy. Currently only sqlite and postgresql are supported
-- *tablename* (optionnal): if a special tablename has to be used within the database and will be mapped with *__tablename__* sqlalchemy class property
-- *tableargs* (optionnal): another usual sqlalchemy class property (*__tableargs__*). In the above example we use it mainly to set a particular schema
+- *tablename* (optional): if a special tablename has to be used within the database and will be mapped with *__tablename__* sqlalchemy class property
+- *tableargs* (optional): another usual sqlalchemy class property (*__tableargs__*). In the above example we use it mainly to set a particular schema
 
 The default values for the above optional arguments are:
 
 - tablename = 'logs'
 - tableargs = None (i.e. it will create the table in the *public* schema of the DB)
 
-The sql logger source code with its documentation can be found here: https://github.com/camptocamp/c2cwsgiutils/tree/master/c2cwsgiutils/sqlalchemylogger
+The sql logger source code with its documentation can be found here: https://github.com/camptocamp/c2cwsgiutils/tree/3.9.0/c2cwsgiutils/sqlalchemylogger
+
+Blacklisting
+------------
+
+This is useful to avoid gathering statistics for non-relevant access logs, such as healthchecks.
 
 The blacklist regex is any string compatible with the python module *re*. It will be compiled and used to avoid writing in the DB the logs that
-match the given regex. This is useful to avoid filling a DB with healtcheck access logs. For example, if the *user-agent* http header of an
-healthcheck is set to some particular string (e.g. 'healthcheck' like in the above example), then you should at least set 'healtcheck' explicitely
-and the logger will avoid writing any log containing the word healthcheck. Please bear in mind that anything within the log that matches the
+match the given regex.  Please bear in mind that anything within the log that matches the
 regex will prevent the log to be written. It is therefore discouraged to use regexes based on url path, which could match also user traffic
 requests, which should be accounted in the statistics instead.
 
+For example if *user-agent* http header of an healthcheck is set to some particular string (e.g. 'healthcheck' like in the above example),
+then you should at least set 'healtcheck' explicitely and the logger will avoid writing any log containing the word healthcheck.
+
+
+Implementation
+--------------
 
 <%! import glob, inspect, re, sys %>
 <%

--- a/docker/production.ini
+++ b/docker/production.ini
@@ -36,10 +36,10 @@ reload = true
 ###
 
 [loggers]
-keys = root, pyramid_oereb, sqlalchemy
+keys = root, pyramid_oereb, sqlalchemy, json
 
 [handlers]
-keys = console
+keys = console, sqlalchemylogger
 
 [formatters]
 keys = generic
@@ -52,6 +52,12 @@ handlers = console
 level = WARN
 handlers =
 qualname = pyramid_oereb
+
+[logger_json]
+level = INFO
+handlers = console, sqlalchemylogger
+qualname = JSON
+propagate = 0
 
 [logger_sqlalchemy]
 level = WARN
@@ -66,6 +72,13 @@ class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
 formatter = generic
+
+[handler_sqlalchemylogger]
+class = c2cwsgiutils.sqlalchemylogger.handlers.SQLAlchemyHandler
+args = ({'url':'postgresql://postgres:password@oereb-db:5432/oereb_stats','tablename':'logs','tableargs': {'schema':'oereb_logs'}},'healthcheck')
+level = NOTSET
+formatter = generic
+propagate = 0
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s

--- a/pyramid_oereb/contrib/stats/decorators.py
+++ b/pyramid_oereb/contrib/stats/decorators.py
@@ -1,0 +1,63 @@
+import logging
+import json
+
+LOG = logging.getLogger('JSON')
+
+
+def log_response(wrapped):
+    def wrapper(context, request):
+        response = wrapped(context, request)
+        ret_dict = _serialize_response(response)
+        ret_dict.update(_serialize_request(request))
+        LOG.info(json.dumps(ret_dict))
+        return response
+    return wrapper
+
+
+def _serialize_response(response):
+    x = {}
+    x['status_code'] = response.status_code
+    x['headers'] = dict(response.headers)
+    x['extras'] = response.extras if hasattr(response, 'extras') else None
+    return {'response': x}
+
+
+def _serialize_request(request):
+    x = {}
+    x['headers'] = dict(request.headers)
+    x['traversed'] = str(request.traversed)
+    x['parameters'] = dict(request.GET)
+    x['path'] = str(request.path)
+    x['view_name'] = str(request.view_name)
+    return {'request': x}
+
+
+class OerebStats(dict):
+    """
+    class OerebStats(dict)
+    this class is used to provide a serializable object that can be
+    used to provide insight of application usage in the logs.
+    """
+    def __init__(self,
+                 service=None,
+                 output_format=None,
+                 params=None):
+        super(OerebStats, self).__init__(service=service,
+                                         output_format=output_format,
+                                         params=params)
+        self.itemlist = super(OerebStats, self).keys()
+
+    def __setitem__(self, key, value):
+        super(OerebStats, self).__setitem__(key, value)
+
+    def __iter__(self):
+        return iter(self.itemlist)
+
+    def keys(self):
+        return self.itemlist
+
+    def values(self):
+        return [self[key] for key in self]
+
+    def itervalues(self):
+        return (self[key] for key in self)

--- a/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
+++ b/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from c2cwsgiutils.sqlalchemylogger.handlers import SQLAlchemyHandler
+import configparser
+import ast
+from mako.template import Template
+import os
+import optparse
+
+SCRIPT_FOLDER = os.path.dirname(os.path.abspath(__file__))
+
+
+def create_stats_tables():
+    parser = optparse.OptionParser(
+        usage='usage: %prog [options]',
+        description='creates database and views for sqlalchemylogger'
+    )
+    parser.add_option(
+        '-c', '--config',
+        dest='configfile',
+        metavar='INI_FILE',
+        type='string',
+        help='The same config .ini file used to initialize the sqlalchemylogger handler'
+    )
+    parser.add_option(
+        '-s', '--section',
+        dest='config_section',
+        metavar='SECTION_NAME',
+        default='handler_sqlalchemylogger',
+        help='section in the ini-file. Default = "handler_sqlalchemylogger"'
+    )
+    parser.add_option(
+        '-a', '--args',
+        dest='config_sql_args',
+        metavar='SUBSECTION',
+        default='args',
+        help='subsection in the ini-file. Default = "args"'
+    )
+    options, _ = parser.parse_args()
+    if not options.configfile:
+        parser.error('No configfile set')
+    _create_views(config_file=options.configfile,
+                  config_section=options.config_section,
+                  config_sql_args=options.config_sql_args)
+
+
+def _create_views(config_file,
+                  config_section='handler_sqlalchemylogger',
+                  config_sql_args='args'):
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    schema_name = ast.literal_eval(config[config_section][config_sql_args])[0]['tableargs']['schema']
+    tablename = ast.literal_eval(config[config_section][config_sql_args])[0]['tablename']
+    fake_handler = SQLAlchemyHandler(ast.literal_eval(config[config_section][config_sql_args])[0])
+    fake_handler.create_db()
+    create_view_sql = Template(filename='{}/templates/views.sql.mako'.format(SCRIPT_FOLDER))
+    fake_handler.session.execute(create_view_sql.render(schema_name=schema_name, tablename=tablename))
+    fake_handler.session.commit()

--- a/pyramid_oereb/contrib/stats/scripts/templates/views.sql.mako
+++ b/pyramid_oereb/contrib/stats/scripts/templates/views.sql.mako
@@ -1,0 +1,86 @@
+/*GetVersions view*/
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_versions;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_versions AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetVersions';
+
+/*GetCapabilities view*/
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_capabilities;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_capabilities AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetCapabilities';
+
+/*GetEgridCoord view*/
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_egrid_coord;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_egrid_coord AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'xy' AS xy,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'gnss' AS gnss,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridCoord';
+
+/*GetEgridIdent view*/
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_egrid_ident;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_egrid_ident AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'identdn' AS identdn,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'number' AS number,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridIdent';
+
+/*GetEgridAddress view*/
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_egrid_address;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_egrid_address AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'postalcode' AS postalcode,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'localisation' AS localisation,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> 'number' AS number,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetEgridAddress';
+
+/*GetExtractById view*/
+DROP VIEW IF EXISTS ${schema_name|u}.stats_get_extract_by_id CASCADE;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_get_extract_by_id AS
+    SELECT cast(msg AS json) -> 'response' -> 'extras' ->> 'service' AS service ,
+           cast(cast(msg AS json) -> 'response' ->> 'status_code' AS INTEGER) AS status_code,
+           cast(msg AS json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__flavour__' AS flavour,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__egrid__' AS egrid,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__identdn__' AS identdn,
+           cast(msg AS json) -> 'response' -> 'extras' -> 'params' ->> '__number__' AS number,
+           created_at,
+           cast(msg AS json) -> 'request' ->> 'path' AS path
+    FROM ${schema_name|u}.${tablename|u} WHERE logger = 'JSON' AND cast(msg AS json) -> 'response' ->'extras' ->> 'service' = 'GetExtractById';
+
+/*stats_daily_extract_by_id*/
+DROP VIEW IF EXISTS ${schema_name|u}.stats_daily_extract_by_id;
+CREATE OR REPLACE VIEW ${schema_name|u}.stats_daily_extract_by_id AS
+    SELECT
+        date_trunc('day', created_at) AS day,
+        COUNT(1) AS nb_requests,
+        COUNT(1) FILTER (WHERE  output_format = 'pdf') AS format_pdf,
+        COUNT(1) FILTER (WHERE  output_format = 'json') AS format_json,
+        COUNT(1) FILTER (WHERE  output_format = 'xml') AS format_xml,
+        COUNT(1) FILTER (WHERE flavour = 'signed') AS flavour_signed,
+        COUNT(1) FILTER (WHERE flavour = 'full') AS flavour_full,
+        COUNT(1) FILTER (WHERE flavour = 'embeddable') AS flavour_embeddable,
+        COUNT(1) FILTER (WHERE flavour = 'reduced') AS flavour_reduced
+    FROM ${schema_name|u}.stats_get_extract_by_id WHERE cast(status_code as INTEGER) = 200
+    GROUP BY 1;

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from pyramid_oereb import route_prefix
 from pyramid_oereb.views.webservice import PlrWebservice, Symbol, Logo, Municipality, Sld
+from pyramid_oereb.contrib.stats.decorators import log_response
 
 
 def includeme(config):  # pragma: no cover
@@ -12,25 +13,29 @@ def includeme(config):  # pragma: no cover
     """
 
     # Service for logo images
-    config.add_route('{0}/image/logo'.format(route_prefix), '/image/logo/{logo}/{language}.{extension}')
+    config.add_route('{0}/image/logo'.format(route_prefix),
+                     '/image/logo/{logo}/{language}.{extension}')
     config.add_view(Logo, attr='get_image', route_name='{0}/image/logo'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Service for municipality images
-    config.add_route('{0}/image/municipality'.format(route_prefix), '/image/municipality/{fosnr}.{extension}')
-    config.add_view(Municipality, attr='get_image', route_name='{0}/image/municipality'.format(route_prefix),
-                    request_method='GET')
+    config.add_route('{0}/image/municipality'.format(route_prefix),
+                     '/image/municipality/{fosnr}.{extension}')
+    config.add_view(Municipality,
+                    attr='get_image',
+                    route_name='{0}/image/municipality'.format(route_prefix),
+                    request_method='GET', decorator=log_response)
 
     # Service for symbol images
     config.add_route('{0}/image/symbol'.format(route_prefix),
                      '/image/symbol/{theme_code}/{view_service_id}/{type_code}.{extension}')
     config.add_view(Symbol, attr='get_image', route_name='{0}/image/symbol'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Service for sld creation on egrid input
     config.add_route('{0}/sld'.format(route_prefix), '/sld')
     config.add_view(Sld, attr='get_sld', route_name='{0}/sld'.format(route_prefix),
-                    request_method='GET')
+                    request_method='GET', decorator=log_response)
 
     # Get versions
     config.add_route('{0}/versions/'.format(route_prefix), '/versions/{format}')
@@ -38,7 +43,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get version - Can be removed if backward compatibility no longer required.
@@ -47,21 +53,24 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/versions'.format(route_prefix), '/versions')
     config.add_view(
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/versions_old/'.format(route_prefix), '/versions/')
     config.add_view(
         PlrWebservice,
         attr='get_versions',
         route_name='{0}/versions_old/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get capabilities
@@ -70,7 +79,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get capabilities - Can be removed if backward compatibility no longer required.
@@ -79,73 +89,87 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/capabilities'.format(route_prefix), '/capabilities')
     config.add_view(
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/capabilities_old'.format(route_prefix), '/capabilities/')
     config.add_view(
         PlrWebservice,
         attr='get_capabilities',
         route_name='{0}/capabilities_old'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get egrid
-    config.add_route('{0}/getegrid_coord/'.format(route_prefix), '/getegrid/{format}/')
-    config.add_route('{0}/getegrid_ident/'.format(route_prefix), '/getegrid/{format}/{identdn}/{number}')
+    config.add_route('{0}/getegrid_coord/'.format(route_prefix),
+                     '/getegrid/{format}/')
+    config.add_route('{0}/getegrid_ident/'.format(route_prefix),
+                     '/getegrid/{format}/{identdn}/{number}')
     config.add_route('{0}/getegrid_address/'.format(route_prefix),
                      '/getegrid/{format}/{postalcode}/{localisation}/{number}')
     config.add_view(
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_address',
         route_name='{0}/getegrid_address/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get egrid - Can be removed if backward compatibility no longer required.
-    config.add_route('{0}/getegrid_coord.json'.format(route_prefix), '/getegrid.json')
-    config.add_route('{0}/getegrid_ident.json'.format(route_prefix), '/getegrid/{identdn}/{number}.json')
+    config.add_route('{0}/getegrid_coord.json'.format(route_prefix),
+                     '/getegrid.json')
+    config.add_route('{0}/getegrid_ident.json'.format(route_prefix),
+                     '/getegrid/{identdn}/{number}.json')
     config.add_route('{0}/getegrid_address.json'.format(route_prefix),
                      '/getegrid/{postalcode}/{localisation}/{number}.json')
     config.add_view(
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_address',
         route_name='{0}/getegrid_address.json'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/getegrid_coord'.format(route_prefix), '/getegrid')
     config.add_route('{0}/getegrid_ident'.format(route_prefix), '/getegrid/{identdn}/{number}')
-    # This legacy route (old specification) can't work anymore because of the one with {format} so it's
+    # This legacy route (old specification) can't work anymore
+    # because of the one with {format} so it's
     # commented and the view removed.
     # config.add_route('{0}/getegrid_address'.format(route_prefix),
     #                 '/getegrid/{postalcode}/{localisation}/{number}')
@@ -153,13 +177,15 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     config.add_route('{0}/getegrid_coord_old/'.format(route_prefix), '/getegrid/')
@@ -167,7 +193,8 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_coord',
         route_name='{0}/getegrid_coord_old/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Get extract by id
@@ -181,19 +208,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_1'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_2'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_3'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_route('{0}/extract_1/'.format(route_prefix),
                      '/extract/{flavour}/{format}/{param1}/')
@@ -205,19 +235,22 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_1/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_2/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
     config.add_view(
         PlrWebservice,
         attr='get_extract_by_id',
         route_name='{0}/extract_3/'.format(route_prefix),
-        request_method='GET'
+        request_method='GET',
+        decorator=log_response
     )
 
     # Commit config

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -520,8 +520,8 @@ class PlrWebservice(object):
 
 
 class Parameter(object):
-    def __init__(self, flavour, format, with_geometry, images, identdn=None, number=None,
-                 egrid=None, language=None, topics=None):
+    def __init__(self, response_format, flavour=None, with_geometry=False, images=False, identdn=None,
+                 number=None, egrid=None, language=None, topics=None):
         """
         Creates a new parameter instance.
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
             'create_standard_yaml = pyramid_oereb.standard.create_yaml:create_standard_yaml',
             'drop_standard_tables = pyramid_oereb.standard.drop_tables:drop_standard_tables',
             'create_legend_entries = pyramid_oereb.standard.load_legend_entries:run',
-            'import_federal_topic = pyramid_oereb.standard.import_federal_topic:run'
+            'import_federal_topic = pyramid_oereb.standard.import_federal_topic:run',
+            'create_stats_tables = pyramid_oereb.contrib.stats.scripts.create_stats_tables:create_stats_tables'  # noqa: E501
         ]
     }
 )

--- a/tests/webservice/test_getegrid.py
+++ b/tests/webservice/test_getegrid.py
@@ -24,8 +24,8 @@ def test_getegrid_coord_missing_parameter():
         'format': u'json'
     })
     webservice = PlrWebservice(request)
-    with pytest.raises(HTTPBadRequest):
-        webservice.get_egrid_coord()
+    response = webservice.get_egrid_ident()
+    assert response.code == 400
 
 
 def test_getegrid_ident():
@@ -126,8 +126,8 @@ def test_getegrid_ident_missing_parameter():
         'format': u'json'
     })
     webservice = PlrWebservice(request)
-    with pytest.raises(HTTPBadRequest):
-        webservice.get_egrid_ident()
+    response = webservice.get_egrid_ident()
+    assert response.code == 400
 
 
 def test_getegrid_address():
@@ -169,8 +169,8 @@ def test_getegrid_address_missing_parameter():
         'format': u'json'
     })
     webservice = PlrWebservice(request)
-    with pytest.raises(HTTPBadRequest):
-        webservice.get_egrid_address()
+    response = webservice.get_egrid_address()
+    assert response.code == 400
 
 
 def test_get_egrid_response():


### PR DESCRIPTION
This PR implements the [following enhancement](https://github.com/openoereb/pyramid_oereb/issues/936), in replacement of [this PR](https://github.com/openoereb/pyramid_oereb/pull/961) which had differed too much from `master`.

What this PR does:
- It uses the new `sqlalchemylogger` in [c2cwsgiutils](https://github.com/camptocamp/c2cwsgiutils/) to push application logs based on the received requests in a postgresql database
- it adds a module `stats` in `pyramid_oereb/contrib` which provides a custom decorator that analyses the response and request objects, and serialize useful info as JSON. This JSON is then written in the DB using `sqlalchemylogger`
- it provides a couple of scripts to generate SQL tables which use the JSON strings to provide usage statistics of the OEREB services.
- it also provides a filter to avoid writing some regex-matching logs. This can be useful to avoid writing and accounting health-checks.

### How to test:
```shell
# ensure you have the most recent c2cwsgiutils version 3 image
docker pull camptocamp/c2cwsgiutils:3

# launch the app
make serve

# make a test curl request
curl -H "User-Agent: Firefox" localhost:6543/oereb/capabilities/json

# in another terminal, connect to the DB
docker exec -it pyramidoereb_oereb-db_1 psql -U postgres
# and then
postgres=# \c oereb_stats
stats=# SELECT * FROM oereb_logs.logs;

# make another request and see that it gets filtered out
curl -H "User-Agent: healthcheck" localhost:6543/oereb/capabilities/json

in psql again
stats=# SELECT * FROM oereb_logs.logs;

# the second request should appear in the console output of the app, but not in the sql logs

# to use the json field to filter out only errors:
stats=# SELECT cast(msg as json),created_at AS response FROM oereb_logs.logs WHERE cast( cast(msg as json) -> 'response' ->> 'status_code' AS INT) >= 400;

```

Here is an example of a view using the json fields:
```sql
CREATE VIEW stats_get_extract_by_id AS 
    SELECT cast(msg as json) -> 'response' -> 'extras' ->> 'service' AS service ,
           cast(msg as json) -> 'response' ->> 'status_code' AS status_code,
           cast(msg as json) -> 'response' -> 'extras' ->> 'output_format' AS output_format,
           cast(msg as json) -> 'response' -> 'extras' -> 'params' ->> '__flavour__' AS flavour,
           cast(msg as json) -> 'response' -> 'extras' -> 'params' ->> '__egrid__' AS egrid
    FROM oereb_logs.logs WHERE cast(msg as json) -> 'response' ->'extras' ->> 'service' = 'GetExtractById';

SELECT * FROM stats_get_extract_by_id;
```
which gives something like:
```
    service     | status_code | output_format |  flavour   |     egrid      
----------------+-------------+---------------+------------+----------------
 GetExtractById | 200         | json          | embeddable | CH113928077734
 GetExtractById | 200         | json          | reduced    | CH113928077734
(2 rows)

```

To create the views in the database, connect to the oereb-server container:
```bash
 docker exec -it pyramidoereb_oereb-server_1 bash
```
and then call the following script (inside the container):
```bash
create_stats_tables -c production.ini
```

To view the aggregated logs of extract_by_id as daily entries:
```sql
SELECT * FROM oereb_logs.stats_daily_extract_by_id;
```
which will give a similar output:
```
         day         | nb_requests | format_pdf | format_json | format_xml | flavour_signed
 | flavour_full | flavour_embeddable | flavour_reduced 
---------------------+-------------+------------+-------------+------------+---------------
-+--------------+--------------------+-----------------
 2019-11-28 00:00:00 |          11 |          0 |           1 |          9 |              0
 |            0 |                  4 |               6
(1 row)
```
