### PR TITLE
Add more infos upon error

### DIFF
--- a/pyramid_oereb/lib/__init__.py
+++ b/pyramid_oereb/lib/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import traceback
 
 from pyramid.httpexceptions import HTTPInternalServerError
 
@@ -13,6 +14,10 @@ def get_multilingual_element(value, language, not_null=True):
         msg = 'Default language "{language}" is not available in: \n {element}'\
             .format(language=language, element=value)
         log.error(msg)
+        log.info("Call stack of failing get_multilingual_element:")
+        for line in traceback.format_stack():
+            log.info("{}".format(line))
+
         raise HTTPInternalServerError()
 
     return multilingual_value

--- a/pyramid_oereb/lib/config.py
+++ b/pyramid_oereb/lib/config.py
@@ -497,8 +497,8 @@ class Config(object):
             if lookup[key] == code:
                 return lookup
         raise ConfigurationError(
-            'Document type lookup with key "{}" and code "{}" is not '
-            'defined in configuration!'.format(key, code)
+            'Document type lookup for theme {} with key "{}" and code "{}" is not '
+            'defined in configuration!'.format(theme_code, key, code)
         )
 
     @staticmethod
@@ -977,8 +977,8 @@ class Config(object):
             if lookup[key] == code:
                 return lookup
         raise ConfigurationError(
-            'Document type lookup with key "{}" and code "{}" is not'
-            'defined in configuration!'.format(key, code)
+            'Document type lookup for theme {} with key "{}" and code "{}" is not '
+            'defined in configuration!'.format(theme_code, key, code)
         )
 
     @staticmethod
@@ -1114,7 +1114,7 @@ class Config(object):
         lookups = Config.get_real_estate_type_config().get('lookup')
         if lookups is None:
             raise ConfigurationError(
-                '"lookup" must be defined in configuration for theme real_estate_type!'
+                '"lookup" must be defined in configuration for real_estate_type!'
             )
         return lookups
 


### PR DESCRIPTION
Partially addresses #1381 

Notably regarding the get_multilingual_element, adding a stack trace, to show where the call came from.