### PR TITLE
1410 fix doc

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,8 @@
+engines:
+  bandit:
+    exclude_paths:
+      - "doc/source/conf.py"
+
 exclude_paths:
   - 'tests/**'
   - 'sample_data/**.json'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,26 @@ jobs:
           path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
 
+  doc:
+    name: Make and deploy documentation
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1410_fix_doc'
+    runs-on: ubuntu-20.04
+    needs: deploy-dev
+    steps:
+      - uses: actions/checkout@v2
+      - name: Make documentation
+        run: |
+          sudo rm /etc/apt/sources.list.d/*.list
+          sudo apt update
+          sudo apt-get install virtualenv libpq-dev libgeos-dev
+          make doc-html
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: doc/build/html # The folder the action should deploy.
+
+
   build-and-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,6 @@ jobs:
     name: Make and deploy documentation
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1410_fix_doc'
     runs-on: ubuntu-20.04
-    needs: deploy-dev
     steps:
       - uses: actions/checkout@v2
       - name: Make documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
 
   doc:
     name: Make and deploy documentation
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/1410_fix_doc'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,7 @@ flake8==3.9.2
 pycodestyle==2.7.0
 psycopg2==2.9.1
 McCabe==0.6.1
+Sphinx<1.6
+sphinx_rtd_theme
 c2c.template==2.0.9  # rq.filter: <= 2.1
 -e .

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -111,26 +111,26 @@ Oereblex related changes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 pyramid_oereb now supports and uses by default the Oereblex geoLink schema version 1.2.0 (#1010):
 
- * New doctype 'notice' (will be classified as 'HintRecord'). If you want to add related notices as
-   additional legal provisions directly on public law restrictions, you should set the new oereblex
-   'related_notice_as_main' flag in the config of the project.
- * 'Notice' can have no authority nor enactment_date. In this case, the enactment date will be
-   '01.01.1970' and the authority '-'.
- * 'Notice' can have no authority_at_web. In previous versions, this was not supported by MapFish Print.
-   If you use MapFish Print with Oereblex 1.2.0, you must update your MapFish Print templates.
- * The new document attribute 'language' and the new file attribute 'description' are currently not used by
-   pyramid_oereb, but are now available to custom code, for example for document title generation.
+* New doctype 'notice' (will be classified as 'HintRecord'). If you want to add related notices as
+  additional legal provisions directly on public law restrictions, you should set the new oereblex
+  'related_notice_as_main' flag in the config of the project.
+* 'Notice' can have no authority nor enactment_date. In this case, the enactment date will be
+  '01.01.1970' and the authority '-'.
+* 'Notice' can have no authority_at_web. In previous versions, this was not supported by MapFish Print.
+  If you use MapFish Print with Oereblex 1.2.0, you must update your MapFish Print templates.
+* The new document attribute 'language' and the new file attribute 'description' are currently not used by
+  pyramid_oereb, but are now available to custom code, for example for document title generation.
 
 MapFish Print related changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you are using MapFish Print, you must update your print templates and configuration to v1.7.3.
 The following improvements have been made:
 
- * The inclusion of all geometry data in the print payload is now configurable (#1006).
-   MapFish Print users should set the print configuration parameter ```with_geometry``` to ```False```
-   to improve performance.
- * It is now allowed to print reports with missing OfficeAtWeb information in documents, because
-   OfficeAtWeb is an optional attribute in the specification (#62).
+* The inclusion of all geometry data in the print payload is now configurable (#1006).
+  MapFish Print users should set the print configuration parameter ```with_geometry``` to ```False```
+  to improve performance.
+* It is now allowed to print reports with missing OfficeAtWeb information in documents, because
+  OfficeAtWeb is an optional attribute in the specification (#62).
 
 
 .. _changes-version-1.7.1:
@@ -981,7 +981,7 @@ Find an example configuration for OEREBlex below:
 .. note:: The configuration above is an example only. If you want to know more in detail what to configure
     and why please have a detailed look at the documentation of the used package
     `python_geolink_formatter <https://gf-bl.gitlab.io/python-geolink-formatter/v1.3.0/index.html>`__ and
-    :ref:`api-pyramid_oereb-contrib-sources-document-oereblexsource`.
+    ``api.pyramid_oereb.contrib.sources.document.oereblexsource``.
 
 
 Find an example configuration for land use plans below:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,7 +28,7 @@ import subprocess
 import sphinx_rtd_theme
 from pyramid_oereb.core.config import Config
 
-Config._config = {'srid': -1}
+Config._config = {'srid': -1, 'app_schema': {'name': 'pyramid_oereb_main'}}
 
 
 # -- General configuration ------------------------------------------------
@@ -84,28 +84,46 @@ with open('contrib/stats.rst', 'w') as sources:
         '../../.venv/bin/mako-render' if os.path.exists('../../.venv/bin/mako-render') else 'mako-render',
         'contrib/stats.rst.mako']).decode('utf-8'))
 
-files = glob.glob('../../pyramid_oereb/contrib/data_sources/standard/models/*.py')
-modules = [
-    re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
-    if not f.startswith("../../pyramid_oereb/standard/models/main.py") and
-    not f.startswith("../../pyramid_oereb/standard/models/__init__.py")
-]
-modules.sort()
-for module in modules:
-    __import__(module)
-classes = {}
-for module in modules:
-    classes[module] = []
-    for name, obj in inspect.getmembers(sys.modules[module]):
-        if inspect.isclass(obj) and obj.__module__ == module:
-            classes[module].append(name)
 module_file_names = []
-for module_name, classes in six.iteritems(classes):
-    file_name = module_name.replace('.', '_').lower()
-    module_file_names.append(file_name)
-    with open('standard/models/{name}.rst'.format(name=file_name), 'w') as sources:
-        template = Template(filename='standard/models/models.rst.mako')
-        sources.write(template.render(**{'module_name': module_name, 'classes': classes}))
+
+module_file_names.append('pyramid_oereb_contrib_data_sources_standard_models_main')
+
+from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser
+conf_parser = StandardThemeConfigParser(source={
+    "class": 'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource',
+    "params": {
+        "model_factory": "pyramid_oereb.contrib.data_sources.standard.models.theme.model_factory_string_pk",
+        "schema_name": "land_use_plans"
+    }
+})
+
+models = conf_parser.get_models()
+modelnames = [modelname for modelname in dir(models) if modelname[0].isupper()and modelname != 'Base']
+
+# create fake python module pyramid_oereb.contrib.data_sources.standard.factory_models
+import pyramid_oereb.contrib.data_sources.standard
+import types
+import sys
+factory_models = types.ModuleType('FactoryModels', 'Virtual module for factory generated classes')
+factory_models.__name__ = 'factory_models'
+factory_models.__mro__ = []
+factory_models.__module__ = 'pyramid_oereb.contrib.data_sources.standard'
+for modelname in modelnames:
+    model = models.__getattribute__(modelname)
+    model.__name__ = modelname
+    model.__module__ = 'pyramid_oereb.contrib.data_sources.standard.factory_models'
+    factory_models.__dict__.update({modelname: model})
+
+pyramid_oereb.contrib.data_sources.standard.__dict__.update({'factory_models': factory_models})
+sys.modules['pyramid_oereb.contrib.data_sources.standard.factory_models'] = factory_models
+
+module_name = 'pyramid_oereb.contrib.data_sources.standard.factory_models'
+file_name = module_name.replace('.', '_').lower()
+module_file_names.append(file_name)
+with open('standard/models/{name}.rst'.format(name=file_name), 'w') as sources:
+    template = Template(filename='standard/models/models.rst.mako')
+    sources.write(template.render(**{'module_name': module_name, 'classes': modelnames}))
+
 with open('standard/models/index.rst', 'w') as sources:
     template = Template(filename='standard/models/index.rst.mako')
     sources.write(template.render(**{'module_file_names': module_file_names}))
@@ -124,7 +142,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pyramid_oereb'
-copyright = u'2017-2020, openoereb community'
+copyright = u'2017-2022, openoereb community'
 author = u'openoereb community'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,17 +16,17 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import glob
-import inspect
 import os
 from mako.template import Template
 import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import re
-import six
 import subprocess
 import sphinx_rtd_theme
 from pyramid_oereb.core.config import Config
+from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser
+import pyramid_oereb.contrib.data_sources.standard
+import types
 
 Config._config = {'srid': -1, 'app_schema': {'name': 'pyramid_oereb_main'}}
 
@@ -88,7 +88,6 @@ module_file_names = []
 
 module_file_names.append('pyramid_oereb_contrib_data_sources_standard_models_main')
 
-from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser
 conf_parser = StandardThemeConfigParser(source={
     "class": 'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource',
     "params": {
@@ -98,12 +97,9 @@ conf_parser = StandardThemeConfigParser(source={
 })
 
 models = conf_parser.get_models()
-modelnames = [modelname for modelname in dir(models) if modelname[0].isupper()and modelname != 'Base']
+modelnames = [modelname for modelname in dir(models) if modelname[0].isupper() and modelname != 'Base']
 
 # create fake python module pyramid_oereb.contrib.data_sources.standard.factory_models
-import pyramid_oereb.contrib.data_sources.standard
-import types
-import sys
 factory_models = types.ModuleType('FactoryModels', 'Virtual module for factory generated classes')
 factory_models.__name__ = 'factory_models'
 factory_models.__mro__ = []

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -147,7 +147,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pyramid_oereb'
-copyright = u'2017-2022, openoereb community'
+copyright = u'2017-2022, openoereb community'  # pylint: disable=W0622
 author = u'openoereb community'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,16 +19,17 @@
 import os
 from mako.template import Template
 import sys
+import inspect
 # sys.path.insert(0, os.path.abspath('.'))
 import re
+import types
 import subprocess
 import sphinx_rtd_theme
 from pyramid_oereb.core.config import Config
-from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser
-import pyramid_oereb.contrib.data_sources.standard
-import types
-
 Config._config = {'srid': -1, 'app_schema': {'name': 'pyramid_oereb_main'}}
+from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser  # noqa E402
+import pyramid_oereb.contrib.data_sources.standard  # noqa E402
+import pyramid_oereb.contrib.data_sources.standard.models.main  # noqa E402
 
 
 # -- General configuration ------------------------------------------------
@@ -85,8 +86,16 @@ with open('contrib/stats.rst', 'w') as sources:
         'contrib/stats.rst.mako']).decode('utf-8'))
 
 module_file_names = []
-
-module_file_names.append('pyramid_oereb_contrib_data_sources_standard_models_main')
+module_name = 'pyramid_oereb.contrib.data_sources.standard.models.main'
+file_name = 'pyramid_oereb_contrib_data_sources_standard_models_main'
+module_file_names.append(file_name)
+main_classes = []
+for name, obj in inspect.getmembers(pyramid_oereb.contrib.data_sources.standard.models.main):
+    if inspect.isclass(obj) and obj.__module__ == module_name:
+        main_classes.append(name)
+with open('standard/models/{name}.rst'.format(name=file_name), 'w') as sources:
+    template = Template(filename='standard/models/models.rst.mako')
+    sources.write(template.render(**{'module_name': module_name, 'classes': main_classes}))
 
 conf_parser = StandardThemeConfigParser(source={
     "class": 'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource',
@@ -117,7 +126,7 @@ module_name = 'pyramid_oereb.contrib.data_sources.standard.factory_models'
 file_name = module_name.replace('.', '_').lower()
 module_file_names.append(file_name)
 with open('standard/models/{name}.rst'.format(name=file_name), 'w') as sources:
-    template = Template(filename='standard/models/models.rst.mako')
+    template = Template(filename='standard/models/factory_models.rst.mako')
     sources.write(template.render(**{'module_name': module_name, 'classes': modelnames}))
 
 with open('standard/models/index.rst', 'w') as sources:

--- a/doc/source/contrib/print_proxy.rst.mako
+++ b/doc/source/contrib/print_proxy.rst.mako
@@ -6,7 +6,8 @@ Print Proxy
 <%! import glob, inspect, re, sys %>
 <%
 modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
-files = glob.glob('../../pyramid_oereb/contrib/print_proxy/*.py')
+files = glob.glob('../../pyramid_oereb/contrib/print_proxy/mapfish_print/*.py')
+files += glob.glob('../../pyramid_oereb/contrib/print_proxy/xml_2_pdf/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
 ]

--- a/doc/source/contrib/sources.rst.mako
+++ b/doc/source/contrib/sources.rst.mako
@@ -6,7 +6,9 @@ Sources
 <%! import glob, inspect, re, sys %>
 <%
 modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
-files = glob.glob('../../pyramid_oereb/contrib/sources/*.py')
+files = glob.glob('../../pyramid_oereb/contrib/data_sources/oereblex/sources/*.py')
+files += glob.glob('../../pyramid_oereb/contrib/data_sources/swisstopo/*.py')
+files += glob.glob('../../pyramid_oereb/contrib/data_sources/interlis_2_3/sources/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
 ]

--- a/doc/source/core/readers.rst.mako
+++ b/doc/source/core/readers.rst.mako
@@ -6,7 +6,7 @@ Readers
 <%! import glob, inspect, re, sys%>
 <%
 modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
-files = glob.glob('../../pyramid_oereb/lib/readers/*.py')
+files = glob.glob('../../pyramid_oereb/core/readers/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
 ]

--- a/doc/source/core/records.rst.mako
+++ b/doc/source/core/records.rst.mako
@@ -6,7 +6,7 @@ Records
 <%! import glob, inspect, re, sys %>
 <%
 modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
-files = glob.glob('../../pyramid_oereb/lib/records/*.py')
+files = glob.glob('../../pyramid_oereb/core/records/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
 ]

--- a/doc/source/core/sources.rst.mako
+++ b/doc/source/core/sources.rst.mako
@@ -6,7 +6,7 @@ Sources
 <%! import glob, inspect, re, sys %>
 <%
 modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
-files = glob.glob('../../pyramid_oereb/lib/sources/*.py')
+files = glob.glob('../../pyramid_oereb/core/sources/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
 ]

--- a/doc/source/standard/index.rst
+++ b/doc/source/standard/index.rst
@@ -17,38 +17,15 @@ layer.
 Functions for creating standard environment
 -------------------------------------------
 
-.. _api-pyramid_oereb-standard:
-
-.. automodule:: pyramid_oereb.standard
-   :members:
-      create_tables_from_standard_configuration,
-      drop_tables_from_standard_configuration,
-      _create_standard_yaml_config_
-
 .. _api-pyramid_oereb-standard-create_tables:
 
-.. automodule:: pyramid_oereb.standard.create_tables
+.. automodule:: pyramid_oereb.contrib.data_sources.create_tables
    :members:
-      _create_theme_tables
-
-Functions for filling standard environment with data
-----------------------------------------------------
-
-.. _api-pyramid_oereb-standard-load_sample_data:
-
-.. automodule:: pyramid_oereb.standard.load_sample_data
-   :members:
-      SampleData
-
-.. _api-pyramid_oereb-standard-import_federal_topic:
-
-.. automodule:: pyramid_oereb.standard.import_federal_topic
-   :members:
-      FederalTopic
+      create_tables_from_standard_configuration
 
 .. _api-pyramid_oereb-standard-load_legend_entries:
 
-.. automodule:: pyramid_oereb.standard.load_legend_entries
+.. automodule:: pyramid_oereb.contrib.data_sources.standard.load_legend_entries
    :members:
       create_legend_entries_in_standard_db
 
@@ -57,5 +34,5 @@ Functions used as configurable hooks
 
 .. _api-pyramid_oereb-standard-hook_methods:
 
-.. automodule:: pyramid_oereb.standard.hook_methods
+.. automodule:: pyramid_oereb.contrib.data_sources.standard.hook_methods
    :members:

--- a/doc/source/standard/models/factory_models.rst.mako
+++ b/doc/source/standard/models/factory_models.rst.mako
@@ -5,7 +5,11 @@
 *${module_name.split('.')[-1].title().replace('_', ' ')}*
 ${re.sub('.', '^', module_name.split('.')[-1].title().replace('_', ' ') + '  ')}
 
-.. automodule:: ${module_name}
+TODO: improve explication of how generic classes adapt to themes
+
+The classes below are generated through a class builder factory and are customized for the different themes (TODO: insert link) which make up the app.
+
+.. autoclass:: ${module_name}
 
 %for cls in classes:
 
@@ -15,9 +19,5 @@ ${cls}
 ${re.sub('.', '~', cls)}
 
 .. autoclass:: ${module_name}.${cls}
-   :members:
-   :inherited-members:
-
-   .. automethod:: __init__
 
 %endfor

--- a/doc/source/standard/models/index.rst.mako
+++ b/doc/source/standard/models/index.rst.mako
@@ -3,7 +3,7 @@
 Models
 ======
 
-.. automodule:: pyramid_oereb.standard.models
+.. automodule:: pyramid_oereb.contrib.data_sources.standard.models
 
 
 .. toctree::

--- a/doc/source/standard/models/models.rst.mako
+++ b/doc/source/standard/models/models.rst.mako
@@ -5,7 +5,11 @@
 *${module_name.split('.')[-1].title().replace('_', ' ')}*
 ${re.sub('.', '^', module_name.split('.')[-1].title().replace('_', ' ') + '  ')}
 
-.. automodule:: ${module_name}
+TODO: improve explication of how generic classes adapt to themes
+
+The classes below are generated through a class builder factory and are customized for the different themes (TODO: insert link) which make up the app.
+
+.. autoclass:: ${module_name}
 
 %for cls in classes:
 
@@ -15,9 +19,5 @@ ${cls}
 ${re.sub('.', '~', cls)}
 
 .. autoclass:: ${module_name}.${cls}
-   :members:
-   :inherited-members:
-
-   .. automethod:: __init__
 
 %endfor

--- a/doc/source/standard/sources.rst.mako
+++ b/doc/source/standard/sources.rst.mako
@@ -6,7 +6,7 @@ Sources
 <%! import glob, inspect, re, sys %>
 <%
 modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
-files = glob.glob('../../pyramid_oereb/standard/sources/*.py')
+files = glob.glob('../../pyramid_oereb/core/sources/*.py')
 modules = [
     re.sub(r'\.__init__', '', f[6:-3].replace("/", ".")) for f in files
 ]

--- a/pyramid_oereb/contrib/data_sources/standard/models/main.py
+++ b/pyramid_oereb/contrib/data_sources/standard/models/main.py
@@ -65,9 +65,10 @@ class RealEstate(Base):
             based on which is  delivering a machine readable response format (XML).
         land_registry_area (str): The amount of the area of this real estate as it is declared in
             the land  registers information.
+
         limit (geoalchemy2.types.Geometry): The geometry of real estates border. For type
-            information see geoalchemy2_.  .. _geoalchemy2:
-            https://geoalchemy-2.readthedocs.io/en/0.2.4/types.html  docs dependent on the
+            information see `geoalchemy2 <https://geoalchemy-2.readthedocs.io/en/0.8.4/types.html>`_
+            docs dependent on the
             configured type.  This concrete one is MULTIPOLYGON
     """
     __table_args__ = {'schema': app_schema_name}
@@ -100,8 +101,8 @@ class Municipality(Base):
         published (bool): Switch whether a municipality is published or not. This has direct
             influence on extract  generation.
         geom (geoalchemy2.types.Geometry): The geometry of municipality borders. For type
-            information see geoalchemy2_.  .. _geoalchemy2:
-            https://geoalchemy-2.readthedocs.io/en/0.2.4/types.html  docs dependent on the
+            information see `geoalchemy2 <https://geoalchemy-2.readthedocs.io/en/0.8.4/types.html>`_
+            docs dependent on the
             configured type.  This concrete one is MULTIPOLYGON
     """
     __table_args__ = {'schema': app_schema_name}
@@ -123,8 +124,8 @@ class Address(Base):
         street_number (str): The house number of this address.
         zip_code (int): The ZIP code for this address.
         geom (geoalchemy2.types.Geometry): The geometry of real estates border. For type information
-            see geoalchemy2_.  .. _geoalchemy2:
-            https://geoalchemy-2.readthedocs.io/en/0.2.4/types.html  docs dependent on the
+            see `geoalchemy2 <https://geoalchemy-2.readthedocs.io/en/0.8.4/types.html>`_
+            docs dependent on the
             configured type.  This concrete one is POINT
     """
     __table_args__ = (

--- a/pyramid_oereb/core/readers/general_information.py
+++ b/pyramid_oereb/core/readers/general_information.py
@@ -27,10 +27,12 @@ class GeneralInformationReader(object):
     def read(self):
         """
         The central read accessor method to get all desired records from configured source.
+
         .. note:: If you subclass this class your implementation needs to offer this method in the same
             signature. Means the parameters must be the same and the return must be a list of
             :ref:`api-pyramid_oereb-core-records-general_information-generalinformationrecord`.
             Otherwise the API like way the server works would be broken.
+
         Returns:
             list of pyramid_oereb.core.records.general_information.GeneralInformationRecord:
                 The list of found records. Since these are not filtered by any criteria the list simply

--- a/pyramid_oereb/core/readers/law_status.py
+++ b/pyramid_oereb/core/readers/law_status.py
@@ -27,11 +27,14 @@ class LawStatusReader(object):
     def read(self):
         """
         The central read accessor method to get all desired records from configured source.
+
         .. note:: If you subclass this class your implementation needs to offer this method in the same
             signature. Means the parameters must be the same and the return must be a list of
             :ref:`api-pyramid_oereb-core-records-lawstatus-lawstatusrecord`.
             Otherwise the API like way the server works would be broken.
+
         params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
+
         Returns:
             list of pyramid_oereb.core.records.lawstatus.LawStatusRecord:
                 The list of found records. Since these are not filtered by any criteria the list simply

--- a/pyramid_oereb/core/records/view_service.py
+++ b/pyramid_oereb/core/records/view_service.py
@@ -69,9 +69,9 @@ class ViewServiceRecord(object):
             legends (list of LegendEntry or None): A list of all relevant legend entries.
 
         Attributes:
-        image (dict): multilingual dictionary containing the binary image
-            (pyramid_oereb.core.records.image.ImageRecord) downloaded from WMS link for the
-            requested (if any) or default language. Empty for an extract without images
+            image (dict): multilingual dictionary containing the binary image
+                (pyramid_oereb.core.records.image.ImageRecord) downloaded from WMS link for the
+                requested (if any) or default language. Empty for an extract without images
         """
         self.reference_wms = reference_wms
         self.image = dict()  # multilingual dict with binary map images resulting from calling the wms link


### PR DESCRIPTION
Reactivate automatic doc generation on push @master.

Additionally, we could activate automatic doc generation on another well defined branch (eg. doc_test_branch) as had been done temporarily for test purposes here: https://github.com/openoereb/pyramid_oereb/commit/8adae1aba66f645682ec6e7aa8363bf4109aaabb#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL84

The results of the doc build are visible on the github pages https://openoereb.github.io/pyramid_oereb/
(the current pages have been deployed by this workflow https://github.com/openoereb/pyramid_oereb/runs/4898582295?check_suite_focus=true)