### PR TITLE
update shapely to 1.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,6 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-          - '3.11.0-alpha.5'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python v${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,11 +47,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
-          - 3.10
-          - 3.11
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python v${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
   test-py:
     name: Test Python
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     services:
       # Label used to access the service container
       postgres:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
   test-py:
     name: Test Python
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
       # Label used to access the service container
       postgres:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,19 +47,22 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - python3.7
-          - python3.8
-          - python3.9
-          - python3.10
-          - python3.11
+          - 3.7
+          - 3.8
+          - 3.9
+          - 3.10
+          - 3.11
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python v${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
       - run: sudo rm /etc/apt/sources.list.d/*.list
       - run: sudo apt update
       - run: sudo apt-get install virtualenv libpq-dev libgeos-dev
       - name: Run tests for Python ${{ matrix.python-version }}
-        env:
-          PYTHON_TEST_VERSION: ${{ matrix.python-version }}
         run: make tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-          - '3.11'
+          - '3.11.0-alpha.5'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python v${{ matrix.python-version }}

--- a/pyramid_oereb/core/records/geometry.py
+++ b/pyramid_oereb/core/records/geometry.py
@@ -136,8 +136,6 @@ class GeometryRecord(object):
         point_types = geometry_types.get('point').get('types')
         if self.published:
             intersection = self.geom.intersection(real_estate.limit)
-            # TODO upon update to Shapely 1.7, a check for result.is_emtpy will be needed (see PR#1037)
-            # differentiate between Points and MultiPoint
             if not intersection.is_empty:
                 result = self._extract_collection(intersection)
                 if self.geom.type not in point_types + line_types + polygon_types:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ filetype==1.0.7
 geoalchemy2==0.8.5 # rq.filter: <0.9
 pyramid==1.10.8 # rq.filter: <2
 pyramid-debugtoolbar==4.9
-shapely==1.7.1  # rq.filter: == 1.7.1
+shapely==1.8.1  # rq.filter: == 1.8.1
 SQLAlchemy==1.4.23 # rq.filter: >= 1.4
 urllib3[secure]==1.26.8
 waitress==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ filetype==1.0.7
 geoalchemy2==0.8.5 # rq.filter: <0.9
 pyramid==1.10.8 # rq.filter: <2
 pyramid-debugtoolbar==4.9
-shapely==1.6.4.post1  # rq.filter: ==1.6.4.post1
+shapely==1.7.1  # rq.filter: == 1.7.1
 SQLAlchemy==1.4.23 # rq.filter: >= 1.4
 urllib3[secure]==1.26.8
 waitress==2.0.0

--- a/tests/core/records/test_geometry.py
+++ b/tests/core/records/test_geometry.py
@@ -218,7 +218,7 @@ def test_extract_collection(input_geom, result, extracted):
                 open(
                     os.path.join(__location__, "interlis-valid-ogc-invalid-geometry.txt")
                 ).read()
-            ).buffer(0),  # does not work any longer without repairing the geometry
+            ),
             Polygon([(2698200, 1208800), (2698400, 1208800), (2698400, 1209000), (2698200, 1209000)]),
             1,
             1,
@@ -233,7 +233,7 @@ def test_extract_collection(input_geom, result, extracted):
                 open(
                     os.path.join(__location__, "interlis-valid-ogc-invalid-geometry.txt")
                 ).read()
-            ).buffer(0),  # does not work any longer without repairing the geometry,
+            ),
             Polygon([(2696500, 1208800), (2696700, 1208800), (2696700, 1209000), (2696500, 1209000)]),
             1,
             1,


### PR DESCRIPTION
shapely version 1.8 fixes the problems experienced with 1.7
So there is no reason not to use version 1.8
fixes #1111 

the CI is being improved so that different versions of python are tested correctly
(python 3.11 is removed until it is released and compatible with the used libraries)
fixes #1513 