### PR TITLE
Add test for empty geometry of intersection results (Python 3.7 support)

### DIFF
--- a/pyramid_oereb/lib/records/geometry.py
+++ b/pyramid_oereb/lib/records/geometry.py
@@ -131,49 +131,51 @@ class GeometryRecord(object):
         polygon_types = geometry_types.get('polygon').get('types')
         point_types = geometry_types.get('point').get('types')
         if self.published:
-            result = self._extract_collection(self.geom.intersection(real_estate.limit))
+            intersection = self.geom.intersection(real_estate.limit)
             # TODO upon update to Shapely 1.7, a check for result.is_emtpy will be needed (see PR#1037)
             # differentiate between Points and MultiPoint
-            if self.geom.type not in point_types + line_types + polygon_types:
-                supported_types = ', '.join(point_types + line_types + polygon_types)
-                raise AttributeError(
-                    u'The passed geometry is not supported: {type}. It should be one of: {types}'.format(
-                        type=self.geom.type, types=supported_types
+            if not intersection.is_empty:
+                result = self._extract_collection(intersection)
+                if self.geom.type not in point_types + line_types + polygon_types:
+                    supported_types = ', '.join(point_types + line_types + polygon_types)
+                    raise AttributeError(
+                        u'The passed geometry is not supported: {type}. It should be one of: {types}'.format(
+                            type=self.geom.type, types=supported_types
+                        )
                     )
-                )
-            elif self.geom.type in point_types:
-                if result.type == point_types[1]:
-                    # If it is a multipoint make a list and count the number of elements in the list
-                    self._nr_of_points = len(list(result.geoms))
-                    self._test_passed = True
-                elif result.type == point_types[0]:
-                    # If it is a single point the number of points is one
-                    self._nr_of_points = 1
-                    self._test_passed = True
-            elif self.geom.type in line_types and result.type in line_types:
-                self._units = length_unit
-                length_share = result.length
-                if length_share >= min_length:
-                    self._length_share = length_share
-                    self._test_passed = True
-            elif self.geom.type in polygon_types and result.type in polygon_types:
-                self._units = area_unit
-                area_share = result.area
-                compensated_area = area_share / real_estate.areas_ratio
-                if compensated_area >= min_area:
-                    self._area_share = compensated_area
-                    self._test_passed = True
-            else:
-                # This intersection result should not be used for the OEREB extract:
-                # for example, if two polygons are touching each other, the intersection geometry will be
-                # the point or linestring representing the touching part.
-                log.debug(
-                    u'Intersection result changed geometry type. '
-                    u'Original geometry was {0} and result is {1}'.format(
-                        self.geom.type,
-                        result.type
+                elif self.geom.type in point_types:
+                    if result.type == point_types[1]:
+                        # If it is a multipoint make a list and count the number of elements in the list
+                        self._nr_of_points = len(list(result.geoms))
+                        self._test_passed = True
+                    elif result.type == point_types[0]:
+                        # If it is a single point the number of points is one
+                        self._nr_of_points = 1
+                        self._test_passed = True
+                elif self.geom.type in line_types and result.type in line_types:
+                    self._units = length_unit
+                    length_share = result.length
+                    if length_share >= min_length:
+                        self._length_share = length_share
+                        self._test_passed = True
+                elif self.geom.type in polygon_types and result.type in polygon_types:
+                    self._units = area_unit
+                    area_share = result.area
+                    compensated_area = area_share / real_estate.areas_ratio
+                    if compensated_area >= min_area:
+                        self._area_share = compensated_area
+                        self._test_passed = True
+                else:
+                    # This intersection result should not be used for the OEREB extract:
+                    # for example, if two polygons are touching each other, the intersection geometry will be
+                    # the point or linestring representing the touching part.
+                    log.debug(
+                        u'Intersection result changed geometry type. '
+                        u'Original geometry was {0} and result is {1}'.format(
+                            self.geom.type,
+                            result.type
+                        )
                     )
-                )
         self.calculated = True
         return self._test_passed
 


### PR DESCRIPTION
With Python 3.7 there is currently a failed test, test_geometry for geometry9: the `Point(2, 2)` is evaluated as in the polygon `MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))])`). After trying with my local installations of Python, I saw that the type of the return values for shapely intersection in case of empty intersection appears to be different (in both cases version 1.6.4.post1). In Python 3.6 the return value of the shapely function was an empty GeometryCollection and in 3.7 it is an empty Point. I added a test for empty geometry similarly to fc260fde8dc559390edc4ca5f0fb61cb4f0776bb which solved this issue, but I think further testing of this issue on other installations would be a nice