### PR TITLE
Separate table creation for interlis and standart themes

### DIFF
--- a/doc/source/contrib/contributing.rst
+++ b/doc/source/contrib/contributing.rst
@@ -240,10 +240,13 @@ NOTE
    Make sure (eg using pgAdmin) the configured database exists and has the postgis extensions installed
    (create extension postgis). Set the db parameters in your pyramid\_oereb.yml config or use
    pyramid\_oereb\_standard.yml for your test environnement then
-
    .. code-block:: shell
 
-    .build\venv\Scripts\create_standard_tables.exe -c pyramid_oereb_standard.yml
+    .build\venv\Scripts\create_main_schema_tables.exe -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
+    .build\venv\Scripts\create_standard_tables.exe -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
+    .build\venv\Scripts\create_oereblex_tables.exe -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
+
+   Then load the generate sql file into your DB
 
 #. Load sample data in the standard db or connect your own PLR database for standard sample data:
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -100,7 +100,7 @@ script:
  create_standard_tables -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
  create_oereblex_tables -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
 
-Then load the generate sql file into your DB
+Then load the generated sql file into your DB
 
 .. warning:: We assume you did not specify a custom name for the configuration file. If you have used a custom
    name, you will have to replace `pyramid_oereb_standard.yml` with your specified name in this and all

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -96,7 +96,11 @@ script:
 
 .. code-block:: shell
 
- create_standard_tables -c pyramid_oereb_standard.yml
+ create_main_schema_tables -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
+ create_standard_tables -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
+ create_oereblex_tables -c pyramid_oereb_standard.yml --sql-file=sqlFile.sql
+
+Then load the generate sql file into your DB
 
 .. warning:: We assume you did not specify a custom name for the configuration file. If you have used a custom
    name, you will have to replace `pyramid_oereb_standard.yml` with your specified name in this and all

