### PR TITLE
Reorganize hook methods

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-omit =
-    pyramid_oereb/models.py
-    pyramid_oereb/standard/create_tables.py
-    pyramid_oereb/standard/drop_tables.py

--- a/.coveragerc.contrib-data_sources-standard
+++ b/.coveragerc.contrib-data_sources-standard
@@ -1,0 +1,3 @@
+[run]
+source =
+    pyramid_oereb/contrib/data_sources/standard/*.py

--- a/.coveragerc.contrib-print_proxy-mapfish_print
+++ b/.coveragerc.contrib-print_proxy-mapfish_print
@@ -1,0 +1,3 @@
+[run]
+source =
+    pyramid_oereb/contrib/print_proxy/mapfish_print/*.py

--- a/.coveragerc.core
+++ b/.coveragerc.core
@@ -1,0 +1,3 @@
+[run]
+source =
+    pyramid_oereb/core/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,23 +62,24 @@ jobs:
         env:
           PYTHON_TEST_VERSION: ${{ matrix.python-version }}
         run: make test-core
-      - name: Run contrib tests for Python ${{ matrix.python-version }}
+      - name: Run contrib-print_proxy-mapfish_print tests for Python ${{ matrix.python-version }}
         env:
           PYTHON_TEST_VERSION: ${{ matrix.python-version }}
-        run: make test-contrib
+        run: make test-contrib-print_proxy-mapfish_print
+      - name: Run contrib-data_sources-standard tests for Python ${{ matrix.python-version }}
+        env:
+          PYTHON_TEST_VERSION: ${{ matrix.python-version }}
+        run: make test-contrib-data_sources-standard
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/reports/
           env_vars: OS,PYTHON
           fail_ci_if_error: true
-          files: ./coverage.xml,./cov_contrib.xml
+          files: ./coverage.core.xml,./coverage.contrib-data_sources-standard.xml,./coverage.contrib-print_proxy-mapfish_print.xml
           flags: unittests
-          name: codecov-umbrella
-          path_to_write_report: ./coverage/codecov_report.txt
+          name: codecov-unittest
           verbose: true
-
   doc:
     name: Make and deploy documentation
     if: github.ref == 'refs/heads/master'
@@ -96,7 +97,6 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: doc/build/html # The folder the action should deploy.
-
 
   build-and-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,8 @@ DataExtract.json
 /dev/sample_data/ch.real_estate_type.json
 /dev/sample_data/ch.themes.json
 /dev/sample_data/ch.themes_docs.json
+
+/coverage.contrib-data_sources-standard.xml
+/coverage.contrib-print_proxy-mapfish_print.xml
+/coverage.core.xml
+/coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,9 @@ build: install $(DEV_CREATE_TABLES_SCRIPT) $(DEV_CONFIGURATION_YML) create_dev_d
 .PHONY: clean
 clean: clean_fed_data clean_dev_db_scripts
 	rm -f $(DEV_CONFIGURATION_YML)
+	rm -f core.xml
+	rm -f contrib-print_proxy-mapfish_print.xml
+	rm -f contrib-data_sources-standard.xml
 
 .PHONY: clean-all
 clean-all: clean
@@ -279,16 +282,19 @@ test-postgis:
 
 .PHONY: test-core
 test-core: .venv/requirements-timestamp
-	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc --cov $(PACKAGE) --cov-report=xml tests/core
+	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.core --cov $(PACKAGE)/core --cov-report=term-missing --cov-report=xml:coverage.core.xml tests/core
 
-.PHONY: test-contrib
-test-contrib: .venv/requirements-timestamp
-	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc --cov $(PACKAGE) --cov-report xml:cov_contrib.xml tests/contrib.print_proxy.mapfish_print
+.PHONY: test-contrib-print_proxy-mapfish_print
+test-contrib-print_proxy-mapfish_print: .venv/requirements-timestamp
+	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-print_proxy-mapfish_print --cov $(PACKAGE) --cov-report xml:coverage.contrib-print_proxy-mapfish_print.xml tests/contrib.print_proxy.mapfish_print
 	# $(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc --cov $(PACKAGE) --cov-report term-missing:skip-covered tests/contrib.print_proxy.xml_2_pdf
 
+.PHONY: test-contrib-data_sources-standard
+test-contrib-data_sources-standard: .venv/requirements-timestamp
+	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-data_sources-standard --cov $(PACKAGE)/contrib/data_sources/standard --cov-report=term-missing:skip-covered --cov-report=xml:coverage.contrib-data_sources-standard.xml tests/contrib.data_sources.standard
+
 .PHONY: tests
-tests: .venv/requirements-timestamp
-	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc --cov $(PACKAGE) --cov-report term-missing:skip-covered tests/$(PYTEST_PATH)
+tests: .venv/requirements-timestamp test-core test-contrib-data_sources-standard test-contrib-print_proxy-mapfish_print
 
 .PHONY: check
 check: git-attributes lint test

--- a/Makefile
+++ b/Makefile
@@ -254,9 +254,9 @@ build: install $(DEV_CREATE_TABLES_SCRIPT) $(DEV_CONFIGURATION_YML) create_dev_d
 .PHONY: clean
 clean: clean_fed_data clean_dev_db_scripts
 	rm -f $(DEV_CONFIGURATION_YML)
-	rm -f core.xml
-	rm -f contrib-print_proxy-mapfish_print.xml
-	rm -f contrib-data_sources-standard.xml
+	rm -f coverage.core.xml
+	rm -f coverage.contrib-data_sources-standard.xml
+	rm -f coverage.contrib-print_proxy-mapfish_print.xml
 
 .PHONY: clean-all
 clean-all: clean

--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -250,7 +250,7 @@ pyramid_oereb:
       layer_index: 0
       layer_opacity: 1.0
     visualisation:
-      method: pyramid_oereb.contrib.data_sources.standard.hook_methods.produce_sld_content
+      method: pyramid_oereb.core.hook_methods.produce_sld_content
       # Note: these parameters must fit to the attributes provided by the RealEstateRecord!!!!
       url_params:
         - egrid
@@ -561,10 +561,10 @@ pyramid_oereb:
     # Information about the official survey (last update and provider) used as a base map in the extract
     base_data:
       methods:
-        date: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_surveying_data_update_date
-        provider:  pyramid_oereb.contrib.data_sources.standard.hook_methods.get_surveying_data_provider
+        date: pyramid_oereb.core.hook_methods.get_surveying_data_update_date
+        provider:  pyramid_oereb.core.hook_methods.get_surveying_data_provider
 
-    sort_within_themes_method: pyramid_oereb.contrib.data_sources.standard.hook_methods.plr_sort_within_themes
+    sort_within_themes_method: pyramid_oereb.core.hook_methods.plr_sort_within_themes
     # Example of a specific sorting method:
     # sort_within_themes_method: pyramid_oereb.contrib.plr_sort_within_themes_by_type_code
     # Redirect configuration for type URL. You can use any attribute of the real estate RealEstateRecord
@@ -606,7 +606,7 @@ pyramid_oereb:
           schema_name: land_use_plans
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -657,7 +657,7 @@ pyramid_oereb:
           schema_name: motorways_project_planing_zones
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -708,7 +708,7 @@ pyramid_oereb:
           schema_name: motorways_building_lines
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -759,7 +759,7 @@ pyramid_oereb:
           schema_name: railways_project_planning_zones
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -810,7 +810,7 @@ pyramid_oereb:
           schema_name: railways_building_lines
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -861,7 +861,7 @@ pyramid_oereb:
           schema_name: airports_project_planning_zones
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -912,7 +912,7 @@ pyramid_oereb:
           schema_name: airports_building_lines
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -963,7 +963,7 @@ pyramid_oereb:
           schema_name: airports_security_zone_plans
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1015,7 +1015,7 @@ pyramid_oereb:
           schema_name: contaminated_sites
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1066,7 +1066,7 @@ pyramid_oereb:
           schema_name: contaminated_military_sites
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1117,7 +1117,7 @@ pyramid_oereb:
           schema_name: contaminated_civil_aviation_sites
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1168,7 +1168,7 @@ pyramid_oereb:
           schema_name: contaminated_public_transport_sites
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1219,7 +1219,7 @@ pyramid_oereb:
           schema_name: groundwater_protection_zones
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1270,7 +1270,7 @@ pyramid_oereb:
           schema_name: groundwater_protection_sites
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1321,7 +1321,7 @@ pyramid_oereb:
           schema_name: noise_sensitivity_levels
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1375,7 +1375,7 @@ pyramid_oereb:
           schema_name: forest_perimeters
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -1426,7 +1426,7 @@ pyramid_oereb:
           schema_name: forest_distance_lines
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft

--- a/pyramid_oereb/contrib/data_sources/interlis_2_3/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/interlis_2_3/sources/plr.py
@@ -41,7 +41,7 @@ class StandardThemeConfigParser(object):
 
     @property
     def srid(self):
-        return Config._config.get('srid')
+        return Config.get_srid()
 
     @property
     def db_connection(self):

--- a/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
@@ -38,7 +38,7 @@ class StandardThemeConfigParser(object):
 
     @property
     def srid(self):
-        return Config._config.get('srid')
+        return Config.get_srid()
 
     @property
     def db_connection(self):

--- a/pyramid_oereb/core/config.py
+++ b/pyramid_oereb/core/config.py
@@ -333,6 +333,17 @@ class Config(object):
         return office_reader.read()
 
     @staticmethod
+    def get_srid():
+        """
+        Returns the srid.
+
+        Returns:
+            int: The srid if it was set.
+        """
+        assert Config._config is not None
+        return Config._config.get('srid')
+
+    @staticmethod
     def get_general_information():
         """
         Returns the general information.

--- a/pyramid_oereb/core/hook_methods.py
+++ b/pyramid_oereb/core/hook_methods.py
@@ -1,0 +1,137 @@
+import datetime
+import io
+from PIL import Image
+from mako.template import Template
+from pyramid.path import AssetResolver
+
+from pyramid_oereb import route_prefix
+from pyramid_oereb.core.records.office import OfficeRecord
+
+
+def get_symbol(theme_code, sub_theme_code, view_service_id, type_code, theme_config):
+    """
+    Returns the symbol for the requested theme and type code from database. It queries the model
+    for the legend entry pyramid_oereb.contrib.data_sources.standard.models.get_legend_entry
+
+    Args:
+        theme_code (str): The theme code.
+        sub_theme_code (str or None): The sub_theme code.
+        view_service_id (str): The ID linking to the view service.
+        type_code (str): The type_code.
+        theme_config (dict): The configuration of the theme how it was set up in the YAML.
+
+    Returns:
+        bytearray, str: The image content and the mimetype of image.
+    """
+    # produces a dummy image of the correct dimension grey filled
+    image = Image.new("RGB", (72, 36), (128, 128, 128))
+    output = io.BytesIO()
+    image.save(output, format='PNG')
+    return output.getvalue(), 'image/png'
+
+
+def get_symbol_ref(request, record):
+    """
+    Returns the link to the symbol of the specified public law restriction.
+
+    Args:
+        request (pyramid.request.Request): The current request instance.
+        record (pyramid_oereb.core.records.view_service.LegendEntryRecord): The legend entry record to get
+            the symbol reference (link/url) for.
+
+    Returns:
+        uri: The link to the symbol for the specified public law restriction.
+    """
+    query = None
+    if record.sub_theme:
+        query = {'sub_theme_code': record.sub_theme.sub_code}
+    return request.route_url(
+        '{0}/image/symbol'.format(route_prefix),
+        theme_code=record.theme.code,
+        view_service_id=record.view_service_id,
+        type_code=record.type_code,
+        extension=record.symbol.extension,
+        _query=query
+    )
+
+
+def get_surveying_data_provider(real_estate):
+    """
+
+    Args:
+        real_estate (pyramid_oereb.lib.records.real_estate.RealEstateRecord): The real estate for which the
+            provider of the surveying data should be delivered.
+    Returns:
+        provider (pyramid_oereb.core.records.office.OfficeRecord): The provider who produced the used
+            surveying data.
+    """
+    provider = OfficeRecord({u'de': u'This is only a dummy'})
+    return provider
+
+
+def get_surveying_data_update_date(real_estate):
+    """
+    Gets the date of the latest update of the used survey data data for the
+    situation map. The method you find here is only matching the standard configuration. But you can provide
+    your own one if your configuration is different. The only thing you need to take into account is that the
+    input of this method is always and only a real estate record. And the output of this method must be a
+    datetime.date object.
+
+    Args:
+        real_estate (pyramid_oereb.lib.records.real_estate.RealEstateRecord): The real
+            estate for which the last update date of the base data should be indicated
+
+    Returns:
+        update_date (datetime.datetime): The date of the last update of the cadastral base data
+    """
+
+    update_date = datetime.datetime.now()
+
+    return update_date
+
+
+def produce_sld_content(params, real_estate_config):
+    """
+    This is the standard hook method to provide the sld content. Of course you can set it to another one. For
+    instance to use another template. Or to use other parameters to provide the correctly constructed SLD.
+
+    The SLD can be used as Styling parameter to the WMS call to produce a highlighted real estate.
+
+    When you are replacing this method take care that it has to accept the parameters as defined here as input
+    and must deliver a valid SLD. It is in your responsibility.
+
+    Args:
+        params (dict): The URL params which are passed.
+        real_estate_config (dict): The configuration of the real estate how it was set up in the YAML.
+
+    Returns:
+        str: The rendered SLD (XML) as text.
+    """
+    template = Template(
+        filename=AssetResolver('pyramid_oereb').resolve('core/views/templates/sld.xml').abspath(),
+        input_encoding='utf-8',
+        output_encoding='utf-8'
+    )
+    template_params = {
+        'layer_name': real_estate_config['visualisation']['layer']['name'],
+        'identifier': params['egrid'],
+        'stroke_opacity': real_estate_config['visualisation']['style']['stroke_opacity'],
+        'stroke_color': real_estate_config['visualisation']['style']['stroke_color'],
+        'stroke_width': real_estate_config['visualisation']['style']['stroke_width']
+    }
+    return template.render(**template_params)
+
+
+def plr_sort_within_themes(extract):
+    """
+    This is the standard hook method to sort a plr list (while respecting the theme order).
+    This standard hook does no sorting, you can set your configuration to a different method if you need a
+    specific sorting.
+
+    Args:
+        extract (pyramid_oereb.lib.records.extract.ExtractRecord): The unsorted extract
+
+    Returns:
+        pyramid_oereb.lib.records.extract.ExtractRecord: Returns the updated extract
+    """
+    return extract

--- a/pyramid_oereb/core/hook_methods.py
+++ b/pyramid_oereb/core/hook_methods.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from mako.template import Template
 from pyramid.path import AssetResolver
 

--- a/pyramid_oereb/core/hook_methods.py
+++ b/pyramid_oereb/core/hook_methods.py
@@ -8,9 +8,7 @@ from pyramid_oereb.core.records.office import OfficeRecord
 
 
 def get_symbol(theme_code, sub_theme_code, view_service_id, type_code, theme_config):
-    
     """
-    
     This is a dummy method only to define what is expected by the real implementation.
 
     It is expected that this method delivers the actual binary content of the found image
@@ -112,11 +110,21 @@ def produce_sld_content(params, real_estate_config):
         output_encoding='utf-8'
     )
     template_params = {
-        'layer_name': re.sub('<.*?>', '', real_estate_config['visualisation']['layer']['name'], flags=re.DOTALL),
-        'identifier': re.sub('<.*?>', '', params['egrid'], flags=re.DOTALL),
-        'stroke_opacity': re.sub('<.*?>', '', real_estate_config['visualisation']['style']['stroke_opacity'], flags=re.DOTALL),
-        'stroke_color': re.sub('<.*?>', '', real_estate_config['visualisation']['style']['stroke_color'], flags=re.DOTALL),
-        'stroke_width': re.sub('<.*?>', '', real_estate_config['visualisation']['style']['stroke_width'], flags=re.DOTALL)
+        'layer_name': re.sub(
+            '<.*?>', '', real_estate_config['visualisation']['layer']['name'], flags=re.DOTALL
+        ),
+        'identifier': re.sub(
+            '<.*?>', '', params['egrid'], flags=re.DOTALL
+        ),
+        'stroke_opacity': re.sub(
+            '<.*?>', '', real_estate_config['visualisation']['style']['stroke_opacity'], flags=re.DOTALL
+        ),
+        'stroke_color': re.sub(
+            '<.*?>', '', real_estate_config['visualisation']['style']['stroke_color'], flags=re.DOTALL
+        ),
+        'stroke_width': re.sub(
+            '<.*?>', '', real_estate_config['visualisation']['style']['stroke_width'], flags=re.DOTALL
+        )
     }
     return template.render(**template_params)
 

--- a/pyramid_oereb/core/hook_methods.py
+++ b/pyramid_oereb/core/hook_methods.py
@@ -7,7 +7,9 @@ from pyramid_oereb.core.records.office import OfficeRecord
 
 
 def get_symbol(theme_code, sub_theme_code, view_service_id, type_code, theme_config):
+    
     """
+    
     This is a dummy method only to define what is expected by the real implementation.
 
     It is expected that this method delivers the actual binary content of the found image
@@ -109,11 +111,11 @@ def produce_sld_content(params, real_estate_config):
         output_encoding='utf-8'
     )
     template_params = {
-        'layer_name': real_estate_config['visualisation']['layer']['name'],
-        'identifier': params['egrid'],
-        'stroke_opacity': real_estate_config['visualisation']['style']['stroke_opacity'],
-        'stroke_color': real_estate_config['visualisation']['style']['stroke_color'],
-        'stroke_width': real_estate_config['visualisation']['style']['stroke_width']
+        'layer_name': re.sub('<.*?>', '', real_estate_config['visualisation']['layer']['name'], flags=re.DOTALL),
+        'identifier': re.sub('<.*?>', '', params['egrid'], flags=re.DOTALL),
+        'stroke_opacity': re.sub('<.*?>', '', real_estate_config['visualisation']['style']['stroke_opacity'], flags=re.DOTALL),
+        'stroke_color': re.sub('<.*?>', '', real_estate_config['visualisation']['style']['stroke_color'], flags=re.DOTALL),
+        'stroke_width': re.sub('<.*?>', '', real_estate_config['visualisation']['style']['stroke_width'], flags=re.DOTALL)
     }
     return template.render(**template_params)
 

--- a/pyramid_oereb/core/hook_methods.py
+++ b/pyramid_oereb/core/hook_methods.py
@@ -1,6 +1,4 @@
 import datetime
-import io
-from PIL import Image
 from mako.template import Template
 from pyramid.path import AssetResolver
 
@@ -10,8 +8,10 @@ from pyramid_oereb.core.records.office import OfficeRecord
 
 def get_symbol(theme_code, sub_theme_code, view_service_id, type_code, theme_config):
     """
-    Returns the symbol for the requested theme and type code from database. It queries the model
-    for the legend entry pyramid_oereb.contrib.data_sources.standard.models.get_legend_entry
+    This is a dummy method only to define what is expected by the real implementation.
+
+    It is expected that this method delivers the actual binary content of the found image
+    and the mime type fitting to the image content.
 
     Args:
         theme_code (str): The theme code.
@@ -23,11 +23,7 @@ def get_symbol(theme_code, sub_theme_code, view_service_id, type_code, theme_con
     Returns:
         bytearray, str: The image content and the mimetype of image.
     """
-    # produces a dummy image of the correct dimension grey filled
-    image = Image.new("RGB", (72, 36), (128, 128, 128))
-    output = io.BytesIO()
-    image.save(output, format='PNG')
-    return output.getvalue(), 'image/png'
+    raise NotImplementedError('Method has to be implemented.')
 
 
 def get_symbol_ref(request, record):

--- a/pyramid_oereb/core/renderer/extract/json_.py
+++ b/pyramid_oereb/core/renderer/extract/json_.py
@@ -293,7 +293,7 @@ class Renderer(Base):
                     # Link to symbol is only available if type code is set!
                     if plr.type_code:
                         plr_dict.update({
-                            'SymbolRef': self.get_symbol_ref(self._request, plr)
+                            'SymbolRef': self.get_symbol_ref(self._request, plr.legend_entry)
                         })
 
                 if plr.area_share is not None:

--- a/pyramid_oereb/core/renderer/extract/templates/xml/legend_entry.xml
+++ b/pyramid_oereb/core/renderer/extract/templates/xml/legend_entry.xml
@@ -11,5 +11,9 @@
 <data:TypeCode>${legend_entry.type_code | x}</data:TypeCode>
 <data:TypeCodelist>${legend_entry.type_code_list | x}</data:TypeCodelist>
 <data:Theme>
+%if legend_entry.sub_theme:
+    <%include file="theme.xml" args="theme=legend_entry.sub_theme"/>
+%else:
     <%include file="theme.xml" args="theme=legend_entry.theme"/>
+%endif
 </data:Theme>

--- a/pyramid_oereb/core/renderer/extract/templates/xml/public_law_restriction.xml
+++ b/pyramid_oereb/core/renderer/extract/templates/xml/public_law_restriction.xml
@@ -37,7 +37,7 @@
     %if params.images:
     <data:Symbol>${public_law_restriction.symbol.encode()}</data:Symbol>
     %else:
-    <data:SymbolRef>${get_symbol_ref(request, public_law_restriction)|u}</data:SymbolRef>
+    <data:SymbolRef>${get_symbol_ref(request, public_law_restriction.legend_entry)|u}</data:SymbolRef>
     %endif
     %for geometry in public_law_restriction.geometries:
     <%include file="geometry.xml" args="geometry=geometry"/>

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -7,7 +7,6 @@ from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPInternalServer
 from pyramid.path import DottedNameResolver
 from shapely.geometry import Point
 from pyramid.renderers import render_to_response
-from pyramid.response import Response
 
 from pyramid_oereb import route_prefix
 from pyramid_oereb import Config
@@ -803,16 +802,27 @@ class Symbol(object):
         Returns:
             pyramid.response.Response: Response containing the binary image content.
         """
-        method = None
-        dnr = DottedNameResolver()
-        for plr in Config.get('plrs'):
-            if str(plr.get('code')).lower() == str(self._request_.matchdict.get('theme_code')).lower():
-                method = dnr.resolve(plr.get('hooks').get('get_symbol'))
-                break
+        theme_code = self._request_.matchdict.get('theme_code')
+        sub_theme_code = self._request_.params.get('sub_theme_code')
+        view_service_id = self._request_.matchdict.get('view_service_id')
+        type_code = self._request_.matchdict.get('type_code')
+        method = self.get_method(theme_code)
+        theme_config = Config.get_theme_config_by_code(str(theme_code))
         if method:
-            return method(self._request_)
+            body, mimetype = method(theme_code, sub_theme_code, view_service_id, type_code, theme_config)
+            response = self._request_.response
+            response.status_int = 200
+            response.body = body
+            response.content_type = mimetype
+            return response
         log.error('"get_symbol_method" not found')
         raise HTTPNotFound()
+
+    @staticmethod
+    def get_method(theme_code):
+        dnr = DottedNameResolver()
+        theme_config = Config.get_theme_config_by_code(str(theme_code))
+        return dnr.resolve(theme_config.get('hooks').get('get_symbol'))
 
 
 class Sld(object):
@@ -848,22 +858,24 @@ class Sld(object):
             value of the hooked method was not of type pyramid.response.Response
             pyramid.httpexceptions.HTTPNotFound: When the configured method was not found.
         """
+        real_estate_config = Config.get_real_estate_config()
+        params = {}
+        for param in real_estate_config['visualisation']['url_params']:
+            params.update({param: self._request_.params.get(param)})
+        method = self.get_method()
+        response = self._request_.response
+        response.content_type = 'application/xml'
+        if method:
+            response.body = method(params, real_estate_config)
+            return response
+        log.error(u'method in path "{path}" not found'.format(
+            path=real_estate_config['visualisation']['method'])
+        )
+        raise HTTPNotFound()
+
+    @staticmethod
+    def get_method():
         dnr = DottedNameResolver()
         visualisation_config = Config.get_real_estate_config().get('visualisation')
         method_path = visualisation_config.get('method')
-        method = dnr.resolve(method_path)
-        if method:
-            result = method(self._request_)
-            if isinstance(result, Response):
-                return result
-            else:
-                log.error(
-                    u'The called method {path} does not returned the expected '
-                    u'pyramid.response.Response instance. Returned value was {type}'.format(
-                        path=method_path,
-                        type=type(result)
-                    )
-                )
-                raise HTTPInternalServerError()
-        log.error(u'method in path "{path}" not found'.format(path=method_path))
-        raise HTTPNotFound()
+        return dnr.resolve(method_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tqdm==4.62.1
 numpy==1.21.0 # rq.filter: <1.20.0
 defusedxml==0.7.1
 c2cwsgiutils==3.*
+pillow==8.4.0

--- a/tests/contrib.data_sources.standard/conftest.py
+++ b/tests/contrib.data_sources.standard/conftest.py
@@ -1,0 +1,53 @@
+import pytest
+import io
+
+from unittest.mock import patch
+from PIL import Image
+
+
+@pytest.fixture
+def session():
+
+    class Session:
+
+        def query(self, model):
+            return
+
+        def close(self):
+            return
+
+    yield Session
+
+
+@pytest.fixture
+def query():
+
+    class Query:
+
+        def filter(self, term):
+            return self
+
+        def one(self):
+            return
+
+    yield Query
+
+
+@pytest.fixture(autouse=True)
+def srid():
+    def mock_srid():
+        return 2056
+    with patch('pyramid_oereb.core.config.Config.get_srid', mock_srid):
+        yield
+
+
+@pytest.fixture
+def png_image():
+    yield Image.new("RGB", (72, 36), (128, 128, 128))
+
+
+@pytest.fixture
+def png_binary(png_image):
+    output = io.BytesIO()
+    png_image.save(output, format='PNG')
+    yield output.getvalue()

--- a/tests/contrib.data_sources.standard/test_hook_methods.py
+++ b/tests/contrib.data_sources.standard/test_hook_methods.py
@@ -1,0 +1,225 @@
+import binascii
+
+import pytest
+from unittest.mock import patch
+from sqlalchemy import Integer
+from sqlalchemy.ext.declarative import declarative_base
+from pyramid.httpexceptions import HTTPNotFound, HTTPServerError
+from pyramid_oereb.contrib.data_sources.standard.hook_methods import get_symbol
+from pyramid_oereb.contrib.data_sources.standard.models import get_view_service, get_legend_entry
+from pyramid_oereb.core import b64
+
+
+@pytest.fixture
+def theme_config():
+    yield {
+        "srid": 2056,
+        "code": "ch.Nutzungsplanung",
+        "view_service": {
+            "layer_index": 1,
+            "layer_opacity": 0.25,
+        },
+        "law_status_lookup": [{
+            "data_code": "inKraft",
+            "transfer_code": "inKraft",
+            "extract_code": "inForce"
+        }],
+        "standard": True,
+        "federal": True,
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource",
+            "params": {
+                "db_connection": "postgresql://postgres:postgres@123.123.123.123:5432/oereb_test_db",
+                "model_factory": "pyramid_oereb.contrib.data_sources.standard.models.theme.model_factory_string_pk",  # noqa: E501
+                "schema_name": "land_use_plans"
+            }
+        },
+        "hooks": {
+            "get_symbol": "pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol",
+            "get_symbol_ref": "pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref"
+        },
+        "thresholds": {
+            "length": {
+                "limit": 1.0,
+                "unit": 'm',
+                "precision": 2
+            },
+            "area": {
+                "limit": 1.0,
+                "unit": 'm²',
+                "precision": 2
+            },
+            "percentage": {
+                "precision": 1
+            }
+        },
+        "document_types_lookup": [{
+            "data_code": "Rechtsvorschrift",
+            "transfer_code": "Rechtsvorschrift",
+            "extract_code": "LegalProvision"
+        }, {
+            "data_code": "GesetzlicheGrundlage",
+            "transfer_code": "GesetzlicheGrundlage",
+            "extract_code": "Law"
+        }, {
+            "data_code": "Hinweis",
+            "transfer_code": "Hinweis",
+            "extract_code": "Hint"
+        }]
+    }
+
+
+@pytest.fixture
+def legend_entry():
+    Base = declarative_base()
+    ViewService = get_view_service(Base, 'test', Integer)
+    LegendEntry = get_legend_entry(Base, 'test', Integer, ViewService)
+    yield LegendEntry
+
+
+@pytest.fixture
+def one_result_binary_session(legend_entry, png_binary, session, query):
+
+    class Query(query):
+
+        def one(self):
+            return legend_entry(**{
+                'id': 1,
+                'symbol': png_binary,
+                'legend_text': {'de': 'testlegende'},
+                'type_code': 'testCode',
+                'type_code_list': 'testCode,testCode2,testCode3',
+                'theme': 'ch.TestThema',
+                'sub_theme': 'ch.SubTestThema',
+                'view_service_id': 1
+            })
+
+    class Session(session):
+
+        def query(self, term):
+            return Query()
+
+    yield Session
+
+
+@pytest.fixture
+def no_result_session(legend_entry, png_binary, session, query):
+
+    class Session(session):
+
+        def query(self, term):
+            return query()
+
+    yield Session
+
+
+@pytest.fixture
+def one_result_no_symbol_session(legend_entry, session, query):
+
+    class Query(query):
+
+        def one(self):
+            return legend_entry(**{
+                'id': 1,
+                'legend_text': {'de': 'testlegende'},
+                'type_code': 'testCode',
+                'type_code_list': 'testCode,testCode2,testCode3',
+                'theme': 'ch.TestThema',
+                'sub_theme': 'ch.SubTestThema',
+                'view_service_id': 1
+            })
+
+    class Session(session):
+
+        def query(self, term):
+            return Query()
+
+    yield Session
+
+
+@pytest.fixture
+def one_result_wrong_content_session(legend_entry, session, query):
+
+    class Query(query):
+
+        def one(self):
+            return legend_entry(**{
+                'id': 1,
+                'symbol': 1,
+                'legend_text': {'de': 'testlegende'},
+                'type_code': 'testCode',
+                'type_code_list': 'testCode,testCode2,testCode3',
+                'theme': 'ch.TestThema',
+                'sub_theme': 'ch.SubTestThema',
+                'view_service_id': 1
+            })
+
+    class Session(session):
+
+        def query(self, term):
+            return Query()
+
+    yield Session
+
+
+@pytest.fixture
+def one_result_b64_session(legend_entry, png_binary, session, query):
+
+    class Query(query):
+        def one(self):
+            return legend_entry(**{
+                'id': 1,
+                'symbol': b64.encode(png_binary),
+                'legend_text': {'de': 'testlegende'},
+                'type_code': 'testCode',
+                'type_code_list': 'testCode,testCode2,testCode3',
+                'theme': 'ch.TestThema',
+                'sub_theme': 'ch.SubTestThema',
+                'view_service_id': 1
+            })
+
+    class Session(session):
+        def query(self, term):
+            return Query()
+
+    yield Session
+
+
+def test_get_symbol_binary_content(theme_config, one_result_binary_session, png_binary):
+    with patch(
+            'pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
+            return_value=one_result_binary_session()):
+        body, content_type = get_symbol("ch.Nutzungsplanung", None, '1', 'StaoTyp1', theme_config)
+        assert content_type == 'image/png'
+        assert body == b64.decode(binascii.b2a_base64(png_binary).decode('ascii'))
+
+
+def test_get_symbol_no_symbol_content(theme_config, one_result_no_symbol_session):
+    with patch(
+            'pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
+            return_value=one_result_no_symbol_session()):
+        with pytest.raises(HTTPServerError):
+            get_symbol("ch.Nutzungsplanung", None, '1', 'StaoTyp1', theme_config)
+
+
+def test_get_symbol_no_legend_entry(theme_config, no_result_session):
+    with patch(
+            'pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
+            return_value=no_result_session()):
+        with pytest.raises(HTTPNotFound):
+            get_symbol("ch.Nutzungsplanung", None, '1', 'StaoTyp1', theme_config)
+
+
+def test_get_symbol_wrong_content(theme_config, one_result_wrong_content_session):
+    with patch('pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
+               return_value=one_result_wrong_content_session()):
+        with pytest.raises(HTTPServerError):
+            get_symbol("ch.Nutzungsplanung", None, '1', 'StaoTyp1', theme_config)
+
+
+def test_get_symbol_b64_content(theme_config, one_result_b64_session, png_binary):
+    with patch('pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
+               return_value=one_result_b64_session()):
+        body, content_type = get_symbol("ch.Nutzungsplanung", None, '1', 'StaoTyp1', theme_config)
+        assert content_type == 'image/png'
+        assert body == b64.decode(binascii.b2a_base64(png_binary).decode('ascii'))

--- a/tests/core/records/test_extract.py
+++ b/tests/core/records/test_extract.py
@@ -38,7 +38,7 @@ def create_dummy_extract():
     ))
     plr_office = OfficeRecord({u'en': u'PLR Authority'})
     resolver = DottedNameResolver()
-    date_method_string = 'pyramid_oereb.contrib.data_sources.standard.hook_methods.get_surveying_data_update_date'  # noqa: E501
+    date_method_string = 'pyramid_oereb.core.hook_methods.get_surveying_data_update_date'  # noqa: E501
     date_method = resolver.resolve(date_method_string)
     update_date_os = date_method(real_estate)
     record = ExtractRecord(

--- a/tests/core/renderer/test_base.py
+++ b/tests/core/renderer/test_base.py
@@ -15,7 +15,7 @@ from pyramid_oereb.core.records.theme import ThemeRecord
 from pyramid_oereb.core.records.view_service import LegendEntryRecord
 from pyramid_oereb.core.renderer import Base
 from pyramid_oereb.core.renderer.extract.json_ import Renderer
-import pyramid_oereb.contrib.data_sources.standard.hook_methods
+import pyramid_oereb.core.hook_methods
 from tests.mockrequest import MockRequest
 
 
@@ -182,7 +182,7 @@ def test_sort_by_localized_text(DummyRenderInfo):
     assert sorted_multilingual_elements[2]['content']['fr'] == u'Content-Ofo'
 
 
-@patch.object(pyramid_oereb.contrib.data_sources.standard.hook_methods, 'route_prefix', 'oereb')
+@patch.object(pyramid_oereb.core.hook_methods, 'route_prefix', 'oereb')
 @pytest.mark.parametrize('theme_code', [
     u'ch.BelasteteStandorte',
     u'NotExistingTheme',

--- a/tests/core/renderer/test_json.py
+++ b/tests/core/renderer/test_json.py
@@ -26,10 +26,12 @@ from pyramid_oereb.core.records.theme import ThemeRecord
 from pyramid_oereb.core.records.general_information import GeneralInformationRecord
 from pyramid_oereb.core.records.view_service import ViewServiceRecord, LegendEntryRecord
 from pyramid_oereb.core.renderer import Base
-import pyramid_oereb.core.renderer.extract.json_
 from pyramid_oereb.core.renderer.extract.json_ import Renderer
 from tests.mockrequest import MockRequest
 from pyramid_oereb.core.views.webservice import Parameter
+
+import pyramid_oereb.core.renderer.extract.json_
+import pyramid_oereb.core.hook_methods
 
 
 def law_status():
@@ -228,7 +230,7 @@ def test_format_real_estate(DummyRenderInfo, real_estate_test_data):
     }
 
 
-@patch.object(pyramid_oereb.contrib.data_sources.standard.hook_methods, 'route_prefix', 'oereb')
+@patch.object(pyramid_oereb.core.hook_methods, 'route_prefix', 'oereb')
 @pytest.mark.parametrize('parameter', [
     default_param(),
     Parameter('json', False, True, False, 'BL0200002829', '1000', 'CH775979211712', 'de'),
@@ -504,7 +506,7 @@ def test_format_theme(DummyRenderInfo, params):
     }
 
 
-@patch.object(pyramid_oereb.contrib.data_sources.standard.hook_methods, 'route_prefix', 'oereb')
+@patch.object(pyramid_oereb.core.hook_methods, 'route_prefix', 'oereb')
 @pytest.mark.parametrize('parameter', [
     default_param(),
     Parameter('json', 'reduced', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de')

--- a/tests/core/test_hook_methods.py
+++ b/tests/core/test_hook_methods.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
-
 import pytest
 import datetime
 
 from shapely.wkt import loads
 from unittest.mock import patch
 
-from pyramid.httpexceptions import HTTPNotFound
 from pyramid.testing import DummyRequest
 
 from pyramid_oereb.core import b64
@@ -15,7 +13,7 @@ from pyramid_oereb.core.records.image import ImageRecord
 from pyramid_oereb.core.records.theme import ThemeRecord
 from pyramid_oereb.core.records.view_service import LegendEntryRecord
 from pyramid_oereb.core.records.real_estate import RealEstateRecord
-from pyramid_oereb.contrib.data_sources.standard.hook_methods import get_symbol, get_symbol_ref, \
+from pyramid_oereb.core.hook_methods import get_symbol, get_symbol_ref, \
     get_surveying_data_update_date
 from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser
 import pyramid_oereb.contrib.data_sources.standard.hook_methods
@@ -60,40 +58,13 @@ def legend_entry_data(pyramid_oereb_test_config, dbsession, transact, file_adapt
     yield legend_entries
 
 
-def test_get_symbol_invalid_theme_code(pyramid_oereb_test_config):
-    request = DummyRequest()
-    request.matchdict.update({
-        'theme_code': 'InvalidThemeCode',
-        'view_service_id': '1',
-        'type_code': 'CodeA'
-    })
-    with pytest.raises(HTTPNotFound):
-        get_symbol(request)
+def test_get_symbol():
+    binary_image, content_type = get_symbol('ch.BelasteteStandorte', None, '1', 'type', {})
+    assert isinstance(binary_image, bytes)
+    assert content_type == 'image/png'
 
 
-def test_get_symbol_not_found(pyramid_oereb_test_config):
-    request = DummyRequest()
-    request.matchdict.update({
-        'theme_code': 'ch.BelasteteStandorte',
-        'view_service_id': '1',
-        'type_code': 'missing'
-    })
-    with pytest.raises(HTTPNotFound):
-        get_symbol(request)
-
-
-def test_get_symbol(pyramid_oereb_test_config, legend_entry_data):
-    request = DummyRequest()
-    request.matchdict.update({
-        'theme_code': 'ch.BelasteteStandorte',
-        'view_service_id': '1',
-        'type_code': 'CodeA'
-    })
-    response = get_symbol(request)
-    assert response.body == FileAdapter().read('tests/resources/symbol.png')
-
-
-@patch.object(pyramid_oereb.contrib.data_sources.standard.hook_methods, 'route_prefix', 'oereb')
+@patch.object(pyramid_oereb.core.hook_methods, 'route_prefix', 'oereb')
 def test_get_symbol_ref(pyramid_test_config):
     record = LegendEntryRecord(
         ImageRecord(FileAdapter().read('tests/resources/logo_canton.png')),

--- a/tests/core/test_hook_methods.py
+++ b/tests/core/test_hook_methods.py
@@ -59,9 +59,8 @@ def legend_entry_data(pyramid_oereb_test_config, dbsession, transact, file_adapt
 
 
 def test_get_symbol():
-    binary_image, content_type = get_symbol('ch.BelasteteStandorte', None, '1', 'type', {})
-    assert isinstance(binary_image, bytes)
-    assert content_type == 'image/png'
+    with pytest.raises(NotImplementedError):
+        binary_image, content_type = get_symbol('ch.BelasteteStandorte', None, '1', 'type', {})
 
 
 @patch.object(pyramid_oereb.core.hook_methods, 'route_prefix', 'oereb')

--- a/tests/core/webservice/test_getextractbyid.py
+++ b/tests/core/webservice/test_getextractbyid.py
@@ -7,10 +7,11 @@ from jsonschema import Draft4Validator
 from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPNoContent
 
 from tests.mockrequest import MockRequest
-import pyramid_oereb.core.views.webservice
-import pyramid_oereb.contrib.data_sources.standard.hook_methods
-import pyramid_oereb.core.renderer.extract.json_
 from pyramid_oereb.core.views.webservice import PlrWebservice
+
+import pyramid_oereb.core.renderer.extract.json_
+import pyramid_oereb.core.views.webservice
+import pyramid_oereb.core.hook_methods
 
 log = logging.getLogger('pyramid_oereb')
 
@@ -143,7 +144,7 @@ def test_return_no_content():
     assert isinstance(response, HTTPNoContent)
 
 
-@patch.object(pyramid_oereb.contrib.data_sources.standard.hook_methods, 'route_prefix', 'oereb')
+@patch.object(pyramid_oereb.core.hook_methods, 'route_prefix', 'oereb')
 @patch.object(pyramid_oereb.core.renderer.extract.json_, 'route_prefix', 'oereb')
 @patch.object(pyramid_oereb.core.views.webservice, 'route_prefix', 'oereb')
 @pytest.mark.parametrize('egrid,topics', [

--- a/tests/core/webservice/test_symbol.py
+++ b/tests/core/webservice/test_symbol.py
@@ -1,34 +1,69 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+import io
+from PIL import Image
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.response import Response
-
-from pyramid_oereb.core.adapter import FileAdapter
+from pyramid_oereb.core.records.image import ImageRecord
 from tests.mockrequest import MockRequest
 from pyramid_oereb.core.views.webservice import Symbol
 
 
-def test_get_image(pyramid_oereb_test_config, contaminated_sites):
+@pytest.fixture
+def png_image():
+    yield Image.new("RGB", (72, 36), (128, 128, 128))
+
+
+@pytest.fixture
+def png_binary(png_image):
+    output = io.BytesIO()
+    png_image.save(output, format='PNG')
+    yield output.getvalue()
+
+
+@pytest.fixture
+def mock_symbol(png_binary):
+    def mock_get_symbol(theme_code, sub_theme_code, view_service_id, type_code, theme_config):
+        content_type = ImageRecord.get_mimetype(bytearray(png_binary))
+        return png_binary, content_type
+
+    class MockSymbol(Symbol):
+        def get_method(self, theme_code):
+            return mock_get_symbol
+    yield MockSymbol
+
+
+@pytest.fixture
+def mock_symbol_fail():
+    class MockSymbol(Symbol):
+        def get_method(self, theme_code):
+            return None
+    yield MockSymbol
+
+
+def test_get_image(pyramid_oereb_test_config, contaminated_sites, mock_symbol, png_binary):
     request = MockRequest()
     request.matchdict.update({
         'theme_code': 'ch.BelasteteStandorte',
         'view_service_id': '1',
         'type_code': 'StaoTyp1'
     })
-    webservice = Symbol(request)
+    webservice = mock_symbol(request)
     result = webservice.get_image()
     assert isinstance(result, Response)
-    assert result.body == FileAdapter().read('tests/resources/symbol.png')
+    assert result.body == png_binary
+    assert result.status_int == 200
+    assert result.content_type == 'image/png'
 
 
-def test_get_image_invalid():
+def test_get_image_invalid(mock_symbol_fail):
     request = MockRequest()
     request.matchdict.update({
         'theme_code': 'ch.BelasteteStandorte',
         'view_service_id': '1',
         'type_code': 'notExisting'
     })
-    webservice = Symbol(request)
+    webservice = mock_symbol_fail(request)
     with pytest.raises(HTTPNotFound):
         webservice.get_image()

--- a/tests/resources/test_config.yml
+++ b/tests/resources/test_config.yml
@@ -82,7 +82,7 @@ pyramid_oereb:
           schema_name: land_use_plans
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       thresholds:
         length:
           limit: 1.0
@@ -130,7 +130,7 @@ pyramid_oereb:
           schema_name: contaminated_sites
       hooks:
         get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
-        get_symbol_ref: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol_ref
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
       thresholds:
         length:
           limit: 1.0
@@ -307,8 +307,8 @@ pyramid_oereb:
   extract:
     base_data:
       methods:
-        date: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_surveying_data_update_date
-        provider:  pyramid_oereb.contrib.data_sources.standard.hook_methods.get_surveying_data_provider
+        date: pyramid_oereb.core.hook_methods.get_surveying_data_update_date
+        provider:  pyramid_oereb.core.hook_methods.get_surveying_data_provider
     redirect: https://geoview.bl.ch/oereb/?egrid={egrid}
 
   glossary:


### PR DESCRIPTION
There are 2 targets with this PR:

1. organize code to fit better in the new pattern of contrib and core concept
2. improve test ability via separating concerns of methods where it belongs

The decrease of coverage comes from code reorganization I think. Code which was accidentally called through some methods is dissolved now and is not "tested"...

It will be tested in dedicated future tests.