### PR TITLE
bugfix-1560-doc-only-for-one-municipality

### DIFF
--- a/dev/sample_data/contaminated_public_transport_sites/document.json
+++ b/dev/sample_data/contaminated_public_transport_sites/document.json
@@ -203,5 +203,37 @@
       "fr": "B61001",
       "it": "B61001"
     }
+  }, {
+    "office_id": 1,
+    "published_from": "2016-02-25",
+    "id": 1297,
+    "document_type": "Rechtsvorschrift",
+    "index": 2,
+    "text_at_web": {
+      "de": "https://www.bav.admin.ch/dam/bav/de/dokumente/das-bav/finanzierung/faktenblatt_fernverkehr_konzessionierung.pdf.download.pdf/d_Faktenblatt_Fernverkehr_und_Konzessionierung%20.pdf"
+    },
+    "law_status": "inKraft",
+    "title": {
+      "de": "Rechtsvorschrift für Gemeinde 2771",
+      "fr": "Dispositions juridiques pour commune 2771",
+      "it": "Prescrizione legale per commune 2771"
+    },
+    "only_in_municipality": 2771
+  }, {
+    "office_id": 1,
+    "published_from": "2016-02-25",
+    "id": 1298,
+    "document_type": "Rechtsvorschrift",
+    "index": 2,
+    "text_at_web": {
+      "de": "https://www.bav.admin.ch/dam/bav/de/dokumente/das-bav/finanzierung/faktenblatt_fernverkehr_konzessionierung.pdf.download.pdf/d_Faktenblatt_Fernverkehr_und_Konzessionierung%20.pdf"
+    },
+    "law_status": "inKraft",
+    "title": {
+      "de": "Rechtsvorschrift für Gemeinde 2772",
+      "fr": "Dispositions juridiques pour commune 2772",
+      "it": "Prescrizione legale per commune 2772"
+    },
+    "only_in_municipality": 2772
   }
 ]

--- a/dev/sample_data/contaminated_public_transport_sites/public_law_restriction_document.json
+++ b/dev/sample_data/contaminated_public_transport_sites/public_law_restriction_document.json
@@ -83,5 +83,13 @@
     "id": 21,
     "document_id": 1357,
     "public_law_restriction_id": 396
+  }, {
+    "id": 22,
+    "document_id": 1297,
+    "public_law_restriction_id": 396
+  }, {
+    "id": 23,
+    "document_id": 1298,
+    "public_law_restriction_id": 396
   }
 ]

--- a/pyramid_oereb/core/processor.py
+++ b/pyramid_oereb/core/processor.py
@@ -76,9 +76,11 @@ class Processor(object):
 
     def plr_tolerance_check(self, extract):
         """
-        The function checking if the found plr results exceed the minimal surface or length
-        value defined in the configuration and should therefor be represented in the extract
-        or considered 'false trues' and be removed from the results.
+        The function checks if the found plr results exceed the minimal surface or length
+        value defined in the configuration and therefore should be represented in the extract
+        or if they should be considered as 'false trues' and be removed from the results.
+        In addition, this function filters these documents out that are not published or that are not
+        relevant for the municipality the real estate is located in.
 
         Args:
             extract (pyramid_oereb.lib.records.extract.ExtractRecord): The extract in it's

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -458,6 +458,34 @@ def land_use_plans(pyramid_oereb_test_config, dbsession, transact, wms_url_conta
             'text_at_web': {'de': 'http://www.admin.ch/ch/d/sr/c814_01.html'},
             'abbreviation': {'de': 'USG', 'fr': 'LPE', 'it': 'LPAmb', 'en': 'EPA'},
             'official_number': {'de': 'SR 814.01'},
+        }),
+        models.Document(**{
+            'id': 3,
+            'document_type': 'GesetzlicheGrundlage',
+            'index': 1,
+            'law_status': 'inKraft',
+            'published_from': date.today().isoformat(),
+            'published_until': (date.today() + timedelta(days=100)).isoformat(),
+            'title': {'de': 'First level document'},
+            'office_id': 1,
+            'text_at_web': {'de': 'http://www.admin.ch/ch/d/sr/c814_01.html'},
+            'abbreviation': {'de': 'USG', 'fr': 'LPE', 'it': 'LPAmb', 'en': 'EPA'},
+            'official_number': {'de': 'SR 814.01'},
+            'only_in_municipality': 1234
+        }),
+        models.Document(**{
+            'id': 4,
+            'document_type': 'GesetzlicheGrundlage',
+            'index': 1,
+            'law_status': 'inKraft',
+            'published_from': date.today().isoformat(),
+            'published_until': (date.today() + timedelta(days=100)).isoformat(),
+            'title': {'de': 'First level document'},
+            'office_id': 1,
+            'text_at_web': {'de': 'http://www.admin.ch/ch/d/sr/c814_01.html'},
+            'abbreviation': {'de': 'USG', 'fr': 'LPE', 'it': 'LPAmb', 'en': 'EPA'},
+            'official_number': {'de': 'SR 814.01'},
+            'only_in_municipality': 1235
         })
     }
     dbsession.add_all(documents)
@@ -472,6 +500,16 @@ def land_use_plans(pyramid_oereb_test_config, dbsession, transact, wms_url_conta
             'id': 2,
             'public_law_restriction_id': 1,
             'document_id': 2,
+        }),
+        models.PublicLawRestrictionDocument(**{
+            'id': 3,
+            'public_law_restriction_id': 1,
+            'document_id': 3,
+        }),
+        models.PublicLawRestrictionDocument(**{
+            'id': 4,
+            'public_law_restriction_id': 1,
+            'document_id': 4,
         })
     }
     dbsession.add_all(plr_documents)

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -80,7 +80,7 @@ def test_process_geometry_testing(processor_data, real_estate_data, land_use_pla
             assert g._test_passed
 
 
-def test_filter_published_documents(processor_data, real_estate_data, main_schema, land_use_plans):
+def test_filter_documents(processor_data, real_estate_data, main_schema, land_use_plans):
     request = MockRequest()
     request.matchdict.update(request_matchdict)
     request.params.update(request_params)
@@ -93,7 +93,9 @@ def test_filter_published_documents(processor_data, real_estate_data, main_schem
     assert len(plrs) == 1
     for plr in plrs:
         if plr.theme.code == u'ch.Nutzungsplanung':
-            assert len(plr.documents) == 1
+            assert len(plr.documents) == 2
+            for document in plr.documents:
+                assert document.only_in_municipality in [None, 1234]
 
 
 def test_processor_with_images(processor_data, real_estate_data):


### PR DESCRIPTION
closes https://github.com/openoereb/pyramid_oereb/issues/1560

- Additional filter added in processor.py
- Tests for processor slightly adapted

To my knowledge "only_in_municipality" is not an attribute in OerebLex (true?). So "only_in_municipality" is always None for documents provided by OerebLex.
https://github.com/openoereb/pyramid_oereb/blob/8ca834de3f4abd9cd7d8fdfd61a443c3dfd71190/pyramid_oereb/contrib/data_sources/oereblex/sources/document.py#L205 