### PR TITLE
Add configuration option for print header

### DIFF
--- a/docker/config.yaml.mako
+++ b/docker/config.yaml.mako
@@ -133,6 +133,8 @@ vars:
       # and used by the print.
       # wms_url_keep_params:
       #   - ogcserver
+      # Flag to print or not the canton logo
+      print_canton_logo: true
   % endif
 
   # The "app_schema" property contains only one sub property "name". This is directly related to the database

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -544,6 +544,8 @@ class Renderer(JsonRenderer):
                 if 'NrOfPoints' in legend:
                     legend['NrOfPoints'] = '{0}'.format(legend['NrOfPoints'])
 
+        extract_dict['PrintCantonLogo'] = Config.get('print', {}).get('print_canton_logo', True)
+
         log.debug("After transformation, extract_dict is {}".format(extract_dict))
         return extract_dict
 

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -132,6 +132,8 @@ pyramid_oereb:
     # and used by the print.
     # wms_url_keep_params:
     #   - ogcserver
+    # Flag to print or not the canton logo
+    print_canton_logo: true
 % endif
 
   # The "app_schema" property contains only one sub property "name". This is directly related to the database

--- a/tests/contrib/print_proxy/resources/expected_getspec_extract.json
+++ b/tests/contrib/print_proxy/resources/expected_getspec_extract.json
@@ -794,5 +794,6 @@
   "RealEstate_IdentDN": "BL0200002766",
   "CreationDate": "16.02.2018",
   "RealEstate_EGRID": "CH874978848203",
-  "BaseData": "Daten der amtlichen Vermessung, Stand 27.01.2018."
+  "BaseData": "Daten der amtlichen Vermessung, Stand 27.01.2018.",
+  "PrintCantonLogo": true
 }


### PR DESCRIPTION
Add new flag in printable extract to be able to hide canton logo from PDF header (GEO-4197)