### PR TITLE
Further improvement of Performance

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,5 @@ McCabe==0.6.1
 Sphinx<1.6
 sphinx_rtd_theme
 c2c.template==2.3.0
+yappi
 -e .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - .:/workspace:cached
       - venvs:/venvs
     working_dir: /workspace
+    command: [ "/venvs/.venv/bin/pserve", "development.ini", "--reload"]
     ports:
       - ${PYRAMID_OEREB_PORT:-6543}:${PYRAMID_OEREB_PORT:-6543}
     networks:

--- a/pyramid_oereb/contrib/data_sources/standard/sources/disclaimer.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/disclaimer.py
@@ -5,14 +5,11 @@ from pyramid_oereb.core.sources.disclaimer import DisclaimerBaseSource
 
 class DatabaseSource(BaseDatabaseSource, DisclaimerBaseSource):
 
-    def read(self, params):
+    def read(self):
         """
         The read method to access the standard database structure. It uses SQL-Alchemy for querying. It does
         not accept any parameters nor it applies any filter on the database query. It simply loads all
         content from the configured model.
-
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         session = self._adapter_.get_session(self._key_)
         try:

--- a/pyramid_oereb/contrib/data_sources/standard/sources/glossary.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/glossary.py
@@ -5,12 +5,9 @@ from pyramid_oereb.core.sources.glossary import GlossaryBaseSource
 
 class DatabaseSource(BaseDatabaseSource, GlossaryBaseSource):
 
-    def read(self, params):
+    def read(self):
         """
         Central method to read all glossary entries.
-
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         session = self._adapter_.get_session(self._key_)
         try:

--- a/pyramid_oereb/contrib/data_sources/standard/sources/municipality.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/municipality.py
@@ -10,21 +10,16 @@ from pyramid_oereb.core.sources.municipality import MunicipalityBaseSource
 
 class DatabaseSource(BaseDatabaseSource, MunicipalityBaseSource):
 
-    def read(self, params, fosnr=None):
+    def read(self):
         """
-        Central method to read a municipality by it's id_bfs identifier.
-
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-            fosnr (int or None): The federal number of the municipality defined by the statistics office.
+        The read method to access the standard database structure. It uses SQL-Alchemy for querying. It does
+        not accept any parameters nor it applies any filter on the database query. It simply loads all
+        content from the configured model.
         """
         session = self._adapter_.get_session(self._key_)
         try:
             self.records = list()
-            if fosnr:
-                results = session.query(self._model_).filter(self._model_.fosnr == fosnr).all()
-            else:
-                results = session.query(self._model_).all()
+            results = session.query(self._model_).all()
             for result in results:
                 self.records.append(self._record_class_(
                     result.fosnr,

--- a/pyramid_oereb/core/readers/disclaimer.py
+++ b/pyramid_oereb/core/readers/disclaimer.py
@@ -24,7 +24,7 @@ class DisclaimerReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self, params):
+    def read(self):
         """
         The read method of this reader. There we invoke the read method of the bound source.
 
@@ -34,13 +34,10 @@ class DisclaimerReader(object):
             :ref:`api-pyramid_oereb-core-records-availability-availabilityrecord`. Otherwise the API like way
             the server works would be broken.
 
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-
         Returns:
             list of pyramid_oereb.core.records.disclaimer.DisclaimerRecord:
                 The list of found records. Since these are not filtered by any criteria the list simply
                 contains all records delivered by the source.
         """
-        self._source_.read(params)
+        self._source_.read()
         return self._source_.records

--- a/pyramid_oereb/core/readers/glossary.py
+++ b/pyramid_oereb/core/readers/glossary.py
@@ -24,7 +24,7 @@ class GlossaryReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self, params):
+    def read(self):
         """
         The central read accessor method to get all desired records from configured source.
 
@@ -34,13 +34,10 @@ class GlossaryReader(object):
             :ref:`api-pyramid_oereb-core-records-glossary-glossaryrecord`. Otherwise the API like way
             the server works would be broken.
 
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-
         Returns:
             list of pyramid_oereb.core.records.glossary.GlossaryRecord:
                 The list of found records. Since these are not filtered by any criteria the list simply
                 contains all records delivered by the source.
         """
-        self._source_.read(params)
+        self._source_.read()
         return self._source_.records

