### PR TITLE
Update c2ctemplate library

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ psycopg2==2.9.3
 McCabe==0.6.1
 Sphinx<1.6
 sphinx_rtd_theme
-c2c.template==2.0.9  # rq.filter: <= 2.1
+c2c.template==2.3.0
 -e .


### PR DESCRIPTION
Update the library c2ctemplate. The explicit dependency is deprecated (it was for Python 2 compatibility).