### PR TITLE
Oereblex: add parameter for oereblex call

### DIFF
--- a/pyramid_oereb/contrib/models/oereblex/contaminated_sites.py
+++ b/pyramid_oereb/contrib/models/oereblex/contaminated_sites.py
@@ -201,6 +201,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
         sa.String,
         sa.ForeignKey(ViewService.id),

--- a/pyramid_oereb/contrib/models/oereblex/forest_distance_lines.py
+++ b/pyramid_oereb/contrib/models/oereblex/forest_distance_lines.py
@@ -201,6 +201,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
         sa.String,
         sa.ForeignKey(ViewService.id),

--- a/pyramid_oereb/contrib/models/oereblex/forest_perimeters.py
+++ b/pyramid_oereb/contrib/models/oereblex/forest_perimeters.py
@@ -201,6 +201,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
         sa.String,
         sa.ForeignKey(ViewService.id),

--- a/pyramid_oereb/contrib/models/oereblex/groundwater_protection_sites.py
+++ b/pyramid_oereb/contrib/models/oereblex/groundwater_protection_sites.py
@@ -201,6 +201,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
         sa.String,
         sa.ForeignKey(ViewService.id),

--- a/pyramid_oereb/contrib/models/oereblex/groundwater_protection_zones.py
+++ b/pyramid_oereb/contrib/models/oereblex/groundwater_protection_zones.py
@@ -201,6 +201,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
         sa.String,
         sa.ForeignKey(ViewService.id),

--- a/pyramid_oereb/contrib/models/oereblex/land_use_plans.py
+++ b/pyramid_oereb/contrib/models/oereblex/land_use_plans.py
@@ -201,6 +201,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
         sa.String,
         sa.ForeignKey(ViewService.id),

--- a/pyramid_oereb/contrib/models/oereblex/noise_sensitivity_levels.py
+++ b/pyramid_oereb/contrib/models/oereblex/noise_sensitivity_levels.py
@@ -201,6 +201,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
         sa.String,
         sa.ForeignKey(ViewService.id),

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -76,21 +76,23 @@ class OEREBlexSource(Base):
         if self._parser.host_url is None:
             raise AssertionError('host_url has to be defined')
 
-    def read(self, params, geolink_id):
+    def read(self, params, geolink_id, oereblex_params):
         """
         Requests the geoLink for the specified ID and returns records for the received documents.
 
         Args:
             params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             geolink_id (int): The geoLink ID.
+            oereblex_params (string): Any additional parameters to pass to Oereblex
         """
         log.debug("read() start")
 
         # Request documents
