### PR TITLE
Use specific error message in print proxy

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -71,6 +71,9 @@ class Renderer(JsonRenderer):
         if 'lang' in self._lowercase_GET_dict:
             self._language = self._lowercase_GET_dict.get('lang')
 
+        self._static_error_message = Config.get('static_error_message').get(self._language) or \
+            Config.get('static_error_message').get(self._fallback_language)
+
         # Based on extract record and webservice parameter, render the extract data as JSON
         extract_record = value[0]
         extract_as_dict = self._render(extract_record, value[1])
@@ -136,14 +139,14 @@ class Renderer(JsonRenderer):
         except PdfReadError as e:
             err_msg = 'a problem occurred while generating the pdf file'
             log.error(err_msg + ': ' + str(e))
-            raise HTTPInternalServerError(err_msg)
+            raise HTTPInternalServerError(self._static_error_message)
 
         try:
             content = print_result.content
         except PdfReadError as e:
             err_msg = 'No contents from print result available!'
             log.error(err_msg + ': ' + str(e))
-            raise HTTPInternalServerError(err_msg)
+            raise HTTPInternalServerError(self._static_error_message)
 
         # Save printed file to the specified path.
         pdf_archive_path = print_config.get('pdf_archive_path', None)

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -1115,3 +1115,10 @@ pyramid_oereb:
         inKraft: inKraft
         AenderungMitVorwirkung: AenderungMitVorwirkung
         AenderungOhneVorwirkung: AenderungOhneVorwirkung
+
+  # The error message returned if an error occurs when requesting a static extract
+  # The content of the message is defined in the specification (document "Inhalt und Darstellung des statischen Auszugs")
+  static_error_message:
+    de: "Ein oder mehrere ÖREB-Themen stehen momentan nicht zur Verfügung. Daher kann kein Auszug erstellt werden. Versuchen Sie es zu einem späteren Zeitpunkt erneut. Wir entschuldigen uns für die Unannehmlichkeiten."
+    fr: "Un ou plusieurs thèmes RDPPF sont momentanément indisponibles. L’extrait ne peut donc pas être établi. Veuillez réessayer plus tard. Nous vous prions de nous excuser pour ce désagrément."
+    it: "Uno o più temi relativi alle RDPP non sono attualmente disponibili. Non è pertanto possibile allestire alcun estratto. Vi preghiamo di riprovare più tardi. Ci scusiamo per l’inconveniente."


### PR DESCRIPTION
Closes https://github.com/openoereb/pyramid_oereb/issues/1210 (part 2)
I left the original error messages in the server logs, as I think it would be too confusing otherwise.
As already mentioned I think this error message should be returned for any error ocurring during a static extract request (not just in the print proxy) in order to conform to the specification.
Thanks in advance for reviewing

To test:
Turn on PDF-A in `oereb-print` and request http://localhost:6543/oereb/extract/pdf?EGRID=CH113928077734