### PR TITLE
New behavior based on law status

### DIFF
--- a/pyramid_oereb/lib/config.py
+++ b/pyramid_oereb/lib/config.py
@@ -135,7 +135,7 @@ class Config(object):
         return Config.general_information
 
     @staticmethod
-    def get_law_statuses():
+    def get_law_status_codes():
         """
         Returns a list of available law status codes.
 

--- a/pyramid_oereb/lib/config.py
+++ b/pyramid_oereb/lib/config.py
@@ -135,6 +135,17 @@ class Config(object):
         return Config.general_information
 
     @staticmethod
+    def get_law_statuses():
+        """
+        Returns a list of available law status codes.
+
+        Returns:
+            list of unicode: The available law status codes.
+        """
+        assert Config._config is not None
+        return [law_status.code for law_status in Config.law_status]
+
+    @staticmethod
     def get_themes():
         """
         Returns a list of available themes.

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -118,7 +118,7 @@ class ExtractReader(object):
                             datasource.append(ds)
 
                     # Sort PLR records according to their law status
-                    plr_source.records.sort(key=lambda plr_elem: self._sort_plr_law_status(plr_elem))
+                    plr_source.records.sort(key=self._sort_plr_law_status)
 
                     real_estate.public_law_restrictions.extend(plr_source.records)
 
@@ -183,13 +183,12 @@ class ExtractReader(object):
         log.debug("read() done")
         return self.extract
 
-
     def _sort_plr_law_status(self, plr_element):
         """
         TODO add a description
         Args:
         """
         if (isinstance(plr_element, PlrRecord) and plr_element.law_status.code in self.law_status):
-            return -1 * self.law_status.index(plr_element.law_status.code)
+            return self.law_status.index(plr_element.law_status.code)
         else:
             return -1

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -115,7 +115,18 @@ class ExtractReader(object):
                     for ds in plr_source.datasource:
                         if not params.skip_topic(ds.theme.code):
                             datasource.append(ds)
-                    real_estate.public_law_restrictions.extend(plr_source.records)
+
+                    # Group PLR records according to their law status
+                    grouped_plr = list()
+                    for law_status in Config.get_law_statuses():
+                        for plr in plr_source.records:
+                            if isinstance(plr, PlrRecord):
+                                if plr.law_status.code == law_status:
+                                    grouped_plr.append(plr)
+                            elif plr not in grouped_plr:
+                                grouped_plr.append(plr)
+
+                    real_estate.public_law_restrictions.extend(grouped_plr)
 
             for plr in real_estate.public_law_restrictions:
 

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -185,10 +185,21 @@ class ExtractReader(object):
 
     def _sort_plr_law_status(self, plr_element):
         """
-        TODO add a description
+        This method generates the sorting key for plr_elements according to thyr law_status code.
+        The value is generated from the index of the the plr_element.law_status.code has in the law_status list.
+        The law_status list corresponds to the law status teken from the DB
+
+        If the argument is not a PlrRecord or its law_status.code is not contained in the law_status list,
+        the method will return the lenghte of the law_status list so it can be sorted at the end of the list.
+
         Args:
+            plr_element (PlrRecord or EmptyPlrRecord) a plr record element.
+
+        Returns:
+            int: Value which can be used to sort the reccord according depending on its law_status.code.
+
         """
         if (isinstance(plr_element, PlrRecord) and plr_element.law_status.code in self.law_status):
             return self.law_status.index(plr_element.law_status.code)
         else:
-            return -1
+            return len(self.law_status)

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -45,7 +45,7 @@ class ExtractReader(object):
         self._plr_cadastre_authority_ = plr_cadastre_authority
         self._certification = certification
         self._certification_at_web = certification_at_web
-        self.law_status = Config.get_law_statuses()
+        self.law_status = Config.get_law_status_codes()
 
     @property
     def plr_cadastre_authority(self):

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -33,7 +33,7 @@ class ExtractReader(object):
         Args:
             plr_sources (list of pyramid_oereb.lib.sources.plr.PlrBaseSource): The list of PLR source
                 instances which the achieved extract should be about.
-            plr_cadastre_authority (pyramid_oereb.lib.records.office.OffcieRecord): The authority responsible
+            plr_cadastre_authority (pyramid_oereb.lib.records.office.OfficeRecord): The authority responsible
                 for the PLR cadastre.
             logos (dict): The logos of confederation, canton and oereb wrapped in a ImageRecord.
             certification (dict of unicode or None): A mutlilingual dictionary of certification information.
