### PR TITLE
Simplify Makefile for recent python versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ MODEL_PK_TYPE_IS_STRING ?= true
 install: $(PYTHON_VENV)
 
 .venv/timestamp:
-	$(VIRTUALENV) --no-site-packages .venv
+	$(VIRTUALENV) .venv
 	touch $@
 
 .venv/requirements-timestamp: .venv/install-timestamp .venv/timestamp setup.py dev-requirements.txt


### PR DESCRIPTION
Change necessary for Python 3.7.
The option is no longer existing and was in fact not needed for older Python 3 versions (default behaviour since 2011, see https://virtualenv.pypa.io/en/16.7.9/changes.html#v1-7-2011-11-30)