### PR TITLE
setup fixture for creation of temporary test DB

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,9 +80,8 @@ def base_engine(pyramid_oereb_test_base_config):
 
 
 @pytest.fixture(scope='session')
-def test_db_name(pyramid_oereb_test_base_config):
-    base_db_url = pyramid_oereb_test_base_config.get('app_schema').get('db_connection')
-    split_url = urlsplit(base_db_url)
+def test_db_name(test_db_url):
+    split_url = urlsplit(test_db_url)
     yield split_url.path.strip('/')
 
 
@@ -114,11 +113,6 @@ def test_db_engine(base_engine, test_db_name, test_db_url, config_path):
     # initialize the DB with standard tables via a temp string buffer to hold SQL commands
     sql_file = StringIO()
     create_tables_from_standard_configuration(config_path, sql_file=sql_file)
-    for theme_config in Config.get('plrs'):
-        # force load non standard tables for special tests
-        if not theme_config.get('standard'):
-            theme_config['standard'] = True
-            create_theme_tables_(theme_config, sql_file=sql_file)
     sql_file.seek(0)
     engine.execute(sql_file.read())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,11 +118,15 @@ def test_db_engine(base_engine, test_db_name, test_db_url, config_path):
 
     yield engine
 
-    # do cleanup: disconnect users and DROP DB
-    base_connection.execute('SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE '
-                            f'pg_stat_activity.datname = \'{test_db_name}\' AND pid <> pg_backend_pid();')
-    base_connection.execute('COMMIT')
-    base_connection.execute(f"DROP DATABASE if EXISTS {test_db_name}")
+    # currently there is a problem with teardown of the DB and sessions:
+    # DROP DATABASE may be called while a connection is still alive, this may lead to error messages
+    # therefore, the DB will temporarily be dropped at the beginning of the test instead of a final
+    # cleanup (see above)
+    # # do cleanup: disconnect users and DROP DB
+    # base_connection.execute('SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE '
+    #                         f'pg_stat_activity.datname = \'{test_db_name}\' AND pid <> pg_backend_pid();')
+    # base_connection.execute('COMMIT')
+    # base_connection.execute(f"DROP DATABASE if EXISTS {test_db_name}")
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,7 @@ from pyramid_oereb.core.records.glossary import GlossaryRecord
 from pyramid_oereb.core.records.office import OfficeRecord
 from pyramid_oereb.core.records.real_estate import RealEstateRecord
 from pyramid_oereb.core.records.view_service import ViewServiceRecord
-from pyramid_oereb.contrib.data_sources.create_tables import (
-    create_tables_from_standard_configuration,
-    create_theme_tables_
-)
+from pyramid_oereb.contrib.data_sources.create_tables import create_tables_from_standard_configuration
 
 SCHEMA_JSON_EXTRACT_PATH = './tests/resources/schema/20210415/extract.json'
 SCHEMA_JSON_VERSIONS_PATH = './tests/resources/schema/20210415/versioning.json'

--- a/tests/resources/test_config.yml
+++ b/tests/resources/test_config.yml
@@ -4,7 +4,7 @@ pyramid_oereb:
     name: pyramid_oereb_main
     models: pyramid_oereb.contrib.data_sources.standard.models.main
     db_connection: &main_db_connection
-      postgresql://postgres:postgres@localhost:5432/pyramid_oereb_test
+      postgresql://postgres:postgres@localhost:5432/oereb_test_db
 
     law_status_lookup:
       - data_code: inKraft

--- a/tests/resources/test_config.yml
+++ b/tests/resources/test_config.yml
@@ -65,6 +65,7 @@ pyramid_oereb:
         - data_code: inKraft
           transfer_code: inKraft
           extract_code: inForce
+      standard: true
       source:
         class: pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource
         params:
@@ -99,6 +100,7 @@ pyramid_oereb:
         - data_code: inKraft
           transfer_code: inKraft
           extract_code: inForce
+      standard: true
       source:
         class: pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource
         params:
@@ -122,6 +124,7 @@ pyramid_oereb:
         - data_code: Hinweis
           transfer_code: Hinweis
           extract_code: Hint
+      standard: true
       source:
         class: pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource
         params:


### PR DESCRIPTION
From an existing DB connection configured in the yaml file, this fixture creates then deletes a temporary database only to setup test data