### PR TITLE
Make geometry inclusion for pdf calls configurable

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -7,6 +7,20 @@ This chapter will give you hints on how to handle version migration, in particul
 to adapt in your project configuration, database etc. when upgrading to a new version.
 
 
+.. _changes-version-1.7.2:
+
+Version 1.7.2 (CURRENT DEV)
+---------------------------
+This is the current development version, not yet released.
+Changes thus far are relevant only for users of MapFish Print.
+
+MapFish Print related changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The inclusion of all geometry data in the print payload is now configurable (#1006).
+MapFish Print should set the print configuration parameter ```with_geometry``` to ```False```
+to improve performance.
+
+
 .. _changes-version-1.7.1:
 
 Version 1.7.1

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -68,6 +68,8 @@ vars:
   % if print_backend == 'XML2PDF':
       # Configuration for XML2PDF print service
       renderer: pyramid_oereb.contrib.print_proxy.xml_2_pdf.Renderer
+      # Define whether all geometry data must be included when sending the data to the print service
+      with_geometry: True
       # Base URL with application of the print server
       base_url: https://oereb-dev.gis-daten.ch/oereb/report/create
       token: 24ba4328-a306-4832-905d-b979388d4cab
@@ -81,6 +83,8 @@ vars:
   % else:
       # Configuration for MapFish-Print print service
       renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
+      # Define whether all geometry data must be included when sending the data to the print service
+      with_geometry: False
       # Set an archive path to keep a copy of each generated pdf.
       # pdf_archive_path: /tmp
       # The minimum buffer in pixel at 72 DPI between the real estate and the map's border. If your print

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -67,6 +67,8 @@ pyramid_oereb:
 % if print_backend == 'XML2PDF':
     # Configuration for XML2PDF print service
     renderer: pyramid_oereb.contrib.print_proxy.xml_2_pdf.Renderer
+    # Define whether all geometry data must be included when sending the data to the print service
+    with_geometry: True
     # Base URL with application of the print server
     base_url: https://oereb-dev.gis-daten.ch/oereb/report/create
     token: 24ba4328-a306-4832-905d-b979388d4cab
@@ -80,6 +82,8 @@ pyramid_oereb:
 % else:
     # Configuration for MapFish-Print print service
     renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
+    # Define whether all geometry data must be included when sending the data to the print service
+    with_geometry: False
     # Set an archive path to keep a copy of each generated pdf.
     # pdf_archive_path: /tmp
     # The minimum buffer in pixel at 72 DPI between the real estate and the map's border. If your print

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -339,10 +339,11 @@ class PlrWebservice(object):
         if extract_format == 'pdf' and user_requested_geometry:
             raise HTTPBadRequest('Geometry is not available for format PDF.')
 
-        # If PDF is to be produced, always include geometry
-        # (even though the URL shall not contain geometry parameter)
+        # If PDF is to be produced, check if geometry should be included
+        # (even though the URL is not allowed to not contain geometry parameter)
         if extract_format == 'pdf':
-            with_geometry = True
+            if Config.get('print', {}).get('with_geometry', True):
+                with_geometry = True
 
         # With images?
         with_images = self._params.get('WITHIMAGES') is not None

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -340,10 +340,10 @@ class PlrWebservice(object):
             raise HTTPBadRequest('Geometry is not available for format PDF.')
 
         # If PDF is to be produced, check if geometry should be included
-        # (even though the URL is not allowed to not contain geometry parameter)
+        # (this override can be needed for the print service. Note that, to be compliant to specification,
+        # the URL for a PDF request should not contain the geometry parameter)
         if extract_format == 'pdf':
-            if Config.get('print', {}).get('with_geometry', True):
-                with_geometry = True
+            with_geometry = Config.get('print', {}).get('with_geometry', True) or with_geometry
 
         # With images?
         with_images = self._params.get('WITHIMAGES') is not None

--- a/tests/webservice/test_getextractbyid.py
+++ b/tests/webservice/test_getextractbyid.py
@@ -62,7 +62,7 @@ def test_invalid_flavour(params):
         }, {
             'flavour': 'signed',
             'format': 'pdf',
-            'with_geometry': True,
+            'with_geometry': False,
             'images': False,
             'egrid': 'SomeEGRID'
         }
@@ -76,7 +76,7 @@ def test_invalid_flavour(params):
         }, {
             'flavour': 'full',
             'format': 'pdf',
-            'with_geometry': True,
+            'with_geometry': False,
             'images': False,
             'identdn': 'SomeIdent',
             'number': 'SomeNumber'


### PR DESCRIPTION
Make geometry inclusion for pdf calls configurable.

Follow-up to PR #883. For complex/big parcels, the print payload becomes very large when all geometry data is included; but in fact, for the MapFish Print this is not necessary. 

This PR has been tested at Schwyz, using pyramid_oereb v1.7.1.