--- a/pyramid_oereb/core/readers/municipality.py
+++ b/pyramid_oereb/core/readers/municipality.py
@@ -24,7 +24,7 @@ class MunicipalityReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self, params, fosnr=None):
+    def read(self):
         """
         The central read accessor method to get all desired records from configured source.
 
@@ -34,14 +34,10 @@ class MunicipalityReader(object):
             :ref:`api-pyramid_oereb-core-records-municipality-municipalityrecord`. Otherwise the API like way
             the server works would be broken.
 
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-            fosnr (int or None): The federal number of the municipality defined by the statistics office.
-
         Returns:
-            pyramid_oereb.lib.records.municipality.MunicipalityRecord:
+            list of pyramid_oereb.lib.records.municipality.MunicipalityRecord:
             The list of all found records. Since these are not filtered by any criteria the list simply
             contains all records delivered by the source.
         """
-        self._source_.read(params, fosnr)
+        self._source_.read()
         return self._source_.records

--- a/pyramid_oereb/core/sources/disclaimer.py
+++ b/pyramid_oereb/core/sources/disclaimer.py
@@ -13,13 +13,10 @@ class DisclaimerBaseSource(Base):
     """
     _record_class_ = DisclaimerRecord
 
-    def read(self, params):
+    def read(self):
         """
         Every disclaimer source has to implement a read method. This method must accept no
         parameters. Because it should deliver all items available.
         If you want adapt to your own source for disclaimer, this is the point where to hook in.
-
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/core/sources/glossary.py
+++ b/pyramid_oereb/core/sources/glossary.py
@@ -12,13 +12,10 @@ class GlossaryBaseSource(Base):
     """
     _record_class_ = GlossaryRecord
 
-    def read(self, params):
+    def read(self):
         """
         Every glossary source has to implement a read method. This method must accept no parameters. Because
         it should deliver all items available.
         If you want adapt to your own source for glossaries, this is the point where to hook in.
-
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/core/sources/municipality.py
+++ b/pyramid_oereb/core/sources/municipality.py
@@ -13,14 +13,10 @@ class MunicipalityBaseSource(Base):
     """
     _record_class_ = MunicipalityRecord
 
-    def read(self, params, fosnr=None):
+    def read(self):
         """
         Every municipality source has to implement a read method. This method must accept no parameters.
         Because it should deliver all items available.
         If you want adapt to your own source for municipalities, this is the point where to hook in.
-
-        Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-            fosnr (int or None): The federal number of the municipality defined by the statistics office.
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import yappi
+# import yappi
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPInternalServerError, HTTPNoContent, \
     HTTPNotFound

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -284,14 +284,14 @@ class PlrWebservice(object):
                 if params.format == 'url':
                     log.debug("get_extract_by_id() calling url")
                     return self.__redirect_to_dynamic_client__(real_estate_records[0])
-                yappi.set_clock_type("cpu")
-                yappi.start()
+                # yappi.set_clock_type("cpu")
+                # yappi.start()
                 extract = processor.process(
                     real_estate_records[0],
                     params,
                     self._request.route_url('{0}/sld'.format(route_prefix))
                 )
-                yappi.get_func_stats().save('/workspace/processor_function_stats.prof', "pstat")
+                # yappi.get_func_stats().save('/workspace/processor_function_stats.prof', "pstat")
                 # yappi.get_thread_stats().save('/workspace/processor_thread_stats.prof', "pstat")
 
                 if params.format == 'json':

--- a/tests/contrib.data_sources.standard/sources/test_disclaimer.py
+++ b/tests/contrib.data_sources.standard/sources/test_disclaimer.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import patch
 
 from pyramid_oereb.contrib.data_sources.standard.sources.disclaimer import DatabaseSource
-from pyramid_oereb.core.views.webservice import Parameter
 from pyramid_oereb.core.records.disclaimer import DisclaimerRecord
 
 
@@ -45,7 +44,7 @@ def all_disclaimer_result_session(session, query):
 def test_read_all(disclaimer_source_params, all_disclaimer_result_session):
     source = DatabaseSource(**disclaimer_source_params)
     with patch('pyramid_oereb.core.adapter.DatabaseAdapter.get_session', return_value=all_disclaimer_result_session()):  # noqa: E501
-        source.read(Parameter('xml'))
+        source.read()
         assert len(source.records) == 2
         assert isinstance(source.records[0], DisclaimerRecord)
         assert isinstance(source.records[1], DisclaimerRecord)