--- a/pyramid_oereb/contrib/data_sources/create_tables.py
+++ b/pyramid_oereb/contrib/data_sources/create_tables.py
@@ -18,8 +18,12 @@ def create_theme_tables_(theme_config, source_class, tables_only=False, sql_file
 
     Args:
         theme_config (dict): The configuration section for the specific theme.
+        source_class (): The source from which the table is created.
+                         This can be the standard source or the oereblex source.
+                         Only the Themes configured with this source are created.
         tables_only (bool): True to skip creation of schema. Default is False.
         sql_file (file): The file to generate. Default is None (in the database).
+        if_not_exists (bool): create Schema with the flag `IF NOT EXISTS`
     """
     if theme_config['source']['class'] == source_class:
         config_parser = StandardThemeConfigParser(**theme_config)
@@ -35,8 +39,13 @@ def create_theme_tables_(theme_config, source_class, tables_only=False, sql_file
 
 
 def create_tables_from_standard_configuration(
-        configuration_yaml_path, section='pyramid_oereb', c2ctemplate_style=False, tables_only=False,
-        sql_file=None, if_not_exists=False):
+        configuration_yaml_path,
+        source_class,
+        section='pyramid_oereb',
+        c2ctemplate_style=False,
+        tables_only=False,
+        sql_file=None,
+        if_not_exists=False):
     """
     Creates all schemas which are defined in the passed yaml file: <section>.<plrs>.[<plr>.<code>]. The code
     must be camel case. It will be transformed to snake case and used as schema name.
@@ -51,6 +60,43 @@ def create_tables_from_standard_configuration(
             Default is False.
         tables_only (bool): True to skip creation of schema. Default is False.
         sql_file (file): the file to generate. Default is None (in the database).
+        if_not_exists (bool): create Schema with the flag `IF NOT EXISTS`
+    """
+    if Config.get_config() is None:
+        Config.init(configuration_yaml_path, section, c2ctemplate_style)
+
+    for theme_config in Config.get('plrs'):
+        create_theme_tables_(
+            theme_config,
+            source_class,
+            tables_only=tables_only,
+            sql_file=sql_file,
+            if_not_exists=if_not_exists
+        )
+
+
+def create_main_schema_from_configuration_(
+        configuration_yaml_path,
+        section='pyramid_oereb',
+        c2ctemplate_style=False,
+        tables_only=False,
+        sql_file=None,
+        if_not_exists=False):
+    """
+    Creates all schemas which are defined in the passed yaml file: <section>.<plrs>.[<plr>.<code>]. The code
+    must be camel case. It will be transformed to snake case and used as schema name.
+    Creates all tables inside the created schemas. This only affects the sqlalchemy models which are defined
+    with the Base class from pyramid_oereb.standard.models.
+
+    Args:
+        configuration_yaml_path (str): The absolute path to the yaml file which contains the plr
+            definitions.
+        section (str): The section in yaml file where the plrs are configured in. Default is 'pyramid_oereb'.
+        c2ctemplate_style (bool): True if the yaml use a c2c template style (vars.[section]).
+            Default is False.
+        tables_only (bool): True to skip creation of schema. Default is False.
+        sql_file (file): the file to generate. Default is None (in the database).
+        if_not_exists (bool): create Schema with the flag `IF NOT EXISTS`
     """
     if Config.get_config() is None:
         Config.init(configuration_yaml_path, section, c2ctemplate_style)
@@ -67,20 +113,12 @@ def create_tables_from_standard_configuration(
 
     sql_file.write(sql)
 
-    for theme_config in Config.get('plrs'):
-        create_theme_tables_(
-            theme_config,
-            'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource',
-            tables_only=tables_only,
-            sql_file=sql_file,
-            if_not_exists=if_not_exists
-        )
 
-
-def create_standard_tables():
+def create_main_schema_tables():
     parser = optparse.OptionParser(
         usage='usage: %prog [options]',
-        description='Create all content for the standard database'
+        description='Create the main schema with table and its content \
+            used in the standard database'
     )
     parser.add_option(
         '-c', '--configuration',
@@ -116,20 +154,40 @@ def create_standard_tables():
         default=False,
         help='Is the yaml file using a c2ctemplate style (starting with vars)'
     )
+    parser.add_option(
+        '-w', '--over-write',
+        dest='append_to_sql',
+        action='store_true',
+        default=False,
+        help='Setting this will overwrite the given sql-file (defaults to append to the file).'
+    )
+
     options, args = parser.parse_args()
     if not options.configuration:
         parser.error('No configuration file set.')
 
+    if Config.get_config() is None:
+        Config.init(
+            options.configuration,
+            options.section,
+            options.c2ctemplate_style
+        )
+
+    main_config = Config.get('app_schema').get('name')
+    if main_config is None:
+        parser.error('The main config is not found in configuration.')
+
     if options.sql_file is None:
-        create_tables_from_standard_configuration(
+        create_main_schema_from_configuration_(
             configuration_yaml_path=options.configuration,
             section=options.section,
             c2ctemplate_style=options.c2ctemplate_style,
             tables_only=options.tables_only
         )
     else:
-        with open(options.sql_file, 'w') as sql_file:
-            create_tables_from_standard_configuration(
+        append_to_sql = 'w' if options.append_to_sql else 'a'
+        with open(options.sql_file, append_to_sql) as sql_file:
+            create_main_schema_from_configuration_(
                 configuration_yaml_path=options.configuration,
                 section=options.section,
                 c2ctemplate_style=options.c2ctemplate_style,

--- a/pyramid_oereb/contrib/data_sources/oereblex/create_tables.py
+++ b/pyramid_oereb/contrib/data_sources/oereblex/create_tables.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+import optparse
+import logging
+
+from pyramid_oereb.contrib.data_sources.create_tables import \
+    create_tables_from_standard_configuration
+
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+
+def create_oereblex_tables():
+    parser = optparse.OptionParser(
+        usage='usage: %prog [options]',
+        description='Create all content for the standard database'
+    )
+    parser.add_option(
+        '-c', '--configuration',
+        dest='configuration',
+        metavar='YAML',
+        type='string',
+        help='The absolute path to the configuration yaml file.'
+    )
+    parser.add_option(
+        '-s', '--section',
+        dest='section',
+        metavar='SECTION',
+        type='string',
+        default='pyramid_oereb',
+        help='The section which contains configuration (default is: pyramid_oereb).'
+    )
+    parser.add_option(
+        '-T', '--tables-only',
+        dest='tables_only',
+        action='store_true',
+        default=False,
+        help='Use this flag to skip the creation of the schema.'
+    )
+    parser.add_option(
+        '--sql-file',
+        type='string',
+        help='Generate an SQL file.'
+    )
+    parser.add_option(
+        '--c2ctemplate-style',
+        dest='c2ctemplate_style',
+        action='store_true',
+        default=False,
+        help='Is the yaml file using a c2ctemplate style (starting with vars)'
+    )
+    parser.add_option(
+        '-w', '--over-write',
+        dest='append_to_sql',
+        action='store_true',
+        default=False,
+        help='Setting this will overwrite the given sql-file (defaults to append to the file).'
+    )
+
+    options, args = parser.parse_args()
+    if not options.configuration:
+        parser.error('No configuration file set.')
+
+    config_source = 'pyramid_oereb.contrib.data_sources.oereblex.sources.plr_oereblex.DatabaseOEREBlexSource'
+    if options.sql_file is None:
+        create_tables_from_standard_configuration(
+            configuration_yaml_path=options.configuration,
+            source_class=config_source,
+            section=options.section,
+            c2ctemplate_style=options.c2ctemplate_style,
+            tables_only=options.tables_only
+        )
+    else:
+        append_to_sql = 'w' if options.append_to_sql else 'a'
+        with open(options.sql_file, append_to_sql) as sql_file:
+            create_tables_from_standard_configuration(
+                configuration_yaml_path=options.configuration,
+                source_class=config_source,
+                section=options.section,
+                c2ctemplate_style=options.c2ctemplate_style,
+                sql_file=sql_file
+            )

--- a/pyramid_oereb/contrib/data_sources/standard/create_tables.py
+++ b/pyramid_oereb/contrib/data_sources/standard/create_tables.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+import optparse
+import logging
+
+from pyramid_oereb.contrib.data_sources.create_tables import \
+    create_tables_from_standard_configuration
+
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+
+def create_standard_tables():
+    parser = optparse.OptionParser(
+        usage='usage: %prog [options]',
+        description='Create all content for the standard database'
+    )
+    parser.add_option(
+        '-c', '--configuration',
+        dest='configuration',
+        metavar='YAML',
+        type='string',
+        help='The absolute path to the configuration yaml file.'
+    )
+    parser.add_option(
+        '-s', '--section',
+        dest='section',
+        metavar='SECTION',
+        type='string',
+        default='pyramid_oereb',
+        help='The section which contains configuration (default is: pyramid_oereb).'
+    )
+    parser.add_option(
+        '-T', '--tables-only',
+        dest='tables_only',
+        action='store_true',
+        default=False,
+        help='Use this flag to skip the creation of the schema.'
+    )
+    parser.add_option(
+        '--sql-file',
+        type='string',
+        help='Generate an SQL file.'
+    )
+    parser.add_option(
+        '--c2ctemplate-style',
+        dest='c2ctemplate_style',
+        action='store_true',
+        default=False,
+        help='Is the yaml file using a c2ctemplate style (starting with vars)'
+    )
+    parser.add_option(
+        '-w', '--over-write',
+        dest='append_to_sql',
+        action='store_true',
+        default=False,
+        help='Setting this will overwrite the given sql-file (defaults to append to the file).'
+    )
+
+    options, args = parser.parse_args()
+    if not options.configuration:
+        parser.error('No configuration file set.')
+
+    config_source = 'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource'
+    if options.sql_file is None:
+        create_tables_from_standard_configuration(
+            configuration_yaml_path=options.configuration,
+            source_class=config_source,
+            section=options.section,
+            c2ctemplate_style=options.c2ctemplate_style,
+            tables_only=options.tables_only
+        )
+    else:
+        append_to_sql = 'w' if options.append_to_sql else 'a'
+        with open(options.sql_file, append_to_sql) as sql_file:
+            create_tables_from_standard_configuration(
+                configuration_yaml_path=options.configuration,
+                source_class=config_source,
+                section=options.section,
+                c2ctemplate_style=options.c2ctemplate_style,
+                sql_file=sql_file
+            )

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,9 @@ setup(
             'main = pyramid_oereb:main'
         ],
         'console_scripts': [
-            'create_standard_tables = pyramid_oereb.contrib.data_sources.create_tables:create_standard_tables',  # noqa: E501
+            'create_standard_tables = pyramid_oereb.contrib.data_sources.standard.create_tables:create_standard_tables',  # noqa: E501
+            'create_oereblex_tables = pyramid_oereb.contrib.data_sources.oereblex.create_tables:create_oereblex_tables',  # noqa: E501
+            'create_main_schema_tables = pyramid_oereb.contrib.data_sources.create_tables:create_main_schema_tables',  # noqa: E501
             'create_example_yaml = dev.config.create_yaml:create_yaml',
             'create_theme_tables = pyramid_oereb.contrib.data_sources.create_tables:create_theme_tables',
             'create_legend_entries = pyramid_oereb.contrib.data_sources.standard.load_legend_entries:run',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,8 @@ from pyramid_oereb.core.records.theme import ThemeRecord
 from pyramid_oereb.core.records.document_types import DocumentTypeRecord
 from pyramid_oereb.core.records.law_status import LawStatusRecord
 from pyramid_oereb.core.records.logo import LogoRecord
-from pyramid_oereb.contrib.data_sources.create_tables import create_tables_from_standard_configuration
+from pyramid_oereb.contrib.data_sources.create_tables import create_main_schema_from_configuration_, \
+    create_tables_from_standard_configuration
 from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser
 
 SCHEMA_JSON_EXTRACT_PATH = './tests/resources/schema/20210415/extract.json'
@@ -186,8 +187,17 @@ def test_db_engine(base_engine, test_db_name, config_path):
     engine.execute("CREATE EXTENSION POSTGIS")
 
     # initialize the DB with standard tables via a temp string buffer to hold SQL commands
+
+    # crate the main schema
+    sql_file_main = StringIO()
+    create_main_schema_from_configuration_(config_path, sql_file=sql_file_main)
+    sql_file_main.seek(0)
+    engine.execute(sql_file_main.read())
+
+    # create the schemas for the themes
     sql_file = StringIO()
-    create_tables_from_standard_configuration(config_path, sql_file=sql_file)
+    standart_table_source = 'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource'
+    create_tables_from_standard_configuration(config_path, standart_table_source, sql_file=sql_file)
     sql_file.seek(0)
     engine.execute(sql_file.read())
 

--- a/tests/core/test_standard_db_creation.py
+++ b/tests/core/test_standard_db_creation.py
@@ -8,7 +8,20 @@ from sqlalchemy.exc import ProgrammingError
 def test_create_standard_db(config_path, dbsession, transact):
     from pyramid_oereb.contrib.data_sources.create_tables import create_tables_from_standard_configuration
     sql_file = StringIO()
-    create_tables_from_standard_configuration(config_path, sql_file=sql_file)
+    standart_table_source = 'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource'
+    create_tables_from_standard_configuration(config_path, standart_table_source, sql_file=sql_file)
+
+    # tables already exist in DB => error
+    with pytest.raises(ProgrammingError):
+        sql_file.seek(0)
+        dbsession.execute(sql_file.read())
+
+
+@pytest.mark.run(order=-9)
+def test_create_main_schema(config_path, dbsession, transact):
+    from pyramid_oereb.contrib.data_sources.create_tables import create_main_schema_from_configuration_
+    sql_file = StringIO()
+    create_main_schema_from_configuration_(config_path, sql_file=sql_file)
 
     # tables already exist in DB => error
     with pytest.raises(ProgrammingError):
@@ -20,7 +33,23 @@ def test_create_standard_db(config_path, dbsession, transact):
 def test_create_standard_db_if_not_exists(config_path, dbsession, transact):
     from pyramid_oereb.contrib.data_sources.create_tables import create_tables_from_standard_configuration
     sql_file = StringIO()
-    create_tables_from_standard_configuration(config_path, sql_file=sql_file, if_not_exists=True)
+    standart_table_source = 'pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource'
+    create_tables_from_standard_configuration(
+        config_path,
+        standart_table_source,
+        sql_file=sql_file,
+        if_not_exists=True
+    )
+
+    sql_file.seek(0)
+    dbsession.execute(sql_file.read())
+
+
+@pytest.mark.run(order=-9)
+def test_reate_main_schema_if_not_exists(config_path, dbsession, transact):
+    from pyramid_oereb.contrib.data_sources.create_tables import create_main_schema_from_configuration_
+    sql_file = StringIO()
+    create_main_schema_from_configuration_(config_path, sql_file=sql_file, if_not_exists=True)
 
     sql_file.seek(0)
     dbsession.execute(sql_file.read())


### PR DESCRIPTION
Fixes #1541
This replaces the old PR #1542 

- make create_oereblex_tables a command line tool

- separate creation of main schema & tables

- fix and add tests

- update docu