### PR TITLE
Oereblex: add per PLR configurable URL parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 ---------
 
+1.9.0 (DRAFT)
+*************
+- Oereblex: add configuration to pass URL parameters to the oereblex call (#1117)
+- Improve handling of empty geometries, in preparation of library updates (#1107)
+
 1.8.1
 *****
 - Update of external libraries such as numpy, SQLAlchemy, lxml, and more.

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -7,6 +7,15 @@ This chapter will give you hints on how to handle version migration, in particul
 to adapt in your project configuration, database etc. when upgrading to a new version.
 
 
+.. _changes-version-1.9.0:
+
+Version 1.9.0 (DRAFT)
+---------------------
+
+ * Oereblex: add configuration to pass URL parameters to the oereblex call (#1117)
+ * Improve handling of empty geometries, in preparation of library updates (#1107)
+
+
 .. _changes-version-1.8.1:
 
 Version 1.8.1

--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -195,7 +195,7 @@ vars:
       related_decree_as_main: false
       # Same as related_decree_as_main but for related notice document.
       related_notice_as_main: false
-    # Proxy to be used for web requests
+      # Proxy to be used for web requests
       # proxy:
       #   http:
       #   https:
@@ -203,6 +203,10 @@ vars:
       # auth:
       #   username:
       #   password:
+      # Additional URL parameters to pass, depending on the PLR theme
+      # url_param_config:
+      # - code: ForestPerimeters
+      #   url_param: 'oereb_id=5'
 
     # Defines the information of the oereb cadastre providing authority. Please change this to your data. This
     # will be directly used for producing the extract output.

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -88,10 +88,14 @@ class OEREBlexSource(Base):
             geolink_id (int): The geoLink ID.
             oereblex_params (string): Any additional parameters to pass to Oereblex
         """
-        log.debug("read() start")
+        log.debug("read() start for geolink_id {}, oereblex_params {}".format(geolink_id, oereblex_params))
+
+        url_base = '{host}/api/{version}geolinks/{id}.xml'
+        if oereblex_params:
+            url_base = url_base + '?' + oereblex_params
 
         # Request documents
-        url = '{host}/api/{version}geolinks/{id}.xml?{url_params}'.format(
+        url = url_base.format(
             host=self._parser.host_url,
             version=self._version + '/' if self._pass_version else '',
             id=geolink_id,

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -78,6 +78,12 @@ class OEREBlexSource(Base):
             raise AssertionError('host_url has to be defined')
 
         self._url_param_config = kwargs.get('url_param_config')
+        if self._url_param_config:
+            if not (isinstance(self._url_param_config, list)):
+                raise AssertionError('url_param_config is of wrong type {}, should be list'.format(type(self._url_param_config)))
+            for list_entry in self._url_param_config:
+                if not (isinstance(list_entry, dict)):
+                    raise AssertionError('url_param_config list entry is of wrong type {}, should be dictionary'.format(type(list_entry)))
 
     def read(self, params, geolink_id, oereblex_params=None):
         """

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -36,6 +36,7 @@ class OEREBlexSource(Base):
             auth (dict of str): Optional credentials for basic authentication. Requires `username`
                 and `password` to be defined.
             validation (bool): Turn XML validation on/off. Default is true.
+            url_param_config (list of code and url_param): Optional url parameters to use, per plr code
 
         """
         super(OEREBlexSource, self).__init__()
@@ -76,22 +77,27 @@ class OEREBlexSource(Base):
         if self._parser.host_url is None:
             raise AssertionError('host_url has to be defined')
 
-    def read(self, params, geolink_id):
+        self._url_param_config = kwargs.get('url_param_config')
+
+    def read(self, params, geolink_id, oereblex_params=None):
         """
         Requests the geoLink for the specified ID and returns records for the received documents.
 
         Args:
             params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             geolink_id (int): The geoLink ID.
+            oereblex_params (string): Any additional parameters to pass to Oereblex
         """
         log.debug("read() start")
 
         # Request documents
-        url = '{host}/api/{version}geolinks/{id}.xml'.format(
+        url = '{host}/api/{version}geolinks/{id}.xml?{url_params}'.format(
             host=self._parser.host_url,
             version=self._version + '/' if self._pass_version else '',
-            id=geolink_id
+            id=geolink_id,
+            url_params=oereblex_params
         )
+
         language = params.language or self._language
         request_params = {
             'locale': language

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -80,10 +80,12 @@ class OEREBlexSource(Base):
         self._url_param_config = kwargs.get('url_param_config')
         if self._url_param_config:
             if not (isinstance(self._url_param_config, list)):
-                raise AssertionError('url_param_config is of wrong type {}, should be list'.format(type(self._url_param_config)))
+                raise AssertionError('url_param_config is of wrong type {}, should be list'
+                                     .format(type(self._url_param_config)))
             for list_entry in self._url_param_config:
                 if not (isinstance(list_entry, dict)):
-                    raise AssertionError('url_param_config list entry is of wrong type {}, should be dictionary'.format(type(list_entry)))
+                    raise AssertionError('url_param_config list entry is of wrong type {},'
+                                         ' should be dictionary'.format(type(list_entry)))
 
     def read(self, params, geolink_id, oereblex_params=None):
         """

--- a/pyramid_oereb/contrib/sources/plr_oereblex.py
+++ b/pyramid_oereb/contrib/sources/plr_oereblex.py
@@ -59,7 +59,7 @@ class DatabaseOEREBlexSource(DatabaseSource):
         url_param_config = self._oereblex_source._url_param_config
         if url_param_config:
             plr_code = self._theme_record.code
-            oereblex_params = self.get_config_value_for_plr_code(url_param_config, plr_code)
+            oereblex_params = DatabaseOEREBlexSource.get_config_value_for_plr_code(url_param_config, plr_code)
         return self.document_records_from_oereblex(params, public_law_restriction_from_db.geolink,
                                                    oereblex_params)
 
@@ -71,6 +71,7 @@ class DatabaseOEREBlexSource(DatabaseSource):
         Args:
             params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
             lexlink (int): The ID of the geoLink to request the documents for.
+            oereblex_params (string): URL parameter to add to the oereblex request
 
         Returns:
             list of pyramid_oereb.lib.records.documents.DocumentRecord:

--- a/pyramid_oereb/contrib/sources/plr_oereblex.py
+++ b/pyramid_oereb/contrib/sources/plr_oereblex.py
@@ -76,7 +76,8 @@ class DatabaseOEREBlexSource(DatabaseSource):
             list of pyramid_oereb.lib.records.documents.DocumentRecord:
                 The documents created from the parsed OEREBlex response.
         """
-        log.debug("document_records_from_oereblex() start, lexlink {}, oereblex_params {}".format(lexlink, oereblex_params))
+        log.debug("document_records_from_oereblex() start, lexlink {}, oereblex_params {}"
+                  .format(lexlink, oereblex_params))
         if lexlink in self._queried_lexlinks:
             log.debug('skip querying this lexlink "{}" because it was fetched already.'.format(lexlink))
             log.debug('use already queried instead')

--- a/pyramid_oereb/contrib/sources/plr_oereblex.py
+++ b/pyramid_oereb/contrib/sources/plr_oereblex.py
@@ -44,7 +44,11 @@ class DatabaseOEREBlexSource(DatabaseSource):
         """
         for url_param_entry in url_param_config:
             if url_param_entry['code'] == plr_code:
-                return url_param_entry['url_param']
+                if 'url_param' in url_param_entry:
+                    return url_param_entry['url_param']
+                else:
+                    log.warning("Incorrect configuration: missing url_param for entry {}".format(plr_code))
+                    return None
         return None
 
     def get_document_records(self, params, public_law_restriction_from_db):
@@ -72,7 +76,7 @@ class DatabaseOEREBlexSource(DatabaseSource):
             list of pyramid_oereb.lib.records.documents.DocumentRecord:
                 The documents created from the parsed OEREBlex response.
         """
-        log.debug("document_records_from_oereblex() start")
+        log.debug("document_records_from_oereblex() start, lexlink {}, oereblex_params {}".format(lexlink, oereblex_params))
         if lexlink in self._queried_lexlinks:
             log.debug('skip querying this lexlink "{}" because it was fetched already.'.format(lexlink))
             log.debug('use already queried instead')

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -204,6 +204,10 @@ pyramid_oereb:
     #   password:
     # Enable/disable XML validation
     validation: true
+    # Additional URL parameters to pass, depending on the PLR theme
+    # url_param_config:
+    # - code: ForestPerimeters
+    #   url_param: 'oereb_id=5'
 
   # Defines the information of the oereb cadastre providing authority. Please change this to your data. This
   # will be directly used for producing the extract output.

--- a/tests/sources/test_document_oereblex.py
+++ b/tests/sources/test_document_oereblex.py
@@ -31,6 +31,24 @@ from tests.mockrequest import MockParameter
     (False, {
         'host': 'http://oereblex.example.com',
         'language': 'de'
+    }),
+    (True, {
+        'host': 'http://oereblex.example.com',
+        'language': 'de',
+        'canton': 'BL',
+        'url_param_config': [{'code': 'ForestPerimeters', 'url_param': 'oereb_id=5'}, {'code': 'LandUsePlans', 'url_param': 'oereb_id=15'}]
+    }),
+    (False, {
+        'host': 'http://oereblex.example.com',
+        'language': 'de',
+        'canton': 'BL',
+        'url_param_config': {'code': 'ForestPerimeters', 'url_param': 'oereb_id=5'}
+    }),
+    (False, {
+        'host': 'http://oereblex.example.com',
+        'language': 'de',
+        'canton': 'BL',
+        'url_param_config': ['oereb_id=5', 'oereb_id=15']
     })
 ])
 def test_init(valid, cfg):

--- a/tests/sources/test_document_oereblex.py
+++ b/tests/sources/test_document_oereblex.py
@@ -36,7 +36,8 @@ from tests.mockrequest import MockParameter
         'host': 'http://oereblex.example.com',
         'language': 'de',
         'canton': 'BL',
-        'url_param_config': [{'code': 'ForestPerimeters', 'url_param': 'oereb_id=5'}, {'code': 'LandUsePlans', 'url_param': 'oereb_id=15'}]
+        'url_param_config': [{'code': 'ForestPerimeters', 'url_param': 'oereb_id=5'},
+                             {'code': 'LandUsePlans', 'url_param': 'oereb_id=15'}]
     }),
     (False, {
         'host': 'http://oereblex.example.com',


### PR DESCRIPTION
Fix #1065
Supersede #1085 

New functionality to be able to add an (optional) URL parameter string for oereblex calls, to be able to use "oereb_id" parameter, or any other parameters in the future in a generic way.

In the proposal of this PR, the parameter string can be configured per PLR Theme within the oereblex configuration section (See discussion in #1085)