--- a/tests/contrib.data_sources.standard/sources/test_glossary.py
+++ b/tests/contrib.data_sources.standard/sources/test_glossary.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import patch
 
 from pyramid_oereb.contrib.data_sources.standard.sources.glossary import DatabaseSource
-from pyramid_oereb.core.views.webservice import Parameter
 from pyramid_oereb.core.records.glossary import GlossaryRecord
 
 
@@ -50,7 +49,7 @@ def all_glossary_result_session(session, query):
 def test_read_all(glossary_source_params, all_glossary_result_session):
     source = DatabaseSource(**glossary_source_params)
     with patch('pyramid_oereb.core.adapter.DatabaseAdapter.get_session', return_value=all_glossary_result_session()):  # noqa: E501
-        source.read(Parameter('xml'))
+        source.read()
         assert len(source.records) == 3
         assert isinstance(source.records[0], GlossaryRecord)
         assert isinstance(source.records[1], GlossaryRecord)

--- a/tests/contrib.data_sources.standard/sources/test_municipalities.py
+++ b/tests/contrib.data_sources.standard/sources/test_municipalities.py
@@ -5,7 +5,6 @@ from geoalchemy2 import WKTElement
 from geoalchemy2.shape import to_shape
 from pyramid_oereb.contrib.data_sources.standard.sources.municipality import DatabaseSource
 from pyramid_oereb.core.records.municipality import MunicipalityRecord
-from pyramid_oereb.core.views.webservice import Parameter
 
 
 @pytest.fixture
@@ -90,7 +89,7 @@ def all_municipalities_filtered_result_session(session, query, municipalities):
 def test_read_all(municipalities_source_params, all_municipalities_result_session, wkb_multipolygon):
     source = DatabaseSource(**municipalities_source_params)
     with patch('pyramid_oereb.core.adapter.DatabaseAdapter.get_session', return_value=all_municipalities_result_session()):  # noqa: E501
-        source.read(Parameter('xml'))
+        source.read()
         assert len(source.records) == 2
         assert isinstance(source.records[0], MunicipalityRecord)
         assert isinstance(source.records[1], MunicipalityRecord)
@@ -98,10 +97,3 @@ def test_read_all(municipalities_source_params, all_municipalities_result_sessio
         assert source.records[0].geom == to_shape(wkb_multipolygon).wkt
         assert source.records[0].name == "Oberwil (BL)"
         assert source.records[0].published
-
-
-def test_read_all_filtered(municipalities_source_params, all_municipalities_filtered_result_session):
-    source = DatabaseSource(**municipalities_source_params)
-    with patch('pyramid_oereb.core.adapter.DatabaseAdapter.get_session', return_value=all_municipalities_filtered_result_session()):  # noqa: E501
-        source.read(Parameter('xml'), fosnr=2771)
-        assert len(source.records) == 1

--- a/tests/contrib.print_proxy.mapfish_print/test_mapfish_print.py
+++ b/tests/contrib.print_proxy.mapfish_print/test_mapfish_print.py
@@ -5,6 +5,8 @@ import json
 import codecs
 import pytest
 import responses
+
+from pyramid_oereb.core.records.municipality import MunicipalityRecord
 from tests.mockrequest import MockRequest
 from unittest.mock import patch
 import pyramid_oereb
@@ -827,6 +829,7 @@ def dummy_pdf():
 
 @patch.object(pyramid_oereb.core.views.webservice, 'route_prefix', 'oereb')
 @patch.object(pyramid_oereb.core.renderer.extract.json_, 'route_prefix', 'oereb')
+@patch.object(pyramid_oereb.core.config.Config, 'municipalities', [MunicipalityRecord(1234, 'test', True)])
 def test_mfp_service(mock_responses, pyramid_test_config,
                      real_estate_data,
                      municipalities, themes, real_estate_types_test_data, logos,
@@ -841,7 +844,6 @@ def test_mfp_service(mock_responses, pyramid_test_config,
         'EGRID': 'TEST',
         # 'TOPICS': topics
     })
-    from pyramid_oereb.core.config import Config
     pyramid_test_config.add_renderer('pyramid_oereb_extract_print',
                                      Config.get('print').get('renderer'))
     service = PlrWebservice(request)

--- a/tests/core/readers/test_disclaimer.py
+++ b/tests/core/readers/test_disclaimer.py
@@ -51,7 +51,7 @@ def test_read(pyramid_oereb_test_config, disclaimer_data):
         pyramid_oereb_test_config.get_disclaimer_config().get('source').get('class'),
         **pyramid_oereb_test_config.get_disclaimer_config().get('source').get('params')
     )
