### PR TITLE
Update dependency of psycopg, avoid binary package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM camptocamp/c2cwsgiutils:3
 LABEL maintainer "info@camptocamp.org"
 
 WORKDIR /app
-ARG DEV_PACKAGES="python3.7-dev build-essential libgeos-dev"
+ARG DEV_PACKAGES="libgeos-c1v5 libpq-dev"
+ARG PYTHON_DEV_PACKAGES="python3.7-dev build-essential"
 
 # The full pdf extract functionality requires pdftk, but this library is not available in Ubuntu bionic.
 # Note that it is expected that the full pdf extract functionality will be removed from the next
@@ -18,9 +19,9 @@ COPY requirements.txt /app/
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-recommends \
-        libgeos-c1v5 ${DEV_PACKAGES} && \
+        ${DEV_PACKAGES} ${PYTHON_DEV_PACKAGES} && \
     pip install --disable-pip-version-check --no-cache-dir --requirement requirements.txt --requirement docker/requirements.txt && \
-    apt remove --purge --autoremove --yes ${DEV_PACKAGES} binutils && \
+    apt remove --purge --autoremove --yes ${PYTHON_DEV_PACKAGES} binutils && \
     apt-get clean && \
     rm --force --recursive /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM camptocamp/c2cwsgiutils:3
 LABEL maintainer "info@camptocamp.org"
 
 WORKDIR /app
+
 ARG DEV_PACKAGES="libgeos-c1v5 libpq-dev"
 ARG PYTHON_DEV_PACKAGES="python3.7-dev build-essential"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 OPERATING_SYSTEM ?= LINUX
 PYTHON_VERSION ?= python3
 PYTHON_TEST_VERSION ?= python3.7
-DEV_PACKAGES = "libgeos-c1v5 libpq-dev"
 VIRTUALENV = virtualenv --python=$(PYTHON_VERSION)
 USE_DOCKER ?= TRUE
 DOCKER_BASE = openoereb/oereb
@@ -111,7 +110,7 @@ export PRINT_BACKEND = MapFishPrint # Set to XML2PDF if preferred
 .coverage: $(PYTHON_VENV) $(TESTS_DROP_DB) $(TESTS_SETUP_DB) pyramid_oereb/standard/pyramid_oereb.yml
 	@echo Run tests using docker: $(USE_DOCKER)
 	docker stop $(DOCKER_CONTAINER_BASE)-tests || true
-	docker build -t $(DOCKER_CONTAINER_BASE)-tests --build-arg PYTHON_TEST_VERSION=${PYTHON_TEST_VERSION} --build-arg DEV_PACKAGES=${DEV_PACKAGES} --file tests.Dockerfile .
+	docker build -t $(DOCKER_CONTAINER_BASE)-tests --build-arg PYTHON_TEST_VERSION=${PYTHON_TEST_VERSION} --file tests.Dockerfile .
 	docker run -dt --rm --env "TERM=xterm-256color" --name $(DOCKER_CONTAINER_BASE)-tests $(DOCKER_CONTAINER_BASE)-tests tail -f /dev/null
 	docker exec -t $(DOCKER_CONTAINER_BASE)-tests ${PYTHON_TEST_VERSION} -m pytest -vv --cov-config .coveragerc --cov-report term-missing:skip-covered --cov pyramid_oereb tests
 	docker exec -t $(DOCKER_CONTAINER_BASE)-tests coverage html

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 OPERATING_SYSTEM ?= LINUX
 PYTHON_VERSION ?= python3
 PYTHON_TEST_VERSION ?= python3.7
+DEV_PACKAGES = "libgeos-c1v5 libpq-dev"
 VIRTUALENV = virtualenv --python=$(PYTHON_VERSION)
 USE_DOCKER ?= TRUE
 DOCKER_BASE = openoereb/oereb
@@ -110,7 +111,7 @@ export PRINT_BACKEND = MapFishPrint # Set to XML2PDF if preferred
 .coverage: $(PYTHON_VENV) $(TESTS_DROP_DB) $(TESTS_SETUP_DB) pyramid_oereb/standard/pyramid_oereb.yml
 	@echo Run tests using docker: $(USE_DOCKER)
 	docker stop $(DOCKER_CONTAINER_BASE)-tests || true
-	docker build -t $(DOCKER_CONTAINER_BASE)-tests --build-arg PYTHON_TEST_VERSION=${PYTHON_TEST_VERSION} --file tests.Dockerfile .
+	docker build -t $(DOCKER_CONTAINER_BASE)-tests --build-arg PYTHON_TEST_VERSION=${PYTHON_TEST_VERSION} --build-arg DEV_PACKAGES=${DEV_PACKAGES} --file tests.Dockerfile .
 	docker run -dt --rm --env "TERM=xterm-256color" --name $(DOCKER_CONTAINER_BASE)-tests $(DOCKER_CONTAINER_BASE)-tests tail -f /dev/null
 	docker exec -t $(DOCKER_CONTAINER_BASE)-tests ${PYTHON_TEST_VERSION} -m pytest -vv --cov-config .coveragerc --cov-report term-missing:skip-covered --cov pyramid_oereb tests
 	docker exec -t $(DOCKER_CONTAINER_BASE)-tests coverage html

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 pyflakes==2.3.1
 flake8==3.9.2
 pycodestyle==2.7.0
-psycopg2==2.8.6
+psycopg2==2.9.1
 McCabe==0.6.1
 c2c.template==2.0.5  # rq.filter: <= 2.0.5
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyPDF2==1.26.0
 dicttoxml==1.7.4
 filetype==1.0.7
 geoalchemy2==0.8.5 # rq.filter: <0.9
-psycopg2-binary==2.8.6
+psycopg2==2.9.1
 pyramid==1.10.8 # rq.filter: <2
 pyramid-debugtoolbar==4.9
 PyYAML==5.4.1

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && \
 
 COPY requirements.txt requirements-tests.txt /app/
 
-ARG DEV_PACKAGES
+ARG DEV_PACKAGES="libgeos-c1v5 libpq-dev"
 ARG PYTHON_TEST_VERSION
 ENV PYTHON_DEV_PACKAGE=${PYTHON_TEST_VERSION}-dev
 RUN apt update && \

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -4,15 +4,15 @@ LABEL maintainer "info@camptocamp.org"
 WORKDIR /app
 
 RUN apt update && \
-    apt install --yes --no-install-recommends build-essential libgeos-c1v5
+    apt install --yes --no-install-recommends build-essential
 
 COPY requirements.txt requirements-tests.txt /app/
 
+ARG DEV_PACKAGES
 ARG PYTHON_TEST_VERSION
 ENV PYTHON_DEV_PACKAGE=${PYTHON_TEST_VERSION}-dev
-
 RUN apt update && \
-    apt install --yes ${PYTHON_DEV_PACKAGE} && \
+    apt install --yes ${PYTHON_DEV_PACKAGE} ${DEV_PACKAGES} && \
     ${PYTHON_TEST_VERSION} -m pip install  --disable-pip-version-check --no-cache-dir --requirement requirements.txt --requirement requirements-tests.txt && \
     apt-get clean && \
     rm --force --recursive /var/lib/apt/lists/*


### PR DESCRIPTION
Update dependency of psycopg, avoid binary package as it is no longer working and it is anyway not recommended to use in production.

Fixes broken update of #1232