### PR TITLE
Create Theme element

### DIFF
--- a/pyramid_oereb/lib/config.py
+++ b/pyramid_oereb/lib/config.py
@@ -9,7 +9,8 @@ from pyramid.config import ConfigurationError
 from pyramid_oereb.lib.adapter import FileAdapter
 from pyramid_oereb.lib.records.office import OfficeRecord
 from pyramid_oereb.lib.records.image import ImageRecord
-from pyramid_oereb.lib.records.theme import ThemeRecord
+from pyramid_oereb.lib.readers.theme import ThemeReader
+from sqlalchemy.exc import ProgrammingError
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +23,7 @@ class Config(object):
     """
 
     _config = None
+    themes = None
 
     @staticmethod
     def init(configfile, configsection, c2ctemplate_style=False):
@@ -35,6 +37,7 @@ class Config(object):
         assert Config._config is None
 
         Config._config = _parse(configfile, configsection, c2ctemplate_style)
+        Config.init_themes()
 
     @staticmethod
     def get_config():
@@ -51,6 +54,25 @@ class Config(object):
         settings.update(Config._config)
 
     @staticmethod
+    def init_themes():
+        try:
+            Config.themes = Config._read_themes()
+        # When initializing the database (create_tables), the table 'theme' does not exist yet
+        except ProgrammingError:
+            Config.themes = None
+
+    @staticmethod
+    def _read_themes():
+        theme_config = Config.get_theme_config()
+        if theme_config is None:
+            raise ConfigurationError("Missing configuration for themes")
+        theme_reader = ThemeReader(
+            theme_config.get('source').get('class'),
+            **Config.get_theme_config().get('source').get('params')
+        )
+        return theme_reader.read()
+
+    @staticmethod
     def get_themes():
         """
         Returns a list of available themes.
@@ -59,20 +81,10 @@ class Config(object):
             list of pyramid_oereb.lib.records.theme.ThemeRecord: The available themes.
         """
         assert Config._config is not None
-
-        result = []
-        plrs = Config._config.get('plrs')
-        if plrs and isinstance(plrs, list):
-            for position, theme in enumerate(plrs, start=1):
-                result.append(ThemeRecord(
-                    theme.get('code'),
-                    theme.get('text'),
-                    position
-                ))
-        return result
+        return Config.themes
 
     @staticmethod
-    def get_theme(code):
+    def get_theme_by_code(code):
         """
         Returns the theme with the specified code.
 
@@ -83,18 +95,12 @@ class Config(object):
             pyramid_oereb.lib.records.theme.ThemeRecord or None: The theme with the specified
             code.
         """
-        assert Config._config is not None
-
-        plrs = Config._config.get('plrs')
-        if plrs and isinstance(plrs, list):
-            for position, theme in enumerate(plrs, start=1):
-                if theme.get('code') == code:
-                    return ThemeRecord(
-                        theme.get('code'),
-                        theme.get('text'),
-                        position
-                    )
-        return None
+        if Config.themes is None:
+            raise ConfigurationError("Themes have not been initialized")
+        for theme in Config.themes:
+            if theme.code == code:
+                return theme
+        raise ConfigurationError(f"Theme {code} not found in the application configuration")
 
     @staticmethod
     def get_theme_thresholds(code):
@@ -225,6 +231,18 @@ class Config(object):
         assert Config._config is not None
 
         return Config._config.get('address')
+
+    @staticmethod
+    def get_theme_config():
+        """
+        Returns a dictionary of the configured theme settings.
+
+        Returns:
+            dict: The configured theme settings.
+        """
+        assert Config._config is not None
+
+        return Config._config.get('theme')
 
     @staticmethod
     def get_glossary_config():

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -138,7 +138,7 @@ class ExtractReader(object):
 
         else:
             for plr_source in self._plr_sources_:
-                themes_without_data.append(Config.get_theme(plr_source.info.get('code')))
+                themes_without_data.append(Config.get_theme_by_code(plr_source.info.get('code')))
 
         # Load base data form configuration
         resolver = DottedNameResolver()

--- a/pyramid_oereb/lib/readers/theme.py
+++ b/pyramid_oereb/lib/readers/theme.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from pyramid.path import DottedNameResolver
+
+
+class ThemeReader(object):
+    """
+    The central reader for the theme definitions. It is directly bound to a so called source
+    which is defined by a pythonic dotted string to the class definition of this source.
+    An instance of the passed source will be created on instantiation of this reader class by passing through
+    the parameter kwargs.
+    """
+
+    def __init__(self, dotted_source_class_path, **params):
+        """
+        Args:
+            dotted_source_class_path
+                (str or pyramid_oereb.lib.sources.theme.ThemeBaseSource): The path to
+                the class which represents the source used by this reader. This class must
+                exist and it must implement basic source behaviour of the
+                :ref:`api-pyramid_oereb-lib-sources-theme-themebasesource`.
+            (kwargs): kwargs, which are necessary as configuration parameter for the above by
+                dotted name defined class.
+        """
+        source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
+        self._source_ = source_class(**params)
+
+    def read(self):
+        """
+        The central read accessor method to get all desired records from configured source.
+
+        .. note:: If you subclass this class your implementation needs to offer this method in the same
+            signature. Means the parameters must be the same and the return must be a list of
+            :ref:`api-pyramid_oereb-lib-records-theme-themerecord`. Otherwise the API like way
+            the server works would be broken.
+
+        Returns:
+            list of pyramid_oereb.lib.records.theme.ThemeRecord:
+                The list of found records. Since these are not filtered by any criteria the list simply
+                contains all records delivered by the source.
+        """
+        self._source_.read()
+        return self._source_.records

--- a/pyramid_oereb/lib/records/theme.py
+++ b/pyramid_oereb/lib/records/theme.py
@@ -5,22 +5,20 @@ import warnings
 class ThemeRecord(object):
     """Creates a new theme record."""
 
-    def __init__(self, code, text, position=None):
+    def __init__(self, code, title, extract_index):
         """
         Args:
             code (unicode): The theme's code.