-        url = '{host}/api/{version}geolinks/{id}.xml'.format(
+        url = '{host}/api/{version}geolinks/{id}.xml?{url_params}'.format(
             host=self._parser.host_url,
             version=self._version + '/' if self._pass_version else '',
-            id=geolink_id
+            id=geolink_id,
+            url_params=oereblex_params
         )
         language = params.language or self._language
         request_params = {

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -76,7 +76,7 @@ class OEREBlexSource(Base):
         if self._parser.host_url is None:
             raise AssertionError('host_url has to be defined')
 
-    def read(self, params, geolink_id, oereblex_params):
+    def read(self, params, geolink_id, oereblex_params=None):
         """
         Requests the geoLink for the specified ID and returns records for the received documents.
 

--- a/pyramid_oereb/contrib/sources/plr_oereblex.py
+++ b/pyramid_oereb/contrib/sources/plr_oereblex.py
@@ -41,9 +41,10 @@ class DatabaseOEREBlexSource(DatabaseSource):
         """
         Override the parent's get_document_records method to obtain the oereblex document instead.
         """
-        return self.document_records_from_oereblex(params, public_law_restriction_from_db.geolink)
+        return self.document_records_from_oereblex(params, public_law_restriction_from_db.geolink,
+                                                   public_law_restriction_from_db.oereblex_params)
 
-    def document_records_from_oereblex(self, params, lexlink):
+    def document_records_from_oereblex(self, params, lexlink, oereblex_params):
         """
         Create document records parsed from the OEREBlex response with the specified geoLink ID and appends
         them to the current public law restriction.
@@ -51,6 +52,7 @@ class DatabaseOEREBlexSource(DatabaseSource):
         Args:
             params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             lexlink (int): The ID of the geoLink to request the documents for.
+            oereblex_params (string): Parameters for the oereblex link
 
         Returns:
             list of pyramid_oereb.lib.records.documents.DocumentRecord:
@@ -62,7 +64,7 @@ class DatabaseOEREBlexSource(DatabaseSource):
             log.debug('use already queried instead')
             return self._queried_lexlinks[lexlink]
         else:
-            self._oereblex_source.read(params, lexlink)
+            self._oereblex_source.read(params, lexlink, oereblex_params)
             log.debug("document_records_from_oereblex() returning {} records"
                       .format(len(self._oereblex_source.records)))
             self._queried_lexlinks[lexlink] = self._oereblex_source.records

--- a/pyramid_oereb/contrib/templates/plr_oereb.py.mako
+++ b/pyramid_oereb/contrib/templates/plr_oereb.py.mako
@@ -280,6 +280,7 @@ class PublicLawRestriction(Base):
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
     geolink = sa.Column(sa.Integer, nullable=True)
+    oereblex_params = sa.Column(sa.String, nullable=True)
     view_service_id = sa.Column(
 % if primary_key_is_string:
         sa.String,

--- a/tests/sources/test_document_oereblex.py
+++ b/tests/sources/test_document_oereblex.py
@@ -141,7 +141,7 @@ def test_read():
         with open('./tests/resources/geolink_v1.2.0.xml', 'rb') as f:
             m.get('http://oereblex.example.com/api/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL')
-        source.read(MockParameter(), 100)
+        source.read(MockParameter(), 100, None)
         assert len(source.records) == 5
         document = source.records[0]
         assert isinstance(document, DocumentRecord)
@@ -160,7 +160,7 @@ def test_read_related_decree_as_main():
             m.get('http://oereblex.example.com/api/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 related_decree_as_main=True)
-        source.read(MockParameter(), 100)
+        source.read(MockParameter(), 100, None)
         assert len(source.records) == 5
         document = source.records[0]
         assert isinstance(document, DocumentRecord)
@@ -179,7 +179,7 @@ def test_read_related_notice_as_main():
             m.get('http://oereblex.example.com/api/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 related_notice_as_main=True)
-        source.read(MockParameter(), 100)
+        source.read(MockParameter(), 100, None)
         assert len(source.records) == 6
         document = source.records[5]
         assert isinstance(document, HintRecord)
@@ -196,7 +196,7 @@ def test_read_with_version_in_url():
             m.get('http://oereblex.example.com/api/1.2.0/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 pass_version=True)
-        source.read(MockParameter(), 100)
+        source.read(MockParameter(), 100, None)
         assert len(source.records) == 5
 
 
@@ -206,7 +206,7 @@ def test_read_with_specified_version():
             m.get('http://oereblex.example.com/api/1.0.0/geolinks/100.xml', content=f.read())
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL',
                                 pass_version=True, version='1.0.0')
-        source.read(MockParameter(), 100)
+        source.read(MockParameter(), 100, None)
         assert len(source.records) == 2
 
 
@@ -217,7 +217,7 @@ def test_read_with_specified_language():
         source = OEREBlexSource(host='http://oereblex.example.com', language='de', canton='BL')
         params = MockParameter()
         params.set_language('fr')
-        source.read(params, 100)
+        source.read(params, 100, None)
         assert len(source.records) == 5
         document = source.records[0]
         assert document.responsible_office.name == {'fr': 'Bauverwaltung Gemeinde'}


### PR DESCRIPTION
Fix #1065

Proposal to add an (optional) parameter string for oereblex calls, to be able to use "oereb_id" parameter, or other parameters in the future in a generic way. 
In the proposal of this PR, the parameter string would be stored in the model, in addition (separately) to the "geolink". 

Status: DRAFT, for now, looking for feedback whether this approach makes sense. To be tested yet on a real instance.

C2C internal reference: GEO-3711