### PR TITLE
Deglobalize processor gspoe 38

### DIFF
--- a/pyramid_oereb/lib/processor.py
+++ b/pyramid_oereb/lib/processor.py
@@ -2,10 +2,17 @@
 import logging
 
 from operator import attrgetter
+
+from pyramid.path import DottedNameResolver
+
 from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.records.documents import DocumentRecord
 from pyramid_oereb.lib.records.plr import PlrRecord
-from pyramid.path import DottedNameResolver
+from pyramid_oereb.lib.readers.exclusion_of_liability import ExclusionOfLiabilityReader
+from pyramid_oereb.lib.readers.extract import ExtractReader
+from pyramid_oereb.lib.readers.glossary import GlossaryReader
+from pyramid_oereb.lib.readers.municipality import MunicipalityReader
+from pyramid_oereb.lib.readers.real_estate import RealEstateReader
 
 
 log = logging.getLogger(__name__)
@@ -308,3 +315,65 @@ class Processor(object):
             extract.real_estate.set_highlight_url(sld_url)
         log.debug("process() done, returning extract.")
         return extract
+
+
+def create_processor():
+    """
+    Creates and returns a processor based on the application configuration.
+    You should use one (and only one) processor per request. Otherwise some results can be mixed or
+    missing.
+
+    Returns:
+        pyramid_oereb.lib.processor.Processor: A processor.
+    """
+
+    real_estate_config = Config.get_real_estate_config()
+    municipality_config = Config.get_municipality_config()
+    exclusion_of_liability_config = Config.get_exclusion_of_liability_config()
+    glossary_config = Config.get_glossary_config()
+    extract = Config.get_extract_config()
+    certification = extract.get('certification')
+    certification_at_web = extract.get('certification_at_web')
+
+    plr_cadastre_authority = Config.get_plr_cadastre_authority()
+
+    real_estate_reader = RealEstateReader(
+        real_estate_config.get('source').get('class'),
+        **real_estate_config.get('source').get('params')
+    )
+
+    municipality_reader = MunicipalityReader(
+        municipality_config.get('source').get('class'),
+        **municipality_config.get('source').get('params')
+    )
+
+    exclusion_of_liability_reader = ExclusionOfLiabilityReader(
+        exclusion_of_liability_config.get('source').get('class'),
+        **exclusion_of_liability_config.get('source').get('params')
+    )
+
+    glossary_reader = GlossaryReader(
+        glossary_config.get('source').get('class'),
+        **glossary_config.get('source').get('params')
+    )
+
+    plr_sources = []
+    for plr in Config.get('plrs'):
+        plr_source_class = DottedNameResolver().maybe_resolve(plr.get('source').get('class'))
+        plr_sources.append(plr_source_class(**plr))
+
+    extract_reader = ExtractReader(
+        plr_sources,
+        plr_cadastre_authority,
+        certification,
+        certification_at_web,
+    )
+
+    return Processor(
+        real_estate_reader=real_estate_reader,
+        municipality_reader=municipality_reader,
+        exclusion_of_liability_reader=exclusion_of_liability_reader,
+        glossary_reader=glossary_reader,
+        plr_sources=plr_sources,
+        extract_reader=extract_reader,
+    )

--- a/tests/mockrequest.py
+++ b/tests/mockrequest.py
@@ -1,15 +1,6 @@
 # -*- coding: utf-8 -*-
-from pyramid.path import DottedNameResolver
 from pyramid.testing import DummyRequest
 
-from pyramid_oereb import ExtractReader
-from pyramid_oereb import MunicipalityReader
-from pyramid_oereb import ExclusionOfLiabilityReader
-from pyramid_oereb import GlossaryReader
-from pyramid_oereb import Processor
-from pyramid_oereb import RealEstateReader
-
-from pyramid_oereb.lib.config import Config
 from pyramid_oereb.views.webservice import Parameter
 
 
@@ -23,59 +14,6 @@ class MockRequest(DummyRequest):
         super(MockRequest, self).__init__()
 
         self._current_route_url = current_route_url
-
-        real_estate_config = Config.get_real_estate_config()
-        municipality_config = Config.get_municipality_config()
-        exclusion_of_liability_config = Config.get_exclusion_of_liability_config()
-        glossary_config = Config.get_glossary_config()
-        extract = Config.get_extract_config()
-        certification = extract.get('certification')
-        certification_at_web = extract.get('certification_at_web')
-        plr_cadastre_authority = Config.get_plr_cadastre_authority()
-
-        real_estate_reader = RealEstateReader(
-            real_estate_config.get('source').get('class'),
-            **real_estate_config.get('source').get('params')
-        )
-
-        municipality_reader = MunicipalityReader(
-            municipality_config.get('source').get('class'),
-            **municipality_config.get('source').get('params')
-        )
-
-        exclusion_of_liability_reader = ExclusionOfLiabilityReader(
-            exclusion_of_liability_config.get('source').get('class'),
-            **exclusion_of_liability_config.get('source').get('params')
-        )
-
-        glossary_reader = GlossaryReader(
-            glossary_config.get('source').get('class'),
-            **glossary_config.get('source').get('params')
-        )
-
-        plr_sources = []
-        for plr in Config.get('plrs'):
-            plr_source_class = DottedNameResolver().maybe_resolve(plr.get('source').get('class'))
-            plr_sources.append(plr_source_class(**plr))
-
-        extract_reader = ExtractReader(
-            plr_sources,
-            plr_cadastre_authority,
-            certification,
-            certification_at_web
-        )
-        self.processor = Processor(
-            real_estate_reader=real_estate_reader,
-            municipality_reader=municipality_reader,
-            exclusion_of_liability_reader=exclusion_of_liability_reader,
-            glossary_reader=glossary_reader,
-            plr_sources=plr_sources,
-            extract_reader=extract_reader,
-        )
-
-    @property
-    def pyramid_oereb_processor(self):
-        return self.processor
 
     def current_route_url(self, *elements, **kw):
         if self._current_route_url:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from shapely.geometry import Point
 
