### PR TITLE
Restrict version of cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ SQLAlchemy==1.3.23
 sqlalchemy-utils==0.36.8
 transaction==3.0.1
 urllib3[secure]==1.26.3
+cryptography==3.3.2 # rq.filter: <3.4
 waitress==1.4.4
 zope.sqlalchemy==1.3
 jsonschema==3.2.0


### PR DESCRIPTION
Fix the daily build:

Restrict version of cryptography, required by urllib. Newest version of 3.4 is not compatible with pyramid_oereb build process.