### PR TITLE
Use cp instead of volume to preserve user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,11 @@ export PRINT_BACKEND = MapFishPrint # Set to XML2PDF if preferred
 	@echo Run tests using docker: $(USE_DOCKER)
 	docker stop $(DOCKER_CONTAINER_BASE)-tests || true
 	docker build -t $(DOCKER_CONTAINER_BASE)-tests --build-arg PYTHON_TEST_VERSION=${PYTHON_TEST_VERSION} --file tests.Dockerfile .
-	mkdir -p coverage_report
-	docker run -t -v $(shell pwd)/coverage_report:/app/coverage_report --env "TERM=xterm-256color" $(DOCKER_CONTAINER_BASE)-tests /bin/bash -c \
-	  "${PYTHON_TEST_VERSION} -m pytest -vv --cov-config .coveragerc --cov-report term-missing:skip-covered --cov pyramid_oereb tests; \
-	  coverage html"
+	docker run -dt --rm --env "TERM=xterm-256color" --name $(DOCKER_CONTAINER_BASE)-tests $(DOCKER_CONTAINER_BASE)-tests tail -f /dev/null
+	docker exec -ti $(DOCKER_CONTAINER_BASE)-tests ${PYTHON_TEST_VERSION} -m pytest -vv --cov-config .coveragerc --cov-report term-missing:skip-covered --cov pyramid_oereb tests
+	docker exec -ti $(DOCKER_CONTAINER_BASE)-tests coverage html
+	docker cp $(DOCKER_CONTAINER_BASE)-tests:/app/coverage_report ./
+	docker stop $(DOCKER_CONTAINER_BASE)-tests
 
 .PHONY: lint
 lint: $(PYTHON_VENV)


### PR DESCRIPTION
For  #1100 (GSPOE-40)

Copy coverage and preserve user. Without this PR the user of coverage files is root.

I use `docker run exec -ti <container_name> tail -f /dev/null` to never stop the container. That allow me to use docker exec to run tests and `docker cp` (then I stop the container).

Another possibility would be to use `--user` with docker run but I got errors with pytest (file not accessible for my user, I don't want to start resolving this kind of issues...) 