-    results = reader.read(MockParameter())
+    results = reader.read()
     assert isinstance(results, list)
     assert len(results) == len(disclaimer_data)
     assert isinstance(results[0], DisclaimerRecord)

--- a/tests/core/readers/test_disclaimer.py
+++ b/tests/core/readers/test_disclaimer.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid_oereb.core.sources import Base
 from pyramid_oereb.core.readers.disclaimer import DisclaimerReader
 from pyramid_oereb.core.records.disclaimer import DisclaimerRecord
-from tests.mockrequest import MockParameter
 
 
 @pytest.fixture

--- a/tests/core/readers/test_glossary.py
+++ b/tests/core/readers/test_glossary.py
@@ -40,7 +40,7 @@ def test_read(pyramid_oereb_test_config, glossary_data):
         pyramid_oereb_test_config.get_glossary_config().get('source').get('class'),
         **pyramid_oereb_test_config.get_glossary_config().get('source').get('params')
     )
-    results = reader.read(MockParameter())
+    results = reader.read()
     assert isinstance(results, list)
     assert isinstance(results[0], GlossaryRecord)
     assert len(results) == 1

--- a/tests/core/readers/test_glossary.py
+++ b/tests/core/readers/test_glossary.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid_oereb.core.sources import Base
 from pyramid_oereb.core.readers.glossary import GlossaryReader
 from pyramid_oereb.core.records.glossary import GlossaryRecord
-from tests.mockrequest import MockParameter
 
 
 @pytest.fixture

--- a/tests/core/readers/test_municipality.py
+++ b/tests/core/readers/test_municipality.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid_oereb.core.records.municipality import MunicipalityRecord
 from pyramid_oereb.core.sources import Base
 from pyramid_oereb.core.readers.municipality import MunicipalityReader
-from tests.mockrequest import MockParameter
 
 
 @pytest.fixture
@@ -39,7 +38,7 @@ def test_read(pyramid_oereb_test_config, municipality_data):
         pyramid_oereb_test_config.get_municipality_config().get('source').get('class'),
         **pyramid_oereb_test_config.get_municipality_config().get('source').get('params')
     )
-    results = reader.read(MockParameter())
+    results = reader.read()
     assert isinstance(results, list)
     assert len(results) == 1
     result = results[0]

--- a/tests/core/sources/test_disclaimer_database.py
+++ b/tests/core/sources/test_disclaimer_database.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-from tests.mockrequest import MockParameter
-
 from pyramid_oereb.core.adapter import DatabaseAdapter
 
 

--- a/tests/core/sources/test_disclaimer_database.py
+++ b/tests/core/sources/test_disclaimer_database.py
@@ -54,6 +54,6 @@ def test_read(pyramid_oereb_test_config, disclaimer_data):
     source = DatabaseSource(
         **pyramid_oereb_test_config.get_disclaimer_config().get('source').get('params')
     )
-    source.read(MockParameter())
+    source.read()
     assert len(source.records) == 1
     assert source.records[0].title['de'] == disclaimer_data[0].title['de']

--- a/tests/core/sources/test_glossary_database.py
+++ b/tests/core/sources/test_glossary_database.py
@@ -2,7 +2,6 @@
 import pytest
 
 from pyramid_oereb.core.adapter import DatabaseAdapter
-from tests.mockrequest import MockParameter
 
 
 @pytest.fixture

--- a/tests/core/sources/test_glossary_database.py
+++ b/tests/core/sources/test_glossary_database.py
@@ -37,7 +37,7 @@ def test_read(pyramid_oereb_test_config, glossary_data):
     from pyramid_oereb.contrib.data_sources.standard.sources.glossary import DatabaseSource
 
     source = DatabaseSource(**pyramid_oereb_test_config.get_glossary_config().get('source').get('params'))
-    source.read(MockParameter())
+    source.read()
     results = source.records
     assert len(results) == 1
     assert results[0].title['fr'] == glossary_data[0].title['fr']

--- a/tests/core/sources/test_municipality_database.py
+++ b/tests/core/sources/test_municipality_database.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-from tests.mockrequest import MockParameter
-
 
 @pytest.fixture
 def municipality_data(dbsession, transact):

