### PR TITLE
Drop LV03 support and upgrade to pyproj 2

### DIFF
--- a/pyramid_oereb/contrib/sources/address.py
+++ b/pyramid_oereb/contrib/sources/address.py
@@ -72,7 +72,7 @@ class AddressGeoAdminSource(AddressBaseSource):
                 for item in data.get('results'):
                     attrs = item.get('attrs')
                     if isinstance(attrs, dict) and attrs.get('origin') == 'address':
-                        x, y = rp.transform((attrs.get('lon'), attrs.get('lat')), to_srs=srid)
+                        x, y = rp.transform((attrs.get('lat'), attrs.get('lon')), to_srs=srid)
                         self.records.append(AddressRecord(
                             street_name=street_name,
                             zip_code=zip_code,

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -521,9 +521,7 @@ class PlrWebservice(object):
                 'The parameter GNSS has to be a comma-separated pair of coordinates.')
 
         # Coordinates provided as "latitude,longitude"
-        lon = float(coords[1])
-        lat = float(coords[0])
-        return self.__coord_transform__((lon, lat), 4326).buffer(1.0)
+        return self.__coord_transform__(coords, 4326).buffer(1.0)
 
 
 class Parameter(object):

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -472,18 +472,17 @@ class PlrWebservice(object):
 
     def __parse_xy__(self, xy, buffer_dist=None):
         """
-        Parses the coordinates from the XY parameter, transforms them to target CRS
-        and creates a point geometry. If a buffer distance is defined, a buffer
-        with the specified distance will be applied.
+        Parses the coordinates from the XY parameter and creates a point geometry.
+        If a buffer distance is defined, a buffer with the specified distance will be applied.
 
         Args:
             xy (str): XY parameter from the getegrid request.
-            buffer_dist (float or None): Distance for the buffer applied to the transformed
-                point.If None, no buffer will be applied.
+            buffer_dist (float or None): Distance for the buffer applied to the
+                point. If None, no buffer will be applied.
 
         Returns:
-            shapely.geometry.Point or shapely.geometry.Polygon: The transformed coordinates as
-            Point.
+            shapely.geometry.Point or shapely.geometry.Polygon: The coordinates as
+                Point or, if using a buffer, as Polygon.
         """
         coords = xy.split(',')
 
@@ -493,10 +492,7 @@ class PlrWebservice(object):
 
         x = float(coords[0])
         y = float(coords[1])
-        src_crs = 21781
-        if x > 1000000 and y > 1000000:
-            src_crs = 2056
-        p = self.__coord_transform__((x, y), src_crs)
+        p = Point(x, y)
         if buffer_dist:
             return p.buffer(buffer_dist)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ urllib3[secure]==1.26.6
 cryptography==3.3.2 # rq.filter: <3.4
 waitress==2.0.0
 jsonschema==3.2.0
-pyproj==1.9.6  # rq.filter: <2.0.0
-pyreproj==1.0.1 # rq.filter: <2.0.0
+pyproj==3.1.0  # rq.filter: <2.0.0
+pyreproj==2.0.0 # rq.filter: <2.0.0
 lxml==4.6.3
 requests==2.25.1
 geolink-formatter==2.0.0

--- a/tests/sources/test_address_geoadmin.py
+++ b/tests/sources/test_address_geoadmin.py
@@ -85,5 +85,5 @@ def test_read(status_code):
             assert address.zip_code == 4410
             assert address.street_name == u'Muehlemattstrasse'
             assert isinstance(address.geom, Point)
-            assert address.geom.x == 2621857.9869956686
-            assert address.geom.y == 1259852.8231037352
+            assert address.geom.x == 2621857.986995669
+            assert address.geom.y == 1259852.8231037268

--- a/tests/webservice/test_getegrid.py
+++ b/tests/webservice/test_getegrid.py
@@ -57,7 +57,7 @@ def test_getegrid_ident():
 
 def test_getegrid_xy():
     with pyramid_oereb_test_config():
-        url = 'http://example.com/oereb/getegrid/json/?XY=-1999999.032739449,-999998.940457533'
+        url = 'http://example.com/oereb/getegrid/json/?XY=2,0'
         request = MockRequest(
             current_route_url=url
         )
@@ -68,7 +68,7 @@ def test_getegrid_xy():
         })
 
         request.params.update({
-            'XY': '-1999998.000,-999999.000'
+            'XY': '2,0'
         })
         webservice = PlrWebservice(request)
         response = webservice.get_egrid_coord().json

--- a/tests/webservice/test_getegrid.py
+++ b/tests/webservice/test_getegrid.py
@@ -68,7 +68,7 @@ def test_getegrid_xy():
         })
 
         request.params.update({
-            'XY': '-1999999.032739449,-999998.940457533'
+            'XY': '-1999998.000,-999999.000'
         })
         webservice = PlrWebservice(request)
         response = webservice.get_egrid_coord().json

--- a/tests/webservice/test_getegrid.py
+++ b/tests/webservice/test_getegrid.py
@@ -212,8 +212,7 @@ def test_get_egrid_response_no_content():
 
 
 @pytest.mark.parametrize('src,dst,buffer_dist', [
-    ('2621857.856,1259856.578', (2621857.856, 1259856.578), None),
-    ('621857.759,259856.554', (2621857.799, 1259856.500), 1.0)
+    ('2621857.856,1259856.578', (2621857.856, 1259856.578), None)
 ])
 def test_parse_xy(src, dst, buffer_dist):
     geom = PlrWebservice(MockRequest()).__parse_xy__(src, buffer_dist=buffer_dist)


### PR DESCRIPTION
Closes #869 

When fixing the tests (there were some floating point adaptations required) I removed one which was with LV03 and which was also failing due to some floating point inaccuracy (bbaae2220baba008886dc416117953c411238306) (As I understood, pyramid_oereb won't support LV03)

In case anyone else is wondering about these coordinates:
https://github.com/openoereb/pyramid_oereb/blob/bbaae2220baba008886dc416117953c411238306/tests/webservice/test_getegrid.py#L71
It comes from the fact that all test geometries are in the range (0,0) - (10,10) but with SRID=2056 (LV95). Because of the way the SRID is evaluated in the webservice.py: https://github.com/openoereb/pyramid_oereb/blob/bbaae2220baba008886dc416117953c411238306/pyramid_oereb/views/webservice.py#L496-L498
for the coordinates (2,0), the SRID is assumed to be LV03 and they are reprojected and the real estate geometry is not intersected. Probably something to keep in mind when/if dropping support for LV03.