@@ -51,7 +51,7 @@ class ExtractReader(object):
         Returns the authority responsible for the PLR cadastre.
 
         Returns:
-            pyramid_oereb.lib.records.office.OffcieRecord: The authority responsible for the PLR
+            pyramid_oereb.lib.records.office.OfficeRecord: The authority responsible for the PLR
             cadastre.
         """
         return self._plr_cadastre_authority_

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -4,6 +4,7 @@ import logging
 from pyramid.path import DottedNameResolver
 
 from shapely.geometry import box
+from timeit import default_timer as timer
 
 from pyramid_oereb.lib.config import Config
 from pyramid_oereb.lib.records.embeddable import EmbeddableRecord
@@ -118,7 +119,11 @@ class ExtractReader(object):
                             datasource.append(ds)
 
                     # Sort PLR records according to their law status
+                    start_time = timer()
+                    log.debug("sort plrs by law status start")
                     plr_source.records.sort(key=self._sort_plr_law_status)
+                    end_time = timer()
+                    log.debug(f"DONE with sort plrs by law status, time spent: {end_time-start_time} seconds")
 
                     real_estate.public_law_restrictions.extend(plr_source.records)
 
@@ -185,18 +190,18 @@ class ExtractReader(object):
 
     def _sort_plr_law_status(self, plr_element):
         """
-        This method generates the sorting key for plr_elements according to thyr law_status code.
-        The value is generated from the index of the the plr_element.law_status.code has in the law_status list.
-        The law_status list corresponds to the law status teken from the DB
+        This method generates the sorting key for plr_elements according to their law_status code.
+        The value is generated from the index the plr_element.law_status.code has in the law_status
+        list. The law_status list corresponds to the law status taken from the DB
 
         If the argument is not a PlrRecord or its law_status.code is not contained in the law_status list,
-        the method will return the lenghte of the law_status list so it can be sorted at the end of the list.
+        the method will return the length of the law_status list so it can be sorted at the end of the list.
 
         Args:
             plr_element (PlrRecord or EmptyPlrRecord) a plr record element.
 
         Returns:
