### PR TITLE
Fix Oereblex optional param usage

### DIFF
--- a/pyramid_oereb/contrib/data_sources/oereblex/sources/plr_oereblex.py
+++ b/pyramid_oereb/contrib/data_sources/oereblex/sources/plr_oereblex.py
@@ -68,11 +68,11 @@ class DatabaseOEREBlexSource(DatabaseSource):
         """
         oereblex_params = None
         url_param_config = self._oereblex_source._url_param_config
+        plr_code = self._plr_info.get('code')
         if url_param_config:
-            plr_code = self._theme_record.code
             oereblex_params = DatabaseOEREBlexSource.get_config_value_for_plr_code(url_param_config, plr_code)
         law_status = Config.get_law_status_by_data_code(
-            self._plr_info.get('code'),
+            plr_code,
             public_law_restriction_from_db.law_status
         )
         return self.document_records_from_oereblex(params, public_law_restriction_from_db.geolink,


### PR DESCRIPTION
The optional Oereblex parameter was introduced in https://github.com/openoereb/pyramid_oereb/issues/1065, to be able to use parameters like "oereb_id".
It was broken in V2, this PR fixes this, it was tested at Geoinfo by Max:
`[Fri May 20 06:19:26.727155 2022] [wsgi:error] [pid 41360:tid 139698737334016] [remote [172.30.21.101:52056](http://172.30.21.101:52056/)] 2022-05-20 06:19:26,727 DEBUG [pyramid_oereb.contrib.data_sources.oereblex.sources.document][MainThread] read() start for geolink_id 3674, oereblex_params oereb_id=3
[Fri May 20 06:19:26.727197 2022] [wsgi:error] [pid 41360:tid 139698737334016] [remote [172.30.21.101:52056](http://172.30.21.101:52056/)] 2022-05-20 06:19:26,727 DEBUG [pyramid_oereb.contrib.data_sources.oereblex.sources.document][MainThread] read() start for geolink_id 3674, oereblex_params oereb_id=3
[Fri May 20 06:19:26.727314 2022] [wsgi:error] [pid 41360:tid 139698737334016] [remote [172.30.21.101:52056](http://172.30.21.101:52056/)] 2022-05-20 06:19:26,727 DEBUG [pyramid_oereb.contrib.data_sources.oereblex.sources.document][MainThread] read() getting documents, url: http://sg-oereblex-preview.clex.ch//api/1.2.2/geolinks/3674.xml?oereb_id=3, parser: <geolink_formatter.parser.XML object at 0x7f0dfdfde310>
[Fri May 20 06:19:26.727366 2022] [wsgi:error] [pid 41360:tid 139698737334016] [remote [172.30.21.101:52056](http://172.30.21.101:52056/)] 2022-05-20 06:19:26,727 DEBUG [pyramid_oereb.contrib.data_sources.oereblex.sources.document][MainThread] read() getting documents, url: http://sg-oereblex-preview.clex.ch//api/1.2.2/geolinks/3674.xml?oereb_id=3, parser: <geolink_formatter.parser.XML object at 0x7f0dfdfde310>
[Fri May 20 06:19:26.982137 2022] [wsgi:error] [pid 41360:tid 139698737334016] [remote [172.30.21.101:52056](http://172.30.21.101:52056/)] 2022-05-20 06:19:26,981 DEBUG [pyramid_oereb.contrib.data_sources.oereblex.sources.document][MainThread] read() got documents
[Fri May 20 06:19:26.982257 2022] [wsgi:error] [pid 41360:tid 139698737334016] [remote [172.30.21.101:52056](http://172.30.21.101:52056/)] 2022-05-20 06:19:26,981 DEBUG [pyramid_oereb.contrib.data_sources.oereblex.sources.document][MainThread] read() got documents`
