### PR TITLE
set newest c2cWSGIutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ mako-render==0.1.0
 requests==2.27.1
 geolink-formatter==2.0.1
 pyconizer==0.1.4
-c2cwsgiutils==3.*
+c2cwsgiutils==5.*
+sqlalchemy_utils==0.38.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ mako-render==0.1.0
 requests==2.27.1
 geolink-formatter==2.0.1
 pyconizer==0.1.4
-c2cwsgiutils==5.*
-sqlalchemy_utils==0.38.2
+c2cwsgiutils[standard]==5.*


### PR DESCRIPTION
In the current app configuration, the docker images is not based on c2cwsgiutils any more, but the library is imported by pip.
This makes dependencies easier to handle.

json to postgres logging works in various conditions.
When using gunicorn, care has to be taken to setup the logging correctly (cf. https://github.com/camptocamp/c2cwsgiutils/issues/1272#issuecomment-1061988325)