--- a/tests/core/sources/test_municipality_database.py
+++ b/tests/core/sources/test_municipality_database.py
@@ -37,7 +37,7 @@ def test_read(pyramid_oereb_test_config, municipality_data):
     from pyramid_oereb.contrib.data_sources.standard.sources.municipality import DatabaseSource
 
     source = DatabaseSource(**pyramid_oereb_test_config.get_municipality_config().get('source').get('params'))
-    source.read(MockParameter())
+    source.read()
     assert isinstance(source.records, list)
     assert len(source.records) == len(municipality_data)
     assert source.records[0].fosnr == municipality_data[0].fosnr

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -14,10 +14,7 @@ from pyramid_oereb.core.records.theme import ThemeRecord
 from pyramid_oereb.core.records.law_status import LawStatusRecord
 from pyramid_oereb.core.records.view_service import ViewServiceRecord, LegendEntryRecord
 from pyramid_oereb.core.records.municipality import MunicipalityRecord
-from pyramid_oereb.core.readers.disclaimer import DisclaimerReader
 from pyramid_oereb.core.readers.extract import ExtractReader
-from pyramid_oereb.core.readers.glossary import GlossaryReader
-from pyramid_oereb.core.readers.municipality import MunicipalityReader
 from pyramid_oereb.core.readers.real_estate import RealEstateReader
 from pyramid_oereb.core.views.webservice import PlrWebservice
 from tests.mockrequest import MockRequest
@@ -37,8 +34,8 @@ request_params = {
 @pytest.fixture
 def processor_data(pyramid_oereb_test_config, main_schema):
     with patch(
-        'pyramid_oereb.core.readers.municipality.MunicipalityReader.read',
-            return_value=[MunicipalityRecord(1234, 'test', True)]
+        'pyramid_oereb.core.config.Config.municipalities',
+        [MunicipalityRecord(1234, 'test', True)]
     ):
         yield pyramid_oereb_test_config
 
@@ -51,9 +48,6 @@ def test_missing_params():
 def test_properties(pyramid_oereb_test_config):
     processor = create_processor()
     assert isinstance(processor.extract_reader, ExtractReader)
-    assert isinstance(processor.municipality_reader, MunicipalityReader)
-    assert isinstance(processor.disclaimer_reader, DisclaimerReader)
-    assert isinstance(processor.glossary_reader, GlossaryReader)
     assert isinstance(processor.plr_sources, list)
     assert isinstance(processor.real_estate_reader, RealEstateReader)
 

--- a/tests/core/webservice/conftest.py
+++ b/tests/core/webservice/conftest.py
@@ -6,6 +6,7 @@ from pyramid_oereb.core.adapter import FileAdapter
 # from datetime import date, timedelta
 
 from pyramid_oereb.core.config import Config
+from pyramid_oereb.core.records.municipality import MunicipalityRecord
 from pyramid_oereb.core.records.theme import ThemeRecord
 from pyramid_oereb.core.records.logo import LogoRecord
 from pyramid_oereb.core.records.real_estate_type import RealEstateTypeRecord
@@ -20,20 +21,13 @@ def extract_real_estate_data(real_estate_data, municipalities, themes, real_esta
     pass
 
 
-@pytest.fixture
-def municipalities(pyramid_oereb_test_config, dbsession, transact):
-    del transact
-
-    from pyramid_oereb.contrib.data_sources.standard.models import main
-
-    # Add dummy municipality
-    municipalities = [main.Municipality(**{
-        'fosnr': 1234,
-        'name': u'Test',
-        'published': True,
-        'geom': 'SRID=2056;MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0)))'
-    })]
-    dbsession.add_all(municipalities)
+@pytest.fixture(autouse=True)
+def municipalities(pyramid_oereb_test_config):
+    with patch(
+            'pyramid_oereb.core.config.Config.municipalities',
+            [MunicipalityRecord(1234, 'test', True)]
+    ):
+        yield pyramid_oereb_test_config
 
 
 @pytest.fixture


### PR DESCRIPTION
@peterschaer 
I did a quick profile of the extract generation (based on our small test data set). It reveals several points to poke around. But one easy catch is right in the beginning of the process:
![Screenshot_20220406_114602](https://user-images.githubusercontent.com/3714179/161965156-ea8620df-2720-4643-9430-8d604a31a285.png)

Is related to #1508 

As you can see we lose almost 4% of process time between start and ExtractReder.read, I found that we had an old left over in the code. Instead of reading glossaries, disclaimers and municipalities for every extract they are read once on server start now.

Could you please try and tell what you think about this?

To use this patch it should be enough to install it. No config changes needed.

