### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - python3.6
           - python3.7
           - python3.8
           - python3.9

--- a/.github/workflows/daily_check.yaml
+++ b/.github/workflows/daily_check.yaml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - python3.6
           - python3.7
           - python3.8
           - python3.9

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Framework :: Pyramid",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Framework :: Pyramid",


### PR DESCRIPTION
We must remove Python 3.6 support, as the end-of-life date for Python 3.6 has passed, and there are no longer any security updates for Python 3.6.

This also explains why some libraries that we use no longer support Python 3.6 in their current version.