### PR TITLE
Update version returned by GetVersions()

### DIFF
--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -58,7 +58,7 @@ class PlrWebservice(object):
             u'GetVersionsResponse': {
                 u'supportedVersion': [
                     {
-                        u'version': u'1.0',
+                        u'version': u'extract-2.0',
                         u'serviceEndpointBase': endpoint
                     }
                 ]


### PR DESCRIPTION
The following three failing test get fixed with PR #1283:

```log
FAILED tests/webservice/test_getegrid.py::test_getegrid_ident[False] - AssertionError: assert 'Liegenschaft' == 'RealEstate'
FAILED tests/webservice/test_getegrid.py::test_getegrid_ident[True] - AssertionError: assert 'Liegenschaft' == 'RealEstate'
FAILED tests/webservice/test_getegrid.py::test_get_egrid_response - AssertionError: assert {'GetEGRIDResponse': [{'egrid': 'egrid',\n                       'i...
```

Closes #1284 