-from pyramid_oereb.lib.processor import Processor
+from pyramid_oereb.lib.processor import Processor, create_processor
 from pyramid_oereb.lib.records.extract import ExtractRecord
 from pyramid_oereb.lib.records.geometry import GeometryRecord
 from pyramid_oereb.lib.records.image import ImageRecord
@@ -12,11 +12,11 @@ from pyramid_oereb.lib.records.office import OfficeRecord
 from pyramid_oereb.lib.records.plr import PlrRecord
 from pyramid_oereb.lib.records.theme import ThemeRecord
 from pyramid_oereb.lib.records.view_service import ViewServiceRecord, LegendEntryRecord
-from pyramid_oereb import ExtractReader
-from pyramid_oereb import MunicipalityReader
-from pyramid_oereb import ExclusionOfLiabilityReader
-from pyramid_oereb import GlossaryReader
-from pyramid_oereb import RealEstateReader
+from pyramid_oereb.lib.readers.exclusion_of_liability import ExclusionOfLiabilityReader
+from pyramid_oereb.lib.readers.extract import ExtractReader
+from pyramid_oereb.lib.readers.glossary import GlossaryReader
+from pyramid_oereb.lib.readers.municipality import MunicipalityReader
+from pyramid_oereb.lib.readers.real_estate import RealEstateReader
 from pyramid_oereb.views.webservice import PlrWebservice
 from tests.mockrequest import MockRequest
 
@@ -33,9 +33,7 @@ def test_missing_params():
 
 
 def test_properties():
-    request = MockRequest()
-    request.matchdict.update(request_matchdict)
-    processor = request.pyramid_oereb_processor
+    processor = create_processor()
     assert isinstance(processor.extract_reader, ExtractReader)
     assert isinstance(processor.municipality_reader, MunicipalityReader)
     assert isinstance(processor.exclusion_of_liability_reader, ExclusionOfLiabilityReader)
@@ -47,7 +45,7 @@ def test_properties():
 def test_process():
     request = MockRequest()
     request.matchdict.update(request_matchdict)
-    processor = request.pyramid_oereb_processor
+    processor = create_processor()
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
     real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
@@ -58,7 +56,7 @@ def test_process():
 def test_process_geometry_testing():
     request = MockRequest()
     request.matchdict.update(request_matchdict)
-    processor = request.pyramid_oereb_processor
+    processor = create_processor()
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
     real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
@@ -71,7 +69,7 @@ def test_process_geometry_testing():
 def test_filter_published_documents():
     request = MockRequest()
     request.matchdict.update(request_matchdict)
-    processor = request.pyramid_oereb_processor
+    processor = create_processor()
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
     real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
@@ -89,7 +87,7 @@ def test_processor_with_images():
         'WITHIMAGES': '',
         'LANG': 'de'
     })
-    processor = request.pyramid_oereb_processor
+    processor = create_processor()
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
     real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')
@@ -105,7 +103,7 @@ def test_processor_without_images():
     request.params.update({
         'LANG': 'de'
     })
-    processor = request.pyramid_oereb_processor
+    processor = create_processor()
     webservice = PlrWebservice(request)
     params = webservice.__validate_extract_params__()
     real_estate = processor.real_estate_reader.read(params, egrid=u'TEST')


### PR DESCRIPTION
Fix #1068 and [GSPOE-38](https://jira.camptocamp.com/browse/GSPOE-38)

First, I've discovered that we can reproduce the issue with the local server and test data, and with only one extract. We only have to call it ten time at once and we have a small probability that the issue append. It's easier on a real use case and with multiple different extracts, case but the principle is the same.

It looks that having a global processor is the origin of the troubles.
I can imagine that:

- [1] query an extract
- [1] pyramid (create or) use it's processor with linked instances to query an external website or the database
- [1] the involved instances store the result
- [1] The first extract have to wait on other data
- [2] query a second extract
- [2] pyramid use it's processor with (same) linked instances to query an external website or the database
- [2] the involved instances store the result above (or add it to) the first result
- [1] return the first extract with some results of the second.
- [2]  return the second extract with the result of the second.

Now with separate processors, involved instances (especially readers) should be separate and results should be not mixed anymore. But we have to take care that we use one and only one processor per main request.

It looks working but I was able to test my theories only with an empirical method.
I've tried to add code to always reproduce the issue but I was not able to achieve that. I'm not sure exactly at the end where the issue append. Probably at some assignments in an object that we read later.

And as I can't reproduce the issue on a stable base, I can't add automated test to be sure that the problem is gone.