-            text (dict of unicode): The multilingual description.
-            position (int or None): Position of the theme (within the list of themes)
-            data_owner (pyramid_oereb.lib.records.office.OfficeRecord):
-            transfer_from_source (datetime.date): The actuality of the themes data
+            title (dict of unicode): The multilingual description.
+            extract_index (int): Index to sort themes in the extract
         """
-        if not isinstance(text, dict):
-            warnings.warn('Type of "text" should be "dict"')
+        if not isinstance(title, dict):
+            warnings.warn('Type of "title" should be "dict"')
 
         self.code = code
-        self.text = text
-        self.position = position
+        self.title = title
+        self.extract_index = extract_index
 
     def __str__(self):
-        return '<{} -- code: {} text: {} position: {}>'.format(self.__class__.__name__,
-                                                               self.code, self.text, self.position)
+        return '<{} -- code: {} title: {} extract index: {}>'.format(
+            self.__class__.__name__, self.code, self.title, self.extract_index)

--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -444,7 +444,7 @@ class Renderer(Base):
         """
         theme_dict = {
             'Code': theme.code,
-            'Text': self.get_localized_text(theme.text)
+            'Text': self.get_localized_text(theme.title)
         }
         return theme_dict
 

--- a/pyramid_oereb/lib/renderer/extract/templates/xml/theme.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/theme.xml
@@ -1,5 +1,5 @@
 <%page args="theme"/>
 <data:Code>${theme.code | x}</data:Code>
 <data:Text>
-    <%include file="localized_text.xml" args="text=theme.text"/>
+    <%include file="localized_text.xml" args="text=theme.title"/>
 </data:Text>

--- a/pyramid_oereb/lib/sources/theme.py
+++ b/pyramid_oereb/lib/sources/theme.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from pyramid_oereb.lib.sources import Base
+from pyramid_oereb.lib.records.theme import ThemeRecord
+
+
+class ThemeBaseSource(Base):
+    """
+    Base class for theme sources.
+
+    Attributes:
+        records (list of pyramid_oereb.lib.records.theme.ThemeRecord): List of theme records.
+    """
+    _record_class_ = ThemeRecord
+
+    def read(self):
+        """
+        Every theme source has to implement a read method. This method must accept no parameters. Because
+        it should deliver all items available.
+        If you want adapt to your own source for themes, this is the point where to hook in.
+        """
+        pass  # pragma: no cover

--- a/pyramid_oereb/standard/load_sample_data.py
+++ b/pyramid_oereb/standard/load_sample_data.py
@@ -110,6 +110,10 @@ class SampleData(object):
 
             # Truncate tables
             self._connection.execute('TRUNCATE {schema}.{table} CASCADE;'.format(
+                schema=schema.Theme.__table__.schema,
+                table=schema.Theme.__table__.name
+            ))
+            self._connection.execute('TRUNCATE {schema}.{table} CASCADE;'.format(
                 schema=schema.Glossary.__table__.schema,
                 table=schema.Glossary.__table__.name
             ))
@@ -183,13 +187,24 @@ class SampleData(object):
         except KeyError as e:
             raise Exception(f"Missing model in YAML configuration file: {e}")
 
-        from pyramid_oereb.standard.models.main import RealEstate, Address, Municipality, \
+        from pyramid_oereb.standard.models.main import Theme, RealEstate, Address, Municipality, \
             Glossary, ExclusionOfLiability
 
         if self._sql_file is None:
             self._connection = self._engine.connect()
 
         try:
