### PR TITLE
Oereblex 1.2.0 as default and support notice document (HintRecord)

### DIFF
--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -18,10 +18,12 @@ Oereblex related changes
 Pyramid Oereb now supports and uses by default geoLink schema version 1.2.0:
 
  * New doctype 'notice' (will be classified as 'HintRecord'). If you want to add related notice as
-   additional legal provision directly to the public law restriction, You can set the new oereblex
+   additional legal provision directly to the public law restriction, you can set the new oereblex
    'related_notice_as_main' flag in the config of the project.
  * 'Notice' can have no authority nor enactment_date. In this case, the enactment date will be
    '01.01.1970' and the authority '-'.
+ * 'Notice' can have no authority_at_web. That was not supported by MapFish Print. If you use MapFish Print
+   with Oereblex 1.2.0, you must update your MapFish Print instance.
  * New document attribute 'language' and file attribute 'description' are currently not used by
    pyramid_oereb but are now available to custom code, for example for document title generation.
 
@@ -30,6 +32,9 @@ MapFish Print related changes
 The inclusion of all geometry data in the print payload is now configurable (#1006).
 MapFish Print should set the print configuration parameter ```with_geometry``` to ```False```
 to improve performance.
+
+It is now possible to print reports with missing OfficeAtWeb information in documents
+(OfficeAtWeb is an optional attribute in the specification).
 
 
 .. _changes-version-1.7.1:

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -12,7 +12,14 @@ to adapt in your project configuration, database etc. when upgrading to a new ve
 Version 1.7.2 (CURRENT DEV)
 ---------------------------
 This is the current development version, not yet released.
-Changes thus far are relevant only for users of MapFish Print.
+
+Oereblex related changes
+^^^^^^^^^^^^^^^^^^^^^^^^
+Pyramid Oereb now supports and uses by default geoLink schema version 1.2.0:
+
+ * New doctype 'notice' (will be classified as 'HintRecord'). 'Notice' can have no authority nor enactment_date
+ * New document attribute 'language' and file attribute 'description' are currently not used by
+   pyramid_oereb but are now available to custom code, for example for document title generation.
 
 MapFish Print related changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -17,7 +17,11 @@ Oereblex related changes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Pyramid Oereb now supports and uses by default geoLink schema version 1.2.0:
 
- * New doctype 'notice' (will be classified as 'HintRecord'). 'Notice' can have no authority nor enactment_date
+ * New doctype 'notice' (will be classified as 'HintRecord'). If you want to add related notice as
+   additional legal provision directly to the public law restriction, You can set the new oereblex
+   'related_notice_as_main' flag in the config of the project.
+ * 'Notice' can have no authority nor enactment_date. In this case, the enactment date will be
+   '01.01.1970' and the authority '-'.
  * New document attribute 'language' and file attribute 'description' are currently not used by
    pyramid_oereb but are now available to custom code, for example for document title generation.
 

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -190,6 +190,8 @@ vars:
       # document. Set this flag to true, if you want the related decree to be added as additional legal
       # provision directly to the public law restriction. This might have an impact on client side rendering.
       related_decree_as_main: false
+      # Same as related_decree_as_main but for related notice document.
+      related_notice_as_main: false
     # Proxy to be used for web requests
       # proxy:
       #   http:

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -141,15 +141,18 @@ class OEREBlexSource(Base):
 
         enactment_date = document.enactment_date
         authority = document.authority
+        authority_url = document.authority_url
         if document.doctype == 'notice':
             # Oereblex notices documents can have no enactment_date while it is require by pyramid_oereb to
             # have one. Add a fake default one that is identifiable and always older than now (01.0.1.1970).
             if enactment_date is None:
-                enactment_date = datetime.datetime(1970, 1, 1)
-            # Oereblex notices documents can have no `authority` while it is require by pyramid_oereb to
-            # have one. Replace None by '-' in this case.
+                enactment_date = datetime.date(1970, 1, 1)
+            # Oereblex notices documents can have no `authority` nor authority_url while it is require by
+            # pyramid_oereb to have one. Replace None by '-' in this case.
             if authority is None:
                 authority = '-'
+            if authority_url is None:
+                authority_url = '-'
 
         # Check mandatory attributes
         if document.title is None:
@@ -177,7 +180,7 @@ class OEREBlexSource(Base):
             referenced_records.extend(self._get_document_records(reference, language))
 
         # Create related office record
-        office = OfficeRecord({language: authority}, office_at_web=document.authority_url)
+        office = OfficeRecord({language: authority}, office_at_web=authority_url)
 
         # Check for available abbreviation
         abbreviation = {language: document.abbreviation} if document.abbreviation else None

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -141,18 +141,15 @@ class OEREBlexSource(Base):
 
         enactment_date = document.enactment_date
         authority = document.authority
-        authority_url = document.authority_url
         if document.doctype == 'notice':
             # Oereblex notices documents can have no enactment_date while it is require by pyramid_oereb to
             # have one. Add a fake default one that is identifiable and always older than now (01.0.1.1970).
             if enactment_date is None:
                 enactment_date = datetime.date(1970, 1, 1)
-            # Oereblex notices documents can have no `authority` nor authority_url while it is require by
-            # pyramid_oereb to have one. Replace None by '-' in this case.
+            # Oereblex notices documents can have no `authority` while it is require by pyramid_oereb to
+            # have one. Replace None by '-' in this case.
             if authority is None:
                 authority = '-'
-            if authority_url is None:
-                authority_url = '-'
 
         # Check mandatory attributes
         if document.title is None:
@@ -180,7 +177,7 @@ class OEREBlexSource(Base):
             referenced_records.extend(self._get_document_records(reference, language))
 
         # Create related office record
-        office = OfficeRecord({language: authority}, office_at_web=authority_url)
+        office = OfficeRecord({language: authority}, office_at_web=document.authority_url)
 
         # Check for available abbreviation
         abbreviation = {language: document.abbreviation} if document.abbreviation else None

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -189,6 +189,8 @@ pyramid_oereb:
     # document. Set this flag to true, if you want the related decree to be added as additional legal
     # provision directly to the public law restriction. This might have an impact on client side rendering.
     related_decree_as_main: false
+    # Same as related_decree_as_main but for related notice document.
+    related_notice_as_main: false
     # Proxy to be used for web requests
     # proxy:
     #   http:

--- a/tests/adapter/test_file.py
+++ b/tests/adapter/test_file.py
@@ -26,7 +26,7 @@ def test_ls():
     file_adapter = FileAdapter(base_path)
     dir_list = file_adapter.ls()
     assert isinstance(dir_list, list)
-    assert len(dir_list) == 11
+    assert len(dir_list) == 12
     file_found = False
     dir_found = False
     for entry in dir_list:

--- a/tests/resources/geolink_v1.2.0.xml
+++ b/tests/resources/geolink_v1.2.0.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geolinks>
+    <document authority="Bauverwaltung Gemeinde" authority_url="http%3A%2F%2Fwww.zihlschlacht-sitterdorf.ch"
+              category="main" doctype="decree" enactment_date="2001-03-27"
+              federal_level="Gemeinde" id="1500" instance="DBU" subtype="Gestaltungsplan"
+              title="Tiefkühllager" type="Sondernutzungsplan" decree_date="2001-03-15" number="1A"
+              abbreviation="abbr">
+        <file category="main" href="/api/attachments/4735" title="2918-E-1.pdf" description="2918-E-1.pdf"></file>
+        <file category="additional" href="/api/attachments/4736" title="2918-P-1.pdf" description="Plan 1"></file>
+        <file category="additional" href="/api/attachments/4737" title="2918-P-2.pdf" description="Plan 2"></file>
+        <file category="additional" href="/api/attachments/4738" title="2918-P-3.pdf" description="Plan 3"></file>
+        <file category="additional" href="/api/attachments/4739" title="2918-S-1.pdf" description=""></file>
+
+    </document>
+    <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
+              category="related" decree_date="2011-12-21" doctype="edict" enactment_date="2017-04-01"
+              federal_level="Kanton" id="4782" title="Planungs- und Baugesetz">
+        <file category="main"
+              href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1379?locale=de"
+              description="700.pdf"
+              title="700.pdf"></file>
+
+    </document>
+    <document authority="Bundeskanzlei" authority_url="https%3A%2F%2Fwww.bk.admin.ch" category="related"
+              doctype="edict" enactment_date="2016-01-01" federal_level="Bund" id="4776"
+              title="Bundesgesetz über die Raumplanung">
+        <file category="main" href="http://www.lexfind.ch/dtah/136884/2" description="700.de.pdf" title="700.de.pdf"></file>
+
+    </document>
+    <document authority="Staatskanzlei Kanton Thurgau" authority_url="http%3A%2F%2Fwww.staatskanzlei.tg.ch"
+              category="related" decree_date="2012-09-18" doctype="edict" enactment_date="2016-11-05"
+              federal_level="Kanton" id="4783"
+              title="Verordnung des Regierungsrates zum Planungs- und Baugesetz und zur Interkantonalen Vereinbarung über die Harmonisierung der Baubegriffe">
+        <file category="main"
+              href="http://www.rechtsbuch.tg.ch/frontend/versions/pdf_file_with_annex/1319?locale=de"
+              description="700.1.pdf"
+              title="700.1.pdf"></file>
+
+    </document>
+    <document category="related" doctype="notice" id="4" title="Beispiel Hinweis Dokument">
+        <file category="main" href="/api/attachments/5101" description="example_notice.pdf" title="example_notice.pdf"></file>
+    </document>
+</geolinks>

--- a/tests/sources/test_document_oereblex.py
+++ b/tests/sources/test_document_oereblex.py
@@ -138,49 +138,49 @@ def test_get_document_records(i, document):
 
 def test_read():
     with requests_mock.mock() as m:
-        with open('./tests/resources/geolink_v1.1.1.xml', 'rb') as f:
+        with open('./tests/resources/geolink_v1.2.0.xml', 'rb') as f:
             m.get('http://oereblex.example.com/api/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL')
         source.read(MockParameter(), 100)
-        assert len(source.records) == 2
+        assert len(source.records) == 5
         document = source.records[0]
         assert isinstance(document, DocumentRecord)
         assert isinstance(document.responsible_office, OfficeRecord)
-        assert document.responsible_office.name == {'de': 'Landeskanzlei'}
+        assert document.responsible_office.name == {'de': 'Bauverwaltung Gemeinde'}
         assert document.canton == 'BL'
         assert document.text_at_web == {
-            'de': 'http://oereblex.example.com/api/attachments/313'
+            'de': 'http://oereblex.example.com/api/attachments/4735'
         }
-        assert len(document.references) == 5
+        assert len(document.references) == 4
 
 
 def test_read_related_decree_as_main():
     with requests_mock.mock() as m:
-        with open('./tests/resources/geolink_v1.1.1.xml', 'rb') as f:
+        with open('./tests/resources/geolink_v1.2.0.xml', 'rb') as f:
             m.get('http://oereblex.example.com/api/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 related_decree_as_main=True)
         source.read(MockParameter(), 100)
-        assert len(source.records) == 3
+        assert len(source.records) == 5
         document = source.records[0]
         assert isinstance(document, DocumentRecord)
         assert isinstance(document.responsible_office, OfficeRecord)
-        assert document.responsible_office.name == {'de': 'Landeskanzlei'}
+        assert document.responsible_office.name == {'de': 'Bauverwaltung Gemeinde'}
         assert document.canton == 'BL'
         assert document.text_at_web == {
-            'de': 'http://oereblex.example.com/api/attachments/313'
+            'de': 'http://oereblex.example.com/api/attachments/4735'
         }
         assert len(document.references) == 4
 
 
 def test_read_with_version_in_url():
     with requests_mock.mock() as m:
-        with open('./tests/resources/geolink_v1.1.1.xml', 'rb') as f:
-            m.get('http://oereblex.example.com/api/1.1.1/geolinks/100.xml', content=f.read())
+        with open('./tests/resources/geolink_v1.2.0.xml', 'rb') as f:
+            m.get('http://oereblex.example.com/api/1.2.0/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 pass_version=True)
         source.read(MockParameter(), 100)
-        assert len(source.records) == 2
+        assert len(source.records) == 5
 
 
 def test_read_with_specified_version():
@@ -195,17 +195,17 @@ def test_read_with_specified_version():
 
 def test_read_with_specified_language():
     with requests_mock.mock() as m:
-        with open('./tests/resources/geolink_v1.1.1.xml', 'rb') as f:
+        with open('./tests/resources/geolink_v1.2.0.xml', 'rb') as f:
             m.get('http://oereblex.example.com/api/geolinks/100.xml?locale=fr', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL')
         params = MockParameter()
         params.set_language('fr')
         source.read(params, 100)
-        assert len(source.records) == 2
+        assert len(source.records) == 5
         document = source.records[0]
-        assert document.responsible_office.name == {'fr': 'Landeskanzlei'}
+        assert document.responsible_office.name == {'fr': 'Bauverwaltung Gemeinde'}
         assert document.text_at_web == {
-            'fr': 'http://oereblex.example.com/api/attachments/313'
+            'fr': 'http://oereblex.example.com/api/attachments/4735'
         }
 
 

--- a/tests/sources/test_document_oereblex.py
+++ b/tests/sources/test_document_oereblex.py
@@ -172,6 +172,7 @@ def test_read_related_decree_as_main():
         }
         assert len(document.references) == 4
 
+
 def test_read_related_notice_as_main():
     with requests_mock.mock() as m:
         with open('./tests/resources/geolink_v1.2.0.xml', 'rb') as f:
@@ -184,10 +185,9 @@ def test_read_related_notice_as_main():
         assert isinstance(document, HintRecord)
         assert isinstance(document.responsible_office, OfficeRecord)
         assert document.responsible_office.name == {'de': '-'}
-        assert document.responsible_office.office_at_web == '-'
+        assert document.responsible_office.office_at_web is None
         assert document.published_from == datetime.date(1970, 1, 1)
         assert len(document.references) == 3
-
 
 
 def test_read_with_version_in_url():


### PR DESCRIPTION
For GEO-2697 and https://github.com/openoereb/pyramid_oereb/issues/959

 - Default oereblex version is now 1.2.0.
 - Notice document will be "classed" as "HintRecord" (Hinweis).

For the point: 
```
Furthermore, it is requested from the canton AI, that it's sufficient for an geometr
to then have either a geolink which refers to the "Gesetzliche Grundlagen" or
a link to the "Weitere Informationen und Hinweise".
```
It should already work with the `reduced` "mode" (flavour). But not with others as the official requirement from the specification spcify this point: "Eigentumsbeschränkung ohne Rechtsvorschrift ist nur bei einem reduzierten Auszug zulässig".

Can someone with a pyramid_oereb - oereblex application take this commit and test ? (that would be quicker than make a test environment with oereblex)