### PR TITLE
change sort_legal_provision for officialNumber

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
@@ -685,8 +685,13 @@ class Renderer(JsonRenderer):
         """
 
         sort_title = elem['Title'] if 'Title' in elem else ''
-        sort_number = elem['OfficialNumber'] if 'OfficialNumber' in elem else None
-        return sort_title, sort_number
+        if 'OfficialNumber' in elem and elem['OfficialNumber']:
+            sort_number_id = 0
+            sort_number = elem['OfficialNumber']
+        else:
+            sort_number_id = 1
+            sort_number = ''
+        return sort_title, sort_number_id, sort_number
 
     @staticmethod
     def sort_hints_laws(elem):

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
@@ -676,7 +676,9 @@ class Renderer(JsonRenderer):
         """
         Provides the sort key for the supplied legal provision element as a tuple consisting of:
          * title
-         * Official number
+         * official number type ('0': if official number is defined and not an empty string;
+                                 '1': if official number is empty string or not defined)
+         * official number
 
         Args:
             elem (dict): one element of the legal provision list
@@ -686,12 +688,12 @@ class Renderer(JsonRenderer):
 
         sort_title = elem['Title'] if 'Title' in elem else ''
         if 'OfficialNumber' in elem and elem['OfficialNumber']:
-            sort_number_id = 0
+            sort_number_type = 0
             sort_number = elem['OfficialNumber']
         else:
-            sort_number_id = 1
+            sort_number_type = 1
             sort_number = ''
-        return sort_title, sort_number_id, sort_number
+        return sort_title, sort_number_type, sort_number
 
     @staticmethod
     def sort_hints_laws(elem):

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
@@ -686,14 +686,12 @@ class Renderer(JsonRenderer):
             sort key (tuple)
         """
 
-        sort_title = elem['Title'] if 'Title' in elem else ''
-        if 'OfficialNumber' in elem and elem['OfficialNumber']:
-            sort_number_type = 0
-            sort_number = elem['OfficialNumber']
-        else:
-            sort_number_type = 1
-            sort_number = ''
-        return sort_title, sort_number_type, sort_number
+        sort_title = elem.get('Title', '')
+        sort_number = elem.get('OfficialNumber', '')
+        # the additional sorting key below must be produced so that records without OfficialNumber
+        # are sorted after records with OfficialNumber
+        sort_empty_official_number_last = (len(sort_number) == 0)
+        return sort_title, sort_empty_official_number_last, sort_number
 
     @staticmethod
     def sort_hints_laws(elem):

--- a/tests/contrib.print_proxy.mapfish_print/test_mapfish_print.py
+++ b/tests/contrib.print_proxy.mapfish_print/test_mapfish_print.py
@@ -266,6 +266,37 @@ def test_get_sorted_legal_provisions(DummyRenderInfo):
             "DocumentType": "LegalProvision",
             "Lawstatus_Code": "inKraft",
             "Lawstatus_Text": "Rechtskräftig",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz2"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz2"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz3"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
             "OfficialNumber": "07.447",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
@@ -287,6 +318,16 @@ def test_get_sorted_legal_provisions(DummyRenderInfo):
     ]
     test_legal_provisions = [
         {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz2"
+        }, {
            "Canton": "BL",
            "DocumentType": "LegalProvision",
            "Lawstatus_Code": "inKraft",
@@ -329,6 +370,27 @@ def test_get_sorted_legal_provisions(DummyRenderInfo):
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/198"}],
             "Title": "Baugesetz"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz3"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz2"
         }
     ]
     assert expected_result == renderer.sort_dict_list(test_legal_provisions, renderer.sort_legal_provision)

--- a/tests/contrib.print_proxy.mapfish_print/test_mapfish_print.py
+++ b/tests/contrib.print_proxy.mapfish_print/test_mapfish_print.py
@@ -287,6 +287,18 @@ def test_get_sorted_legal_provisions(DummyRenderInfo):
             "DocumentType": "LegalProvision",
             "Lawstatus_Code": "inKraft",
             "Lawstatus_Text": "Rechtskräftig",
+            "OfficialNumber": "3891.100",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz3"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
+            "OfficialNumber": "",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
@@ -327,6 +339,17 @@ def test_get_sorted_legal_provisions(DummyRenderInfo):
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
             "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
             "Title": "Baugesetz2"
+        }, {
+            "Canton": "BL",
+            "DocumentType": "LegalProvision",
+            "Lawstatus_Code": "inKraft",
+            "Lawstatus_Text": "Rechtskräftig",
+            "OfficialNumber": "",
+            "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
+            "ResponsibleOffice_OfficeAtWeb":
+                "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",
+            "TextAtWeb": [{"URL": "https://oereb-gr-preview.000.ch/api/attachments/197"}],
+            "Title": "Baugesetz3"
         }, {
            "Canton": "BL",
            "DocumentType": "LegalProvision",
@@ -375,6 +398,7 @@ def test_get_sorted_legal_provisions(DummyRenderInfo):
             "DocumentType": "LegalProvision",
             "Lawstatus_Code": "inKraft",
             "Lawstatus_Text": "Rechtskräftig",
+            "OfficialNumber": "3891.100",
             "ResponsibleOffice_Name": "Bundesamt für Verkehr BAV",
             "ResponsibleOffice_OfficeAtWeb":
                 "http://www.bav.admin.ch/themen/verkehrspolitik/00709/index.html",


### PR DESCRIPTION
closes https://github.com/openoereb/pyramid_oereb/issues/1474

It is possible that legal provision contains multiple entries with the same title but different official numbers (options for official number: string, empty string, or official number not in dict). Sorting of legal provisions should be able to handle this case. 