### PR TITLE
use unique entry point for all tests both in CI and daily checks

### DIFF
--- a/.coveragerc.contrib-stats
+++ b/.coveragerc.contrib-stats
@@ -1,0 +1,3 @@
+[run]
+source =
+    pyramid_oereb/contrib/stats/*.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,18 +58,10 @@ jobs:
       - run: sudo rm /etc/apt/sources.list.d/*.list
       - run: sudo apt update
       - run: sudo apt-get install virtualenv libpq-dev libgeos-dev
-      - name: Run core tests for Python ${{ matrix.python-version }}
+      - name: Run tests for Python ${{ matrix.python-version }}
         env:
           PYTHON_TEST_VERSION: ${{ matrix.python-version }}
-        run: make test-core
-      - name: Run contrib-print_proxy-mapfish_print tests for Python ${{ matrix.python-version }}
-        env:
-          PYTHON_TEST_VERSION: ${{ matrix.python-version }}
-        run: make test-contrib-print_proxy-mapfish_print
-      - name: Run contrib-data_sources-standard tests for Python ${{ matrix.python-version }}
-        env:
-          PYTHON_TEST_VERSION: ${{ matrix.python-version }}
-        run: make test-contrib-data_sources-standard
+        run: make tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           fail_ci_if_error: true
-          files: ./coverage.core.xml,./coverage.contrib-data_sources-standard.xml,./coverage.contrib-print_proxy-mapfish_print.xml
+          files: ./coverage.core.xml,./coverage.contrib-data_sources-standard.xml,./coverage.contrib-print_proxy-mapfish_print.xml,./coverage.contrib-stats.xml
           flags: unittests
           name: codecov-unittest
           verbose: true

--- a/.github/workflows/daily_check.yaml
+++ b/.github/workflows/daily_check.yaml
@@ -37,14 +37,10 @@ jobs:
       - run: sudo rm /etc/apt/sources.list.d/*.list
       - run: sudo apt update
       - run: sudo apt-get install virtualenv libpq-dev libgeos-dev
-      - name: Run core tests for Python ${{ matrix.python-version }}
+      - name: Run tests for Python ${{ matrix.python-version }}
         env:
           PYTHON_TEST_VERSION: ${{ matrix.python-version }}
-        run: make test-core
-      - name: Run contrib tests for Python ${{ matrix.python-version }}
-        env:
-          PYTHON_TEST_VERSION: ${{ matrix.python-version }}
-        run: make test-contrib
+        run: make tests
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ clean: clean_fed_data clean_dev_db_scripts
 	rm -f coverage.core.xml
 	rm -f coverage.contrib-data_sources-standard.xml
 	rm -f coverage.contrib-print_proxy-mapfish_print.xml
+	rm -f coverage.contrib-stats.xml
 
 .PHONY: clean-all
 clean-all: clean
@@ -293,8 +294,12 @@ test-contrib-print_proxy-mapfish_print: .venv/requirements-timestamp
 test-contrib-data_sources-standard: .venv/requirements-timestamp
 	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-data_sources-standard --cov $(PACKAGE)/contrib/data_sources/standard --cov-report=term-missing:skip-covered --cov-report=xml:coverage.contrib-data_sources-standard.xml tests/contrib.data_sources.standard
 
+.PHONY: test-contrib-stats
+test-contrib-stats: .venv/requirements-timestamp
+	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-stats --cov $(PACKAGE)/contrib/stats --cov-report=xml:coverage.contrib-stats.xml tests/contrib.stats
+
 .PHONY: tests
-tests: .venv/requirements-timestamp test-core test-contrib-data_sources-standard test-contrib-print_proxy-mapfish_print test-contrib-data_sources-standard
+tests: .venv/requirements-timestamp test-core test-contrib-data_sources-standard test-contrib-print_proxy-mapfish_print test-contrib-data_sources-standard test-contrib-stats
 
 .PHONY: check
 check: git-attributes lint test

--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ test-contrib-data_sources-standard: .venv/requirements-timestamp
 	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-data_sources-standard --cov $(PACKAGE)/contrib/data_sources/standard --cov-report=term-missing:skip-covered --cov-report=xml:coverage.contrib-data_sources-standard.xml tests/contrib.data_sources.standard
 
 .PHONY: tests
-tests: .venv/requirements-timestamp test-core test-contrib-data_sources-standard test-contrib-print_proxy-mapfish_print
+tests: .venv/requirements-timestamp test-core test-contrib-data_sources-standard test-contrib-print_proxy-mapfish_print test-contrib-data_sources-standard
 
 .PHONY: check
 check: git-attributes lint test

--- a/tests/contrib.stats/test_logger.py
+++ b/tests/contrib.stats/test_logger.py
@@ -12,7 +12,7 @@ from pyramid_oereb.contrib.stats.scripts.create_stats_tables import _create_view
 
 
 @pytest.fixture(scope="session")
-def webtestapp():
+def webtestapp(test_db_engine):
     Config._config = None
     setup_logging('tests/resources/test.ini#main')
     app = get_app('tests/resources/test.ini#main')


### PR DESCRIPTION
daily checks broke because contrib tests were renamed