+
+            # Fill tables with sample data
+            for class_, file_name in [
+                (Theme, 'themes.json'),
+                (RealEstate, 'real_estates.json'),
+                (Address, 'addresses.json'),
+                (Municipality, 'municipalities_with_logo.json'),
+                (Glossary, 'glossary.json'),
+                (ExclusionOfLiability, 'exclusion_of_liability.json')
+            ]:
+                self._load_sample(class_, file_name)
 
             for schema, folder in [
                 (contaminated_public_transport_sites, "contaminated_public_transport_sites"),
@@ -202,7 +217,6 @@ class SampleData(object):
                 # Truncate existing tables
                 self._truncate_existing(schema)
 
-                # Fill tables with sample data
                 for class_, file_name in [
                     (schema.Availability, 'availabilities.json'),
                     (schema.Office, 'office.json'),
@@ -220,15 +234,6 @@ class SampleData(object):
                         (schema.PublicLawRestrictionDocument, 'public_law_restriction_document.json')
                     ]:
                         self._load_sample(class_, os.path.join('plr119', folder, file_name))
-
-            for class_, file_name in [
-                (RealEstate, 'real_estates.json'),
-                (Address, 'addresses.json'),
-                (Municipality, 'municipalities_with_logo.json'),
-                (Glossary, 'glossary.json'),
-                (ExclusionOfLiability, 'exclusion_of_liability.json')
-            ]:
-                self._load_sample(class_, file_name)
 
         finally:
             if self._has_connection():

--- a/pyramid_oereb/standard/models/main.py
+++ b/pyramid_oereb/standard/models/main.py
@@ -39,6 +39,24 @@ app_schema_name = Config.get('app_schema').get('name')
 srid = Config.get('srid')
 
 
+class Theme(Base):
+    """
+    Insert description here
+
+    Attributes:
+        id (int):
+        code (str):
+        title (dict):
+        extract_index (int):
+    """
+    __table_args__ = {'schema': app_schema_name}
+    __tablename__ = 'theme'
+    id = sa.Column(sa.Integer, primary_key=True, autoincrement=False)
+    code = sa.Column(sa.String, unique=True, nullable=False)
+    title = sa.Column(JSONType, nullable=False)
+    extract_index = sa.Column(sa.Integer, nullable=False)
+
+
 class Municipality(Base):
     """
     The municipality is the place where you hold the information about all the municipalities you are having

--- a/pyramid_oereb/standard/models/main.py
+++ b/pyramid_oereb/standard/models/main.py
@@ -41,13 +41,14 @@ srid = Config.get('srid')
 
 class Theme(Base):
     """
-    Insert description here
+    The OEREB themes of the application
 
     Attributes:
-        id (int):
-        code (str):
-        title (dict):
-        extract_index (int):
+        id (int): identifier, used in the database only
+        code (str): OEREB code of the theme - unique and used to link each PublicLawRestriction
+            with the corresponding theme
+        title (dict): the title of the theme as a multilingual dictionary
+        extract_index (int): index to sort the themes in the extract, defined in the specification
     """
     __table_args__ = {'schema': app_schema_name}
     __tablename__ = 'theme'

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -377,6 +377,23 @@ pyramid_oereb:
         # The model which maps the municipality database table.
         model: pyramid_oereb.standard.models.main.Municipality
 
+  # The processor of the oereb project needs access to theme data. In the standard configuration this
+  # is assumed to be read from a database. Hint: If you want to read the themes out of an existing database
+  # table to avoid imports of this data every time it gets updates, you only need to change the model bound to
+  # the source. The model must implement the same field names and information as the default model does.
+  theme:
+    # The themes must have a property source.
+    source:
+      # The source must have a class which represents the accessor to the source. In this example, it is an
+      # already implemented source which reads data from a database.
+      class: pyramid_oereb.standard.sources.theme.DatabaseSource
+      # The necessary parameters to use this class
+      params:
+        # The connection path where the database can be found
+        db_connection: *main_db_connection
+        # The model which maps the theme database table.
+        model: pyramid_oereb.standard.models.main.Theme
+
   # The processor of the oereb project needs access to glossary data. In the standard configuration this
   # is assumed to be read from a database. Hint: If you want to read the glossary out of an existing database
   # table to avoid imports of this data every time it gets updates, you only need to change the model bound to
@@ -466,12 +483,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Nutzungsplanung (kantonal/kommunal)
-        fr: Plans d'affectation (cantonaux/communaux)
-        it: Piani di utilizzazione (cantonali/comunali)
-        rm: Planisaziun d'utilisaziun (chantunal/communal)
-        en: Land-use planning (cantonal / municipal)
       language: de
       federal: false
       standard: true
@@ -504,12 +515,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Projektierungszonen Nationalstrassen
-        fr: Zones réservées des routes nationales
-        it: Zone riservate per le strade nazionali
-        rm: Zonas projectaziun per las vias naziunalas
-        en: Reserved zones for motorways
       language: de
       federal: true
       standard: true
@@ -542,12 +547,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Baulinien Nationalstrassen
-        fr: Alignements des routes nationales
-        it: Allineamenti per le strade nazionali
-        rm: Lingias da construcziun per las vias naziunalas
-        en: Building lines for motorways
       language: de
       federal: true
       standard: true
@@ -580,12 +579,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Baulinien Eisenbahnanlagen
-        fr: Alignements des installations ferroviaires
-        it: Allineamenti per gli impianti ferroviari
-        rm: Lingias da construcziun per implants da viafier
-        en: Building lines of the railways installations
       language: de
       federal: true
       standard: true
@@ -618,12 +611,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Projektierungszonen Eisenbahnanlagen
-        fr: Zones réservées des installations ferroviaires
-        it: Zone riservate per gli impianti ferroviari
-        rm: Zonas projectaziun per implants da viafier
-        en: Reserved zones of the railways installations
       language: de
       federal: true
       standard: true
@@ -656,12 +643,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Projektierungszonen Flughafenanlagen
-        fr: Zones réservées des installations aéroportuaires
-        it: Zone riservate per gli impianti aeroportuali
-        rm: Zonas projectaziun per implants d'eroports
-        en: Reserved zones of the airport installations
       language: de
       federal: true
       standard: true
@@ -694,12 +675,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Baulinien Flughafenanlagen
-        fr: Alignements des installations aéroportuaires
-        it: Allineamenti per gli impianti aeroportuali
-        rm: Lingias da construcziun per implants d'eroports
-        en: Building lines of the airport installations
       language: de
       federal: true
       standard: true
@@ -732,12 +707,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Sicherheitszonenplan
-        fr: Plan de la zone de sécurité
-        it: Piano delle zone di sicurezza
-        rm: Plan da zonas da segirezza
-        en: Safety zone plan
       language: de
       federal: true
       standard: true
@@ -771,12 +740,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Kataster der belasteten Standorte
-        fr: Cadastre des sites pollués
-        it: Catasto dei siti inquinati
-        rm: Cataster dals lieus contaminads
-        en: Register of polluted sites
       language: de
       federal: false
       standard: true
@@ -809,12 +772,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Kataster der belasteten Standorte im Bereich des Militärs
-        fr: Cadastre des sites pollués - domaine militaire
-        it: Catasto dei siti inquinati nel settore militare
-        rm: Cataster dals lieus contaminads en il sectur da l'armada
-        en: Register of polluted sites in the area of army
       language: de
       federal: true
       standard: true
@@ -847,12 +804,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Kataster der belasteten Standorte im Bereich der zivilen Flugplätze
-        fr: Cadastre des sites pollués - domaine des aérodromes civils
-        it: Catasto dei siti inquinati nel settore degli aeroporti civili
-        rm: Cataster dals lieus contaminads en il sectur da las plazzas aviaticas civilas
-        en: Cadastre of polluted sites on civil aerodromes
       language: de
       federal: true
       standard: true
@@ -885,12 +836,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs
-        fr: Cadastre des sites pollués - domaine des transports publics
-        it: Catasto dei siti inquinati nel settore dei trasporti pubblici
-        rm: Cataster dals lieus contaminads en il sectur dal traffic public
-        en: Register of polluted sites in the area of public transport
       language: de
       federal: true
       standard: true
@@ -933,12 +878,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Grundwasserschutzzonen
-        fr: Zones de protection des eaux souterraines
-        it: Zone di protezione delle acque sotterranee
-        rm: Zona da protecziun da l'aua sutterrana
-        en: Groundwater protection zone
       language: de
       federal: false
       standard: true
@@ -971,12 +910,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Grundwasserschutzareale
-        fr: Périmètres de protection des eaux souterraines
-        it: Aree di protezione delle acque sotterranee
-        rm: Areal da protecziun da l'aua sutterrana
-        en: Groundwater protection areas
       language: de
       federal: false
       standard: true
@@ -1009,12 +942,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Lärmempfindlichkeitsstufen (in Nutzungszonen)
-        fr: Degré de sensibilité au bruit (dans les zones d'affectation)
-        it: Gradi di sensibilità al rumore (in zone d'utilizzazione)
-        rm: Grad da sensibilitad da canera (en zona d'utilisaziun)
-        en: Noise sensitivity level (in land-use zones)
       language: de
       federal: false
       standard: true
@@ -1047,12 +974,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Statische Waldgrenzen
-        fr: Limites forestières statiques
-        it: Margini statici della foresta
-        rm: Cunfin static dal guaud
-        en: Static forest perimeter
       language: de
       federal: false
       standard: true
@@ -1091,12 +1012,6 @@ pyramid_oereb:
           precision: 2
         percentage:
           precision: 1
-      text:
-        de: Waldabstandslinien
-        fr: Distances par rapport à la forêt
-        it: Linee di distanza dalle foreste
-        rm: Lingias da distanza dal guaud
-        en: Forest distance lines
       language: de
       federal: false
       standard: true

--- a/pyramid_oereb/standard/sources/plr.py
+++ b/pyramid_oereb/standard/sources/plr.py
@@ -15,7 +15,6 @@ from pyramid_oereb.lib.records.image import ImageRecord
 from pyramid_oereb.lib.records.law_status import LawStatusRecord
 from pyramid_oereb.lib.records.office import OfficeRecord
 from pyramid_oereb.lib.records.plr import EmptyPlrRecord
-from pyramid_oereb.lib.records.theme import ThemeRecord
 from pyramid_oereb.lib.sources import BaseDatabaseSource
 from pyramid_oereb.lib.sources.plr import PlrBaseSource
 
@@ -62,7 +61,8 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
         data_integration_model = DottedNameResolver().maybe_resolve(
             '{models_path}.DataIntegration'.format(models_path=models_path)
         )
-        self._theme_record = ThemeRecord(self._plr_info.get('code'), self._plr_info.get('text'))
+
+        self._theme_record = Config.get_theme_by_code(self._plr_info.get('code'))
 
         self.availabilities = []
         self.datasource = []

--- a/pyramid_oereb/standard/sources/theme.py
+++ b/pyramid_oereb/standard/sources/theme.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from pyramid_oereb.lib.sources import BaseDatabaseSource
+from pyramid_oereb.lib.sources.theme import ThemeBaseSource
+
+
+class DatabaseSource(BaseDatabaseSource, ThemeBaseSource):
+
+    def read(self):
+        """
+        Central method to read all theme entries.
+        """
+        session = self._adapter_.get_session(self._key_)
+        try:
+            results = session.query(self._model_).all()
+
+            self.records = list()
+            for result in results:
+                self.records.append(self._record_class_(
+                    result.code,
+                    result.title,
+                    result.extract_index
+                ))
+        finally:
+            session.close()

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -94,11 +94,11 @@ class PlrWebservice(object):
         themes = list()
         for theme in Config.get_themes():
             text = list()
-            for lang in theme.text:
+            for lang in theme.title:
                 if lang in supported_languages:
                     text.append({
                         'Language': lang,
-                        'Text': theme.text[lang]
+                        'Text': theme.title[lang]
                     })
             themes.append({
                 'Code': theme.code,

--- a/sample_data/themes.json
+++ b/sample_data/themes.json
@@ -1,0 +1,218 @@
+[
+    {
+        "id": 1,
+        "code": "LandUsePlans",
+        "title": {
+            "de": "Nutzungsplanung (kantonal/kommunal)",
+            "fr": "Plans d'affectation (cantonaux/communaux)",
+            "it": "Piani di utilizzazione (cantonali/comunali)",
+            "rm": "Planisaziun d'utilisaziun (chantunal/communal)",
+            "en": "Land-use planning (cantonal/municipal)"
+        },
+        "extract_index": 20
+    },
+    {
+        "id": 2,
+        "code": "MotorwaysProjectPlaningZones",
+        "title": {
+            "de": "Projektierungszonen Nationalstrassen",
+            "fr": "Zones réservées des routes nationales",
+            "it": "Zone riservate per le strade nazionali",
+            "rm": "Zonas projectaziun per las vias naziunalas",
+            "en": "Reserved zones for motorways"
+        },
+        "extract_index": 110
+    },
+    {
+        "id": 3,
+        "code": "MotorwaysBuildingLines",
+        "title": {
+            "de": "Baulinien Nationalstrassen",
+            "fr": "Alignements des routes nationales",
+            "it": "Allineamenti per le strade nazionali",
+            "rm": "Lingias da construcziun per las vias naziunalass",
+            "en": "Building lines for motorways"
+        },
+        "extract_index": 120
+    },
+    {
+        "id": 4,
+        "code": "RailwaysProjectPlanningZones",
+        "title": {
+            "de": "Projektierungszonen Eisenbahnanlagen",
+            "fr": "Zones réservées des installations ferroviaires",
+            "it": "Zone riservate per gli impianti ferroviari",
+            "rm": "Zonas da projectaziun dals implants da viafier",
+            "en": "Reserved zones for railways"
+        },
+        "extract_index": 210
+    },
+    {
+        "id": 5,
+        "code": "RailwaysBuildingLines",
+        "title": {
+            "de": "Baulinien Eisenbahnanlagen",
+            "fr": "Alignements des installations ferroviaires",
+            "it": "Allineamenti per gli impianti ferroviari",
+            "rm": "Lingias da construcziun dals implants da viafier",
+            "en": "Building lines for railways"
+        },
+        "extract_index": 220
+    },
+    {
+        "id": 6,
+        "code": "AirportsProjectPlanningZones",
+        "title": {
+            "de": "Projektierungszonen Flughafenanlagen",
+            "fr": "Zones réservées des installations aéroportuaires",
+            "it": "Zone riservate per gli impianti aeroportuali",
+            "rm": "Zonas da projectaziun dals implants d'eroport",
+            "en": "Reserved zones for railways"
+        },
+        "extract_index": 310
+    },
+    {
+        "id": 7,
+        "code": "AirportsBuildingLines",
+        "title": {
+            "de": "Baulinien Flughafenanlagen",
+            "fr": "Alignements des installations aéroportuaires",
+            "it": "Allineamenti per gli impianti aeroportuali",
+            "rm": "Lingias da construcziun dals implants d'eroport",
+            "en": "Building lines for airports"
+        },
+        "extract_index": 320
+    },
+    {
+        "id": 8,
+        "code": "AirportsSecurityZonePlans",
+        "title": {
+            "de": "Sicherheitszonenplan",
+            "fr": "Plan de la zone de sécurité",
+            "it": "Piano delle zone di sicurezza",
+            "rm": "Plan da zonas da segirezza",
+            "en": "Security zone plan"
+        },
+        "extract_index": 330
+    },
+    {
+        "id": 9,
+        "code": "ContaminatedSites",
+        "title": {
+            "de": "Kataster der belasteten Standorte",
+            "fr": "Cadastre des sites pollués",
+            "it": "Catasto dei siti inquinati",
+            "rm": "Cataster dals lieus contaminads",
+            "en": "Cadastre of contaminated sites"
+        },
+        "extract_index": 410
+    },
+    {
+        "id": 10,
+        "code": "ContaminatedMilitarySites",
+        "title": {
+            "de": "Kataster der belasteten Standorte im Bereich des Militärs",
+            "fr": "Cadastre des sites pollués – domaine militaire",
+            "it": "Catasto dei siti inquinati nel settore militare",
+            "rm": "Cataster dals lieus contaminads en il sectur da l'armada",
+            "en": "Cadastre of contaminated military sites"
+        },
+        "extract_index": 420
+    },
+    {
+        "id": 11,
+        "code": "ContaminatedCivilAviationSites",
+        "title": {
+            "de": "Kataster der belasteten Standorte im Bereich der zivilen Flugplätze",
+            "fr": "Cadastre des sites pollués – domaine des aérodromes civils",
+            "it": "Catasto dei siti inquinati nel settore degli aeroporti civili",
+            "rm": "Cataster dals lieus contaminads en il sectur da las plazzas aviaticas civilas",
+            "en": "Cadastre of contaminated civil aviation sites"
+        },
+        "extract_index": 430
+    },
+    {
+        "id": 12,
+        "code": "ContaminatedPublicTransportSites",
+        "title": {
+            "de": "Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs",
+            "fr": "Cadastre des sites pollués – domaine des transports publics",
+            "it": "Catasto dei siti inquinati nel settore dei trasporti pubblici",
+            "rm": "Cataster dals lieus contaminads en il sectur dal traffic public",
+            "en": "Cadastre of contaminated public transport sites"
+        },
+        "extract_index": 440
+    },
+    {
+        "id": 13,
+        "code": "GroundwaterProtectionZones",
+        "title": {
+            "de": "Grundwasserschutzzonen",
+            "fr": "Zones de protection des eaux souterraines",
+            "it": "Zone di protezione delle acque sotterranee",
+            "rm": "Zonas da protecziun da l'aua sutterrana",
+            "en": "Groundwater protection zones"
+        },
+        "extract_index": 510
+    },
+    {
+        "id": 14,
+        "code": "GroundwaterProtectionSites",
+        "title": {
+            "de": "Grundwasserschutzareale",
+            "fr": "Périmètres de protection des eaux souterraines",
+            "it": "Aree di protezione delle acque sotterranee",
+            "rm": "Areals da protecziun da las auas sutterranas",
+            "en": "Groundwater protection areas"
+        },
+        "extract_index": 520
+    },
+    {
+        "id": 15,
+        "code": "NoiseSensitivityLevels",
+        "title": {
+            "de": "Lärmempfindlichkeitsstufen (in Nutzungszonen)",
+            "fr": "Degré de sensibilité au bruit (dans les zones d’affectation)",
+            "it": "Gradi di sensibilità al rumore (in zone d’utilizzazione)",
+            "rm": "Grads da sensibladad da canera (en las zonas d'utilisaziun)",
+            "en": "Noise sensitivity level (in land use zones)"
+        },
+        "extract_index": 610
+    },
+    {
+        "id": 16,
+        "code": "ForestPerimeters",
+        "title": {
+            "de": "Statische Waldgrenzen",
+            "fr": "Limites forestières statiques",
+            "it": "Margini statici della foresta",
+            "rm": "Cunfins statics dal guaud",
+            "en": "Static forest perimeter"
+        },
+        "extract_index": 710
+    },
+    {
+        "id": 17,
+        "code": "ForestDistanceLines",
+        "title": {
+            "de": "Waldabstandslinien",
+            "fr": "Distances par rapport à la forêt",
+            "it": "Linee di distanza dalla foresta",
+            "rm": "Lingias da distanza dal guaud",
+            "en": "Forest distance lines"
+        },
+        "extract_index": 720
+    },
+    {
+        "id": 18,
+        "code": "PlanningZones",
+        "title": {
+            "de": "Planungszonen",
+            "fr": "Zones réservées",
+            "it": "Zone di pianificazione",
+            "rm": "Zonas da planisaziun",
+            "en": "Planning zones"
+        },
+        "extract_index": 10
+    }
+]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -66,3 +66,4 @@ Config._config = None
 create_tables_from_standard_configuration(pyramid_oereb_test_yml)
 dummy_data = DummyData()
 dummy_data.init()
+Config.init_themes()

--- a/tests/contrib/print_proxy/resources/test_bad_config.yml
+++ b/tests/contrib/print_proxy/resources/test_bad_config.yml
@@ -4,3 +4,10 @@ pyramid_oereb:
     wms_url_params:
             - TRANSPARENT: 'true'
             - OTHERCUSTOM: 'myvalue'
+
+  theme:
+    source:
+      class: pyramid_oereb.standard.sources.theme.DatabaseSource
+      params:
+        db_connection: postgresql://postgres:postgres@db:5432/pyramid_oereb_test
+        model: pyramid_oereb.standard.models.main.Theme

--- a/tests/contrib/print_proxy/resources/test_config.yml
+++ b/tests/contrib/print_proxy/resources/test_config.yml
@@ -4,3 +4,10 @@ pyramid_oereb:
     wms_url_params:
       TRANSPARENT: 'true'
       OTHERCUSTOM: 'myvalue'
+
+  theme:
+    source:
+      class: pyramid_oereb.standard.sources.theme.DatabaseSource
+      params:
+        db_connection: postgresql://postgres:postgres@db:5432/pyramid_oereb_test
+        model: pyramid_oereb.standard.models.main.Theme

--- a/tests/contrib/print_proxy/resources/test_custom_config.yml
+++ b/tests/contrib/print_proxy/resources/test_custom_config.yml
@@ -4,3 +4,10 @@ pyramid_oereb:
     wms_url_keep_params:
       - epoch
       - TRANSPARENT
+
+  theme:
+    source:
+      class: pyramid_oereb.standard.sources.theme.DatabaseSource
+      params:
+        db_connection: postgresql://postgres:postgres@db:5432/pyramid_oereb_test
+        model: pyramid_oereb.standard.models.main.Theme

--- a/tests/init_db.py
+++ b/tests/init_db.py
@@ -38,6 +38,10 @@ class DummyData(object):
             table=main.Municipality.__table__.name
         ))
         connection.execute('TRUNCATE {schema}.{table};'.format(
+            schema=main.Theme.__table__.schema,
+            table=main.Theme.__table__.name
+        ))
+        connection.execute('TRUNCATE {schema}.{table};'.format(
             schema=main.Glossary.__table__.schema,
             table=main.Glossary.__table__.name
         ))
@@ -166,7 +170,7 @@ class DummyData(object):
             'geom': 'SRID=2056;MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0)))'
         })
 
-        # Add dummy exclustion of liability
+        # Add dummy exclusion of liability
         connection.execute(main.ExclusionOfLiability.__table__.insert(), {
             'id': 1,
             'title': {
@@ -184,6 +188,120 @@ class DummyData(object):
                       base dei criteri definiti dall ...',
                 "rm": u''
             }
+        })
+
+        # Add dummy themes
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 1,
+            'code': 'LandUsePlans',
+            'title': {
+                'de': 'Nutzungsplanung (kantonal/kommunal)',
+                'fr': 'Plans d’affectation (cantonaux/communaux)',
+                'it': 'Piani di utilizzazione (cantonali/comunali)',
+                'rm': 'Planisaziun d’utilisaziun (chantunal/communal)'
+            },
+            'extract_index': 20
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 2,
+            'code': 'MotorwaysProjectPlaningZones',
+            'title': {
+                'de': 'Projektierungszonen Nationalstrassen',
+                'fr': 'Zones réservées des routes nationales',
+                'it': 'Zone riservate per le strade nazionali',
+                'rm': 'Zonas da projectaziun da las vias naziunalas'
+            },
+            'extract_index': 110
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 3,
+            'code': 'MotorwaysBuildingLines',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 120
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 4,
+            'code': 'RailwaysProjectPlanningZones',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 210
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 5,
+            'code': 'RailwaysBuildingLines',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 220
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 6,
+            'code': 'AirportsProjectPlanningZones',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 310
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 7,
+            'code': 'AirportsBuildingLines',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 320
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 8,
+            'code': 'AirportsSecurityZonePlans',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 330
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 9,
+            'code': 'ContaminatedSites',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 410
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 10,
+            'code': 'ContaminatedMilitarySites',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 420
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 11,
+            'code': 'ContaminatedCivilAviationSites',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 430
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 12,
+            'code': 'ContaminatedPublicTransportSites',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 440
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 13,
+            'code': 'GroundwaterProtectionZones',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 510
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 14,
+            'code': 'GroundwaterProtectionSites',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 520
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 15,
+            'code': 'NoiseSensitivityLevels',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 610
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 16,
+            'code': 'ForestPerimeters',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 710
+        })
+        connection.execute(main.Theme.__table__.insert(), {
+            'id': 17,
+            'code': 'ForestDistanceLines',
+            'title': {'de': '', 'fr': '', 'it': '', 'rm': ''},
+            'extract_index': 720
         })
 
         # Add dummy glossary

--- a/tests/records/test_embeddable.py
+++ b/tests/records/test_embeddable.py
@@ -22,7 +22,7 @@ def test_embeddable_record_init():
 
 def test_datasource_record():
     record = DatasourceRecord(
-        ThemeRecord('Test', {'de': 'Test'}),
+        ThemeRecord('Test', {'de': 'Test'}, 100),
         datetime.datetime.now(),
         OfficeRecord({u'de': u'TEST'})
     )

--- a/tests/records/test_extract.py
+++ b/tests/records/test_extract.py
@@ -46,7 +46,7 @@ def create_dummy_extract():
     av_provider_method_string = Config.get('extract').get('base_data').get('methods').get('provider')
     av_provider_method = resolver.resolve(av_provider_method_string)
     cadaster_state = date
-    theme = ThemeRecord(u'TEST', {u'de': u'TEST TEXT'})
+    theme = ThemeRecord(u'TEST', {u'de': u'TEST TEXT'}, 100)
     datasources = [DatasourceRecord(theme, date, plr_office)]
     plr_cadastre_authority = Config.get_plr_cadastre_authority()
     embeddable = EmbeddableRecord(

--- a/tests/records/test_legend_entry.py
+++ b/tests/records/test_legend_entry.py
@@ -17,7 +17,7 @@ def test_init():
         {'de': 'test'},
         'test_code',
         'test',
-        ThemeRecord('test', {'de': 'Test'}),
+        ThemeRecord('test', {'de': 'Test'}, 100),
         view_service_id=1
     )
     assert isinstance(record.symbol, ImageRecord)

--- a/tests/records/test_plr.py
+++ b/tests/records/test_plr.py
@@ -23,7 +23,7 @@ def create_dummy_plr():
     law_status = LawStatusRecord.from_config(u'inForce')
     geometry = GeometryRecord(law_status, datetime.date.today(), Point(1, 1))
     record = PlrRecord(
-        ThemeRecord('code', dict()), {'en': 'Content'}, law_status, datetime.date(1985, 8, 29), office,
+        ThemeRecord('code', dict(), 100), {'en': 'Content'}, law_status, datetime.date(1985, 8, 29), office,
         ImageRecord('1'.encode('utf-8')), view_service, [geometry])
     return record
 

--- a/tests/records/test_theme.py
+++ b/tests/records/test_theme.py
@@ -3,8 +3,8 @@ from pyramid_oereb.lib.records.theme import ThemeRecord
 
 
 def test_theme_init():
-    record = ThemeRecord(u'code', {u'de': u'Beschreibung'})
+    record = ThemeRecord(u'code', {u'de': u'Beschreibung'}, 100)
     assert record.code == u'code'
-    assert record.text == {
+    assert record.title == {
         u'de': u'Beschreibung'
     }

--- a/tests/records/test_view_service.py
+++ b/tests/records/test_view_service.py
@@ -31,7 +31,7 @@ def test_init_with_relation():
         {'en': 'test'},
         'test_code',
         'test',
-        ThemeRecord('test', {'de': 'Test'}),
+        ThemeRecord('test', {'de': 'Test'}, 100),
         view_service_id=1
     )]
     record = ViewServiceRecord({'de': 'http://www.test.url.ch'},

--- a/tests/renderer/__init__.py
+++ b/tests/renderer/__init__.py
@@ -59,7 +59,7 @@ def _get_test_extract(glossary):
         av_provider_method_string = Config.get('extract').get('base_data').get('methods').get('provider')
         av_provider_method = resolver.resolve(av_provider_method_string)
         cadaster_state = date
-        theme = ThemeRecord(u'TEST', {'de': u'TEST TEXT'})
+        theme = ThemeRecord(u'TEST', {'de': u'TEST TEXT'}, 100)
         datasources = [DatasourceRecord(theme, date, office_record)]
         plr_cadastre_authority = Config.get_plr_cadastre_authority()
         embeddable = EmbeddableRecord(

--- a/tests/renderer/test_base.py
+++ b/tests/renderer/test_base.py
@@ -168,7 +168,7 @@ def test_get_symbol_ref(theme_code):
             {'de': 'Test'},
             u'test',
             u'test',
-            ThemeRecord(theme_code, {'de': 'Test'}),
+            ThemeRecord(theme_code, {'de': 'Test'}, 100),
             view_service_id=1
         )
         if theme_code == u'NotExistingTheme':

--- a/tests/renderer/test_json.py
+++ b/tests/renderer/test_json.py
@@ -86,7 +86,7 @@ def test_render(parameter, glossaries_input, glossaries_expected):
         av_provider_method_string = Config.get('extract').get('base_data').get('methods').get('provider')
         av_provider_method = resolver.resolve(av_provider_method_string)
         cadaster_state = date
-        theme = ThemeRecord(u'TEST', {'de': u'TEST TEXT'})
+        theme = ThemeRecord(u'TEST', {'de': u'TEST TEXT'}, 100)
         datasources = [DatasourceRecord(theme, date, office_record)]
         plr_cadastre_authority = Config.get_plr_cadastre_authority()
         embeddable = EmbeddableRecord(
@@ -250,7 +250,7 @@ def test_format_plr(parameter):
             text_at_web={'de': 'http://mein.dokument.ch'}
         )
         documents = [document]
-        theme = ThemeRecord(u'ContaminatedSites', {u'de': u'Test theme'})
+        theme = ThemeRecord(u'ContaminatedSites', {u'de': u'Test theme'}, 410)
         office = OfficeRecord({'de': 'Test Office'})
         legend_entry = LegendEntryRecord(
             ImageRecord(FileAdapter().read('tests/resources/python.svg')),
@@ -502,7 +502,7 @@ def test_format_theme(params):
     renderer = Renderer(DummyRenderInfo())
     renderer._language = u'de'
     renderer._params = params
-    theme = ThemeRecord(u'TestTheme', {u'de': u'Test-Thema'})
+    theme = ThemeRecord(u'TestTheme', {u'de': u'Test-Thema'}, 100)
     result = renderer.format_theme(theme)
     assert isinstance(result, dict)
     assert result == {
@@ -521,7 +521,7 @@ def test_format_legend_entry(parameter):
         renderer._language = u'de'
         renderer._params = parameter
         renderer._request = MockRequest()
-        theme = ThemeRecord(u'ContaminatedSites', {u'de': u'Test'})
+        theme = ThemeRecord(u'ContaminatedSites', {u'de': u'Test'}, 410)
         legend_entry = LegendEntryRecord(
             ImageRecord(FileAdapter().read('tests/resources/python.svg')),
             {u'de': u'Legendeneintrag'},

--- a/tests/renderer/xml/test_legend_entry.py
+++ b/tests/renderer/xml/test_legend_entry.py
@@ -29,7 +29,7 @@ def test_sub_theme():
         legend_text={'de': 'legend1'},
         type_code='LandUsePlans',
         type_code_list='bla',
-        theme=ThemeRecord(u'LandUsePlans', {'de': 'Theme 1'}),
+        theme=ThemeRecord(u'LandUsePlans', {'de': 'Theme 1'}, 20),
         sub_theme={'de': 'sub theme de'}
     )
     content = template.render(**{

--- a/tests/renderer/xml/test_public_law_restriction.py
+++ b/tests/renderer/xml/test_public_law_restriction.py
@@ -37,7 +37,7 @@ def test_sub_theme():
     )
     geometry = GeometryRecord(law_status, datetime.now(), Polygon(), 'test', office=office)
     public_law_restriction = PlrRecord(
-        theme=ThemeRecord(u'LandUsePlans', {'de': 'Theme 1'}),
+        theme=ThemeRecord(u'LandUsePlans', {'de': 'Theme 1'}, 20),
         legend_text={'de': 'information de'},
         law_status=law_status,
         published_from=datetime.now(),

--- a/tests/resources/test_config.yml
+++ b/tests/resources/test_config.yml
@@ -7,6 +7,12 @@ section2:
   param2:
     - first
     - second
+  theme:
+    source:
+      class: pyramid_oereb.standard.sources.theme.DatabaseSource
+      params:
+        db_connection: postgresql://postgres:postgres@db:5432/pyramid_oereb_test
+        model: pyramid_oereb.standard.models.main.Theme
 
 pyramid_oereb:
 
@@ -72,3 +78,10 @@ pyramid_oereb:
         de: https://wms.ch/?BBOX=2475000,1065000,2850000,1300000
       layer_index: 2
       layer_opacity: 0.5
+
+  theme:
+    source:
+      class: pyramid_oereb.standard.sources.theme.DatabaseSource
+      params:
+        db_connection: postgresql://postgres:postgres@db:5432/pyramid_oereb_test
+        model: pyramid_oereb.standard.models.main.Theme

--- a/tests/test_hook_methods.py
+++ b/tests/test_hook_methods.py
@@ -57,7 +57,7 @@ def test_get_symbol_ref():
         {'de': 'Test'},
         'CodeA',
         'http://my.codelist.com/test.xml',
-        ThemeRecord('ContaminatedSites', {'de': 'Belastete Standorte'}),
+        ThemeRecord('ContaminatedSites', {'de': 'Belastete Standorte'}, 410),
         view_service_id='1'
     )
     with pyramid_oereb_test_config():

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -113,8 +113,8 @@ def test_processor_without_images():
 
 
 def test_processor_get_legend_entries():
-    theme1 = ThemeRecord(u'TEST', {'de': 'Theme 1'})
-    theme2 = ThemeRecord(u'TEST', {'de': 'Theme 2'})
+    theme1 = ThemeRecord(u'TEST', {'de': 'Theme 1'}, 100)
+    theme2 = ThemeRecord(u'TEST', {'de': 'Theme 2'}, 200)
     office = OfficeRecord({'de': 'Test Office'})
     law_status = LawStatusRecord.from_config(u'inForce')
     geometries = [GeometryRecord(law_status, datetime.date.today(), Point(1, 1))]


### PR DESCRIPTION
Closes #1256 
New: theme data are moved from `PublicLawRestriction` to a new `Theme` table. The link between the tables goes through the theme code (e.g. `LandUsePlans`), which is used as a soft foreign key (The theme codes are not yet updated to the new specification - it will be done separately after the merging of #1248). The themes are now read from the DB at the application startup, when the configuration is initialized (instead of at each request). 
With this PR the section `theme` is now required in the YAML configuration file for the configuration to be initialized