### PR TITLE
Use UTF-8 encoding for test data for compatibility with Python 3.7

### DIFF
--- a/pyramid_oereb/standard/load_sample_data.py
+++ b/pyramid_oereb/standard/load_sample_data.py
@@ -55,7 +55,7 @@ class SampleData(object):
         if isinstance(value, bool):
             return "'t'" if value else "'f'"
         if isinstance(value, dict):
-            return cls._format_value(json.dumps(value))
+            return cls._format_value(json.dumps(value, ensure_ascii=False))
         raise "Unsupported type {}".format(type(value))
 
     def _do_sql_insert(self, sql, items):


### PR DESCRIPTION
This should fix the error that currently occurs in `make serve` with Python 3.7