### PR TITLE
Configurable geoLink validation

### DIFF
--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -35,6 +35,7 @@ class OEREBlexSource(Base):
             proxy (dict of uri): Optional proxy configuration for HTTP and/or HTTPS.
             auth (dict of str): Optional credentials for basic authentication. Requires `username`
                 and `password` to be defined.
+            validation (bool): Turn XML validation on/off. Default is true.
 
         """
         super(OEREBlexSource, self).__init__()
@@ -67,7 +68,11 @@ class OEREBlexSource(Base):
         if not (isinstance(self._canton, str) and len(self._canton) == 2):
             raise AssertionError('canton has to be string of two characters, e.g. "BL" or "NE"')
 
-        self._parser = XML(host_url=kwargs.get('host'), version=self._version)
+        if kwargs.get('validation') is not None:
+            xsd_validation = kwargs.get('validation')
+        else:
+            xsd_validation = True
+        self._parser = XML(host_url=kwargs.get('host'), version=self._version, xsd_validation=xsd_validation)
         if self._parser.host_url is None:
             raise AssertionError('host_url has to be defined')
 

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -199,6 +199,8 @@ pyramid_oereb:
     # auth:
     #   username:
     #   password:
+    # Enable/disable XML validation
+    validation: true
 
   # Defines the information of the oereb cadastre providing authority. Please change this to your data. This
   # will be directly used for producing the extract output.


### PR DESCRIPTION
An optional configuration parameter `validation` is added to the `OEREBlexSource`. The value is passed to the `geolink_formatter` and turns the XML validation on/off.

To ensure backwards compatibility, the default value is `true` which means the validation to be enabled.

Related to https://github.com/openoereb/geolink_formatter/issues/85