### PR TITLE
For full extracts, add configuration parameter to make additional sld usage optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 ---------
 
+1.8.0 (DRAFT)
+*************
+- Enhance federal data import script to make it more usable with Docker (#1078)
+- For full extracts, add configuration parameter to make additional sld usage optional (#1077)
+
 1.7.6
 *****
 - Improve federal data import script (#1057)

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -172,6 +172,9 @@ vars:
           types:
           - GeometryCollection
 
+    # Configuration options for full extract
+    full_extract_use_sld: true
+
     # Configuration for OEREBlex
     oereblex:
       # OEREBlex host

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -172,7 +172,7 @@ vars:
           types:
           - GeometryCollection
 
-    # Configuration options for full extract
+    # Configuration option for full extract: apply SLD on land register WMS (defaults to true)
     full_extract_use_sld: true
 
     # Configuration for OEREBlex

--- a/pyramid_oereb/lib/processor.py
+++ b/pyramid_oereb/lib/processor.py
@@ -305,6 +305,7 @@ class Processor(object):
         extract.glossaries = glossaries
         # obtain the highlight wms url and its content only if the parameter full was requested (PDF)
         if params.flavour == 'full':
-            extract.real_estate.set_highlight_url(sld_url)
+            if Config.get('full_extract_use_sld', True):
+                extract.real_estate.set_highlight_url(sld_url)
         log.debug("process() done, returning extract.")
         return extract

--- a/pyramid_oereb/lib/records/real_estate.py
+++ b/pyramid_oereb/lib/records/real_estate.py
@@ -11,7 +11,8 @@ class RealEstateRecord(object):
     Attributes:
         plan_for_land_register (pyramid_oereb.lib.records.view_service.ViewServiceRecord): The view service to
             be used for the land registry map.
-        highlight (str): The url which produces a image with the highlighted real estate from a wms.
+        highlight (pyramid_oereb.lib.records.view_service.ViewServiceRecord): the view service with the wms
+        image of the highlighted real estate.
         areas_ratio (decimal): Ratio of geometrical area and area from land registry.
     """
 
@@ -90,6 +91,13 @@ class RealEstateRecord(object):
         self.plan_for_land_register_main_page = plan_for_land_register_main_page
 
     def set_highlight_url(self, sld_url):
+        """
+        Set the highlight of the real estate.
+
+        Args:
+            sld_url (str): The URL which provides the sld to style and filter the highlight of the real
+            estate.
+        """
         configured_params = Config.get_real_estate_config().get('visualisation').get('url_params')
         additional_url_params = {}
         for param in configured_params:

--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -231,7 +231,8 @@ class Renderer(Base):
             real_estate_dict['Reference'] = reference_list
 
         if self._params.flavour == 'full':
-            real_estate_dict['Highlight'] = self.format_map(real_estate.highlight)
+            if Config.get('full_extract_use_sld', True):
+                real_estate_dict['Highlight'] = self.format_map(real_estate.highlight)
 
         return real_estate_dict
 

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -171,6 +171,9 @@ pyramid_oereb:
         types:
         - GeometryCollection
 
+  # Configuration options for full extract
+  full_extract_use_sld: true
+
   # Configuration for OEREBlex
   oereblex:
     # OEREBlex host

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -171,7 +171,7 @@ pyramid_oereb:
         types:
         - GeometryCollection
 
-  # Configuration options for full extract
+  # Configuration option for full extract: apply SLD on land register WMS (defaults to true)
   full_extract_use_sld: true
 
   # Configuration for OEREBlex


### PR DESCRIPTION
Fix #1077

Tested on a cantonal infrastructure, as full extract can not be tested in local docker test environment.

C2C internal reference: GEO-3534