### PR TITLE
Restrict version of numpy to maintain Python 3.6 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ requests==2.25.1
 geolink-formatter==1.5.3
 pyconizer==0.1.4
 tqdm==4.56.0
-numpy==1.19.5
+numpy==1.19.5 # rq.filter: <1.20.0
 defusedxml==0.6.0


### PR DESCRIPTION
Fix #1120 
(workaround as long as pyramid_oereb officially supports Python 3.6)