### PR TITLE
Option --c2ctemplate-style as a flag

### DIFF
--- a/pyramid_oereb/standard/create_tables.py
+++ b/pyramid_oereb/standard/create_tables.py
@@ -113,6 +113,7 @@ def create_standard_tables():
     parser.add_option(
         '--c2ctemplate-style',
         dest='c2ctemplate_style',
+        action='store_true',
         default=False,
         help='Is the yaml file using a c2ctemplate style (starting with vars)'
     )
@@ -174,6 +175,7 @@ def create_theme_tables():
     parser.add_option(
         '--c2ctemplate-style',
         dest='tc2ctemplate_style',
+        action='store_true',
         default=False,
         help='Is the yaml file using a c2ctemplate style (starting with vars)'
     )

--- a/pyramid_oereb/standard/import_federal_topic.py
+++ b/pyramid_oereb/standard/import_federal_topic.py
@@ -101,6 +101,7 @@ def run():
     parser.add_option(
         '--c2ctemplate-style',
         dest='c2ctemplate_style',
+        action='store_true',
         default=False,
         help='Is the yaml file using a c2ctemplate style (starting with vars)'
     )

--- a/pyramid_oereb/standard/load_legend_entries.py
+++ b/pyramid_oereb/standard/load_legend_entries.py
@@ -296,6 +296,7 @@ def run():
     parser.add_option(
         '--c2ctemplate-style',
         dest='c2ctemplate_style',
+        action='store_true',
         default=False,
         help='Is the yaml file using a c2ctemplate style (starting with vars)'
     )

--- a/pyramid_oereb/standard/load_sample_data.py
+++ b/pyramid_oereb/standard/load_sample_data.py
@@ -288,6 +288,7 @@ def _run():
     parser.add_option(
         '--c2ctemplate-style',
         dest='c2ctemplate_style',
+        action='store_true',
         default=False,
         help='Is the yaml file using a c2ctemplate style (starting with vars)'
     )


### PR DESCRIPTION
Improvement for https://github.com/openoereb/pyramid_oereb/pull/1079

To be able to use the `c2ctemplate-style` as a flag:
`--c2ctemplate-style` instead of `--c2ctemplate-style True` to use this option