-            int: Value which can be used to sort the reccord according depending on its law_status.code.
+            int: Value which can be used to sort the record depending on its law_status.code.
 
         """
         if (isinstance(plr_element, PlrRecord) and plr_element.law_status.code in self.law_status):

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -44,6 +44,7 @@ class ExtractReader(object):
         self._plr_cadastre_authority_ = plr_cadastre_authority
         self._certification = certification
         self._certification_at_web = certification_at_web
+        self.law_status = Config.get_law_statuses()
 
     @property
     def plr_cadastre_authority(self):
@@ -116,17 +117,10 @@ class ExtractReader(object):
                         if not params.skip_topic(ds.theme.code):
                             datasource.append(ds)
 
-                    # Group PLR records according to their law status
-                    grouped_plr = list()
-                    for law_status in Config.get_law_statuses():
-                        for plr in plr_source.records:
-                            if isinstance(plr, PlrRecord):
-                                if plr.law_status.code == law_status:
-                                    grouped_plr.append(plr)
-                            elif plr not in grouped_plr:
-                                grouped_plr.append(plr)
+                    # Sort PLR records according to their law status
+                    plr_source.records.sort(key=lambda plr_elem: self._sort_plr_law_status(plr_elem))
 
-                    real_estate.public_law_restrictions.extend(grouped_plr)
+                    real_estate.public_law_restrictions.extend(plr_source.records)
 
             for plr in real_estate.public_law_restrictions:
 
@@ -188,3 +182,14 @@ class ExtractReader(object):
 
         log.debug("read() done")
         return self.extract
+
+
+    def _sort_plr_law_status(self, plr_element):
+        """
+        TODO add a description
+        Args:
+        """
+        if (isinstance(plr_element, PlrRecord) and plr_element.law_status.code in self.law_status):
+            return -1 * self.law_status.index(plr_element.law_status.code)
+        else:
+            return -1

--- a/sample_data/contaminated_public_transport_sites/public_law_restriction.json
+++ b/sample_data/contaminated_public_transport_sites/public_law_restriction.json
@@ -4,7 +4,7 @@
     "published_from": "2016-02-25",
     "published_until": "2100-01-01",
     "id": 396,
-    "law_status": "inKraft",
+    "law_status": "AenderungMitVorwirkung",
     "view_service_id": 1,
     "legend_entry_id": 2
   }, {
@@ -20,7 +20,7 @@
     "published_from": "2016-02-25",
     "published_until": "2100-01-01",
     "id": 398,
-    "law_status": "inKraft",
+    "law_status": "AenderungMitVorwirkung",
     "view_service_id": 1,
     "legend_entry_id": 3
   }, {
@@ -28,7 +28,7 @@
     "published_from": "2016-02-25",
     "published_until": "2100-01-01",
     "id": 399,
-    "law_status": "inKraft",
+    "law_status": "AenderungOhneVorwirkung",
     "view_service_id": 1,
     "legend_entry_id": 3
   }, {

--- a/tests/init_db.py
+++ b/tests/init_db.py
@@ -380,6 +380,18 @@ class DummyData(object):
             'land_registry_area': 9,
             'limit': 'SRID=2056;MULTIPOLYGON(((2 0, 2 3, 5 3, 5 0, 2 0)))'
         })
+        connection.execute(main.RealEstate.__table__.insert(), {
+            'id': '3',
+            'egrid': u'TEST3',
+            'number': u'9998',
+            'identdn': u'BLTEST',
+            'type': u'Liegenschaft',
+            'canton': u'BL',
+            'municipality': u'Liestal',
+            'fosnr': 1234,
+            'land_registry_area': 8,
+            'limit': 'SRID=2056;MULTIPOLYGON(((0 3, 2 3, 6 3, 6 5, 0 5, 0 3)))'
+        })
 
         # Add dummy real estate types
         connection.execute(main.RealEstateType.__table__.insert(), {
@@ -485,7 +497,7 @@ class DummyData(object):
         })
         connection.execute(motorways_building_lines.PublicLawRestriction.__table__.insert(), {
             'id': '2',
-            'law_status': u'inKraft',
+            'law_status': u'AenderungOhneVorwirkung',
             'published_from': date.today().isoformat(),
             'view_service_id': '1',
             'office_id': '1',
@@ -493,7 +505,7 @@ class DummyData(object):
         })
         connection.execute(motorways_building_lines.PublicLawRestriction.__table__.insert(), {
             'id': '3',
-            'law_status': u'AenderungOhneVorwirkung',
+            'law_status': u'inKraft',
             'published_from': date.today().isoformat(),
             'view_service_id': '1',
             'office_id': '1',
@@ -521,7 +533,7 @@ class DummyData(object):
             'published_from': date.today().isoformat(),
             'public_law_restriction_id': '2',
             'office_id': '1',
-            'geom': u'SRID=2056;LINESTRING (1.5 1.5, 1.5 2.5)'
+            'geom': u'SRID=2056;LINESTRING (1.5 1.5, 1.5 4)'
         })
         connection.execute(motorways_building_lines.Geometry.__table__.insert(), {
             'id': '3',

--- a/tests/init_db.py
+++ b/tests/init_db.py
@@ -477,7 +477,7 @@ class DummyData(object):
         })
         connection.execute(motorways_building_lines.PublicLawRestriction.__table__.insert(), {
             'id': '1',
-            'law_status': u'inKraft',
+            'law_status': u'AenderungMitVorwirkung',
             'published_from': date.today().isoformat(),
             'view_service_id': '1',
             'office_id': '1',
@@ -493,7 +493,7 @@ class DummyData(object):
         })
         connection.execute(motorways_building_lines.PublicLawRestriction.__table__.insert(), {
             'id': '3',
-            'law_status': u'inKraft',
+            'law_status': u'AenderungOhneVorwirkung',
             'published_from': date.today().isoformat(),
             'view_service_id': '1',
             'office_id': '1',

--- a/tests/init_db.py
+++ b/tests/init_db.py
@@ -411,6 +411,8 @@ class DummyData(object):
             'code': 'Bergwerk',
             'text': {'de': 'Bergwerk', 'fr': 'Mine', 'it': 'Miniera', 'rm': 'Miniera', 'en': 'Mine'}
         })
+
+        # Add dummy law statuses
         connection.execute(main.LawStatus.__table__.insert(), {
             'code': 'inKraft',
             "text": {"de": "Rechtskräftig", "fr": "En vigueur",

--- a/tests/readers/test_extract.py
+++ b/tests/readers/test_extract.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import pytest
+from pyramid.path import DottedNameResolver
+from shapely.geometry import MultiPolygon, Polygon
+
+from pyramid_oereb.lib.config import Config
+from pyramid_oereb.lib.records.extract import ExtractRecord
+from pyramid_oereb.lib.records.plr import PlrRecord
+from pyramid_oereb.lib.records.real_estate import RealEstateRecord
+from pyramid_oereb.lib.records.view_service import ViewServiceRecord
+from pyramid_oereb.lib.records.municipality import MunicipalityRecord
+from pyramid_oereb.lib.records.image import ImageRecord
+from pyramid_oereb.lib.readers.extract import ExtractReader
+from tests.mockrequest import MockParameter
+
+
+plr_cadastre_authority = Config.get_plr_cadastre_authority()
+
+plr_sources = []
+for plr in Config.get('plrs'):
+    plr_source_class = DottedNameResolver().maybe_resolve(plr.get('source').get('class'))
+    plr_sources.append(plr_source_class(**plr))
+
+real_estate = RealEstateRecord(u'test', u'BL', u'Laufen', 2770, 1000,
+                               MultiPolygon([Polygon([(0, 0), (4, 4), (4, 0)])]),
+                               ViewServiceRecord(
+                                   {'de': 'test_link'},
+                                   1,
+                                   1.0,
+                               ))
+
+municipality = MunicipalityRecord(
+        969,
+        u'FantasyMunicipality',
+        True,
+        ImageRecord('1'.encode('utf-8')),
+        geom=MultiPolygon()
+    )
+
+
+@pytest.mark.run(order=2)
+def test_init():
+    reader = ExtractReader(plr_sources, plr_cadastre_authority)
+    assert isinstance(reader._plr_sources_, list)
+
+
+@pytest.mark.run(order=2)
+def test_read():
+    reader = ExtractReader(plr_sources, plr_cadastre_authority)
+    extract = reader.read(MockParameter(), real_estate, municipality)
+    assert isinstance(extract, ExtractRecord)
+    plrs = extract.real_estate.public_law_restrictions
+    assert isinstance(plrs, list)
+    assert isinstance(plrs[0], PlrRecord)
+    assert plrs[4].theme.code == 'MotorwaysBuildingLines'
+    assert plrs[4].law_status.code == 'AenderungMitVorwirkung'

--- a/tests/readers/test_law_status.py
+++ b/tests/readers/test_law_status.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from pyramid_oereb.lib.config import Config
+from pyramid_oereb.lib.records.law_status import LawStatusRecord
+from pyramid_oereb.lib.sources import Base
+from pyramid_oereb.lib.readers.law_status import LawStatusReader
+
+
+@pytest.mark.run(order=2)
+def test_init():
+    reader = LawStatusReader(
+        Config.get_law_status_config().get('source').get('class'),
+        **Config.get_law_status_config().get('source').get('params')
+    )
+    assert isinstance(reader._source_, Base)
+
+
+@pytest.mark.run(order=2)
+def test_read():
+    reader = LawStatusReader(
+        Config.get_law_status_config().get('source').get('class'),
+        **Config.get_law_status_config().get('source').get('params')
+    )
+    results = reader.read()
+    assert isinstance(results, list)
+    assert len(results) == 3
+    result = results[0]
+    assert isinstance(result, LawStatusRecord)
+    assert result.code == 'inKraft'
+    assert result.text['fr'] == 'En vigueur'

--- a/tests/sources/test_law_status_database.py
+++ b/tests/sources/test_law_status_database.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from pyramid_oereb.lib.config import Config
+from pyramid_oereb.lib.adapter import DatabaseAdapter
+from pyramid_oereb.standard.sources.law_status import DatabaseSource
+from pyramid_oereb.standard.models.main import LawStatus
+from tests.mockrequest import MockParameter
+
+
+@pytest.mark.run(order=2)
+def test_init():
+    source = DatabaseSource(**Config.get_law_status_config().get('source').get('params'))
+    assert isinstance(source._adapter_, DatabaseAdapter)
+    assert source._model_ == LawStatus
+
+
+def test_read():
+    source = DatabaseSource(**Config.get_law_status_config().get('source').get('params'))
+    source.read(MockParameter())
+    assert isinstance(source.records, list)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -20,6 +20,9 @@ from pyramid_oereb.lib.readers.real_estate import RealEstateReader
 from pyramid_oereb.views.webservice import PlrWebservice
 from tests.mockrequest import MockRequest
 
+import logging
+log = logging.getLogger(__name__)
+
 request_matchdict = {
     'format': 'json'
 }
@@ -254,3 +257,20 @@ def test_processor_get_legend_entries():
     outside_plrs = [plr4]
     after_process = Processor.get_legend_entries(inside_plrs, outside_plrs)
     assert len(after_process) == 1
+
+
+def test_processor_sort_by_law_status():
+    request = MockRequest()
+    request.matchdict.update(request_matchdict)
+    request.params.update(request_params)
+    processor = create_processor()
+    webservice = PlrWebservice(request)
+    params = webservice.__validate_extract_params__()
+    real_estate = processor.real_estate_reader.read(params, egrid=u'TEST3')
+    extract = processor.process(real_estate[0], params, 'http://test.ch')
+    plrs = extract.real_estate.public_law_restrictions
+    assert len(plrs) == 4
+    assert plrs[1].theme.code == 'MotorwaysBuildingLines'
+    assert plrs[1].law_status.code == 'inKraft'
+    assert plrs[2].theme.code == 'MotorwaysBuildingLines'
+    assert plrs[2].law_status.code == 'AenderungOhneVorwirkung'

--- a/tests/webservice/test_getegrid.py
+++ b/tests/webservice/test_getegrid.py
@@ -100,7 +100,7 @@ def test_getegrid_en():
 def test_getegrid_gnss():
     with pyramid_oereb_test_config():
         request = MockRequest(
-            current_route_url='http://example.com/oereb/getegrid/json/?GNSS=-19.917989937473,32.1244978460310'
+            current_route_url='http://example.com/oereb/getegrid/json/?GNSS=32.1244978460310,-19.917989937473'
         )
 
         # Add params to matchdict as the view will do it for /getegrid/{format}/


### PR DESCRIPTION
Issues #1194 and #1222 (group PLR according to their law status)

What changes: in the extract, the PLR are sorted by theme (as it was already the case) and by law status (new - before, they would appear as ordered in the DB). I had to edit the sample data because all PLR were `inKraft`. To see the effect of the sorting, check the PLR for the theme `ContaminatedPublicTransportSites` in the sample data. Here is a snippet of the resulting JSON extract:
```json
      "RealEstate": {
      [...]
        "RestrictionOnLandownership": [
          {
            "LegendText": [
              {
                "Language": "de",
                "Text": "Belastet, untersuchungsbedürftig"
              }
            ],
            "Theme": {
              "Code": "ContaminatedPublicTransportSites",
              "Text": {
                "Language": "de",
                "Text": "Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs"
              }
            },
            "Lawstatus": {
              "Code": "inKraft",
              "Text": [
                {
                  "Language": "de",
                  "Text": "Rechtskräftig"
                }
              ]
            },
          },
    [...]
          {
            "LegendText": [
              {
                "Language": "de",
                "Text": "Belastet, untersuchungsbedürftig"
              }
            ],
            "Theme": {
              "Code": "ContaminatedPublicTransportSites",
              "Text": {
                "Language": "de",
                "Text": "Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs"
              }
            },
            "Lawstatus": {
              "Code": "inKraft",
              "Text": [
                {
                  "Language": "de",
                  "Text": "Rechtskräftig"
                }
              ]
            },
          },
    [...]
          {
            "LegendText": [
              {
                "Language": "de",
                "Text": "Belastet, untersuchungsbedürftig"
              }
            ],
            "Theme": {
              "Code": "ContaminatedPublicTransportSites",
              "Text": {
                "Language": "de",
                "Text": "Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs"
              }
            },
            "Lawstatus": {
              "Code": "AenderungMitVorwirkung",
              "Text": [
                {
                  "Language": "de",
                  "Text": "Änderung mit Vorwirkung"
                }
              ]
            },
          },
    [...]
          {
            "LegendText": [
              {
                "Language": "de",
                "Text": "Belastet, untersuchungsbedürftig"
              }
            ],
            "Theme": {
              "Code": "ContaminatedPublicTransportSites",
              "Text": {
                "Language": "de",
                "Text": "Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs"
              }
            },
            "Lawstatus": {
              "Code": "AenderungMitVorwirkung",
              "Text": [
                {
                  "Language": "de",
                  "Text": "Änderung mit Vorwirkung"
                }
              ]
            },
          },
    [...]
          {
            "LegendText": [
              {
                "Language": "de",
                "Text": "Belastet, untersuchungsbedürftig"
              }
            ],
            "Theme": {
              "Code": "ContaminatedPublicTransportSites",
              "Text": {
                "Language": "de",
                "Text": "Kataster der belasteten Standorte im Bereich des öffentlichen Verkehrs"
              }
            },
            "Lawstatus": {
              "Code": "AenderungOhneVorwirkung",
              "Text": [
                {
                  "Language": "de",
                  "Text": "Änderung ohne Vorwirkung"
                }
              ]
            },
           }
[...]
```
It seems to me that this fits to the new specification but let me know if you think that's not the case (in particular, it seemed to me there were some redundancy between #1194  #1222 and #1261 so I might have missed something)