### PR TITLE
add optional tolerance on geometric operations

### DIFF
--- a/.coveragerc.contrib-data_sources-interlis
+++ b/.coveragerc.contrib-data_sources-interlis
@@ -1,0 +1,3 @@
+[run]
+source =
+    pyramid_oereb/contrib/data_sources/interlis_2_3/*.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           fail_ci_if_error: true
-          files: ./coverage.core.xml,./coverage.contrib-data_sources-standard.xml,./coverage.contrib-print_proxy-mapfish_print.xml,./coverage.contrib-stats.xml
+          files: ./coverage.core.xml,./coverage.contrib-data_sources-standard.xml,./coverage.contrib-data_sources-interlis.xml,./coverage.contrib-print_proxy-mapfish_print.xml,./coverage.contrib-stats.xml
           flags: unittests
           name: codecov-unittest
           verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ DataExtract.json
 /dev/database/structure/01_create_extension.sql
 
 /coverage.contrib-data_sources-standard.xml
+/coverage.contrib-data_sources-interlis.xml
 /coverage.contrib-print_proxy-mapfish_print.xml
 /coverage.core.xml
 /coverage.contrib-stats.xml

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ clean: clean_fed_data clean_dev_db_scripts
 	rm -f $(DEV_CONFIGURATION_YML)
 	rm -f coverage.core.xml
 	rm -f coverage.contrib-data_sources-standard.xml
+	rm -f coverage.contrib-data_sources-interlis.xml
 	rm -f coverage.contrib-print_proxy-mapfish_print.xml
 	rm -f coverage.contrib-stats.xml
 
@@ -302,7 +303,7 @@ test-postgis:
 
 .PHONY: test-core
 test-core: ${VENV_ROOT}/requirements-timestamp
-	$(VENV_BIN)/py.test --pdb -vv $(PYTEST_OPTS) --cov-config .coveragerc.core --cov $(PACKAGE)/core --cov-report=term-missing --cov-report=xml:coverage.core.xml tests/core
+	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.core --cov $(PACKAGE)/core --cov-report=term-missing --cov-report=xml:coverage.core.xml tests/core
 
 .PHONY: test-contrib-print_proxy-mapfish_print
 test-contrib-print_proxy-mapfish_print: ${VENV_ROOT}/requirements-timestamp
@@ -313,12 +314,16 @@ test-contrib-print_proxy-mapfish_print: ${VENV_ROOT}/requirements-timestamp
 test-contrib-data_sources-standard: ${VENV_ROOT}/requirements-timestamp
 	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-data_sources-standard --cov $(PACKAGE)/contrib/data_sources/standard --cov-report=term-missing:skip-covered --cov-report=xml:coverage.contrib-data_sources-standard.xml tests/contrib.data_sources.standard
 
+.PHONY: test-contrib-data_sources-interlis
+test-contrib-data_sources-interlis: ${VENV_ROOT}/requirements-timestamp
+	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-data_sources-interlib --cov $(PACKAGE)/contrib/data_sources/interlis_2_3 --cov-report=term-missing:skip-covered --cov-report=xml:coverage.contrib-data_sources-interlis.xml tests/contrib.data_sources.interlis_2_3
+
 .PHONY: test-contrib-stats
 test-contrib-stats: ${VENV_ROOT}/requirements-timestamp
 	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-stats --cov $(PACKAGE)/contrib/stats --cov-report=xml:coverage.contrib-stats.xml tests/contrib.stats
 
 .PHONY: tests
-tests: ${VENV_ROOT}/requirements-timestamp test-core test-contrib-data_sources-standard test-contrib-print_proxy-mapfish_print test-contrib-data_sources-standard test-contrib-stats
+tests: ${VENV_ROOT}/requirements-timestamp test-core test-contrib-data_sources-standard test-contrib-print_proxy-mapfish_print test-contrib-data_sources-standard test-contrib-data_sources-interlis test-contrib-stats
 
 .PHONY: docker-tests
 docker-tests:

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ test-contrib-data_sources-standard: ${VENV_ROOT}/requirements-timestamp
 
 .PHONY: test-contrib-data_sources-interlis
 test-contrib-data_sources-interlis: ${VENV_ROOT}/requirements-timestamp
-	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-data_sources-interlib --cov $(PACKAGE)/contrib/data_sources/interlis_2_3 --cov-report=term-missing:skip-covered --cov-report=xml:coverage.contrib-data_sources-interlis.xml tests/contrib.data_sources.interlis_2_3
+	$(VENV_BIN)/py.test -vv $(PYTEST_OPTS) --cov-config .coveragerc.contrib-data_sources-interlis --cov $(PACKAGE)/contrib/data_sources/interlis_2_3 --cov-report=term-missing:skip-covered --cov-report=xml:coverage.contrib-data_sources-interlis.xml tests/contrib.data_sources.interlis_2_3
 
 .PHONY: test-contrib-stats
 test-contrib-stats: ${VENV_ROOT}/requirements-timestamp

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ tests: ${VENV_ROOT}/requirements-timestamp test-core test-contrib-data_sources-s
 .PHONY: docker-tests
 docker-tests:
 	echo "Running tests as user ${LOCAL_UID}:${LOCAL_GID}"
-	docker-compose run --rm -e PGHOST=oereb-db -e UID=${LOCAL_UID} -e GID=${LOCAL_GID} oereb-server make build tests
+	docker-compose run --rm -e PGHOST=oereb-db -e UID=${LOCAL_UID} -e GID=${LOCAL_GID} oereb-server make build lint tests
 	docker-compose down
 
 .PHONY: docker-clean-all

--- a/pyramid_oereb/contrib/data_sources/interlis_2_3/models/theme.py
+++ b/pyramid_oereb/contrib/data_sources/interlis_2_3/models/theme.py
@@ -537,3 +537,19 @@ def model_factory_integer_pk(schema_name, geometry_type, srid, db_connection):
     if geometry_type is not None:
         geometry_type = None
     return model_factory(schema_name, Integer, srid, db_connection)
+
+
+def model_factory_string_pk(schema_name, geometry_type, srid, db_connection):
+    """
+    Args:
+        schema_name (str): The name of the database schema where this models belong to.
+        geometry_type (str): The geoalchemy geometry type defined as well known string.
+        srid (int): The SRID defining the projection of the geometries stored in standard db schema.
+        db_connection (str): the db connection string
+
+    Returns:
+        Models: the produced set of standard models
+    """
+    if geometry_type is not None:
+        geometry_type = None
+    return model_factory(schema_name, String, srid, db_connection)

--- a/pyramid_oereb/contrib/data_sources/interlis_2_3/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/interlis_2_3/sources/plr.py
@@ -421,32 +421,14 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
             list: The result of the related geometries unique by the public law restriction id
         """
         if self._tolerance is None:
-            return session.query(self._model_).filter(
+            query = session.query(self._model_).filter(
                 or_(
                     self._model_.point.ST_Intersects(from_shape(real_estate.limit, srid=Config.get('srid'))),
                     self._model_.line.ST_Intersects(from_shape(real_estate.limit, srid=Config.get('srid'))),
                     self._model_.surface.ST_Intersects(from_shape(real_estate.limit, srid=Config.get('srid')))
-                )).distinct(self._model_.public_law_restriction_id).options(
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.geometries),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.legal_provisions)
-                        .selectinload(self.models.PublicLawRestrictionDocument.document)
-                        .selectinload(self.models.Document.multilingual_uri)
-                        .selectinload(self.models.MultilingualUri.localised_uri),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.legend_entry),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.view_service)
-                        .selectinload(self.models.ViewService.multilingual_uri)
-                        .selectinload(self.models.MultilingualUri.localised_uri),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.responsible_office)
-                        .selectinload(self.models.Office.multilingual_uri)
-                        .selectinload(self.models.MultilingualUri.localised_uri)
-                )all()
+                ))
         else:
-            return session.query(self._model_).filter(
+            query = session.query(self._model_).filter(
                 or_(
                     self._model_.point.ST_Distance(
                         from_shape(real_estate.limit, srid=Config.get('srid'))
@@ -457,25 +439,26 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
                     self._model_.surface.ST_Distance(
                         from_shape(real_estate.limit, srid=Config.get('srid'))
                     ) < self._tolerance
-                )).distinct(self._model_.public_law_restriction_id).options(
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.geometries),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.legal_provisions)
-                        .selectinload(self.models.PublicLawRestrictionDocument.document)
-                        .selectinload(self.models.Document.multilingual_uri)
-                        .selectinload(self.models.MultilingualUri.localised_uri),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.legend_entry),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.view_service)
-                        .selectinload(self.models.ViewService.multilingual_uri)
-                        .selectinload(self.models.MultilingualUri.localised_uri),
-                        selectinload(self.models.Geometry.public_law_restriction)
-                        .selectinload(self.models.PublicLawRestriction.responsible_office)
-                        .selectinload(self.models.Office.multilingual_uri)
-                        .selectinload(self.models.MultilingualUri.localised_uri)
-                )all()
+                ))
+        return query.distinct(self._model_.public_law_restriction_id).options(
+            selectinload(self.models.Geometry.public_law_restriction)
+            .selectinload(self.models.PublicLawRestriction.geometries),
+            selectinload(self.models.Geometry.public_law_restriction)
+            .selectinload(self.models.PublicLawRestriction.legal_provisions)
+            .selectinload(self.models.PublicLawRestrictionDocument.document)
+            .selectinload(self.models.Document.multilingual_uri)
+            .selectinload(self.models.MultilingualUri.localised_uri),
+            selectinload(self.models.Geometry.public_law_restriction)
+            .selectinload(self.models.PublicLawRestriction.legend_entry),
+            selectinload(self.models.Geometry.public_law_restriction)
+            .selectinload(self.models.PublicLawRestriction.view_service)
+            .selectinload(self.models.ViewService.multilingual_uri)
+            .selectinload(self.models.MultilingualUri.localised_uri),
+            selectinload(self.models.Geometry.public_law_restriction)
+            .selectinload(self.models.PublicLawRestriction.responsible_office)
+            .selectinload(self.models.Office.multilingual_uri)
+            .selectinload(self.models.MultilingualUri.localised_uri)
+        ).all()
 
     def collect_legend_entries_by_bbox(self, session, bbox):
         """

--- a/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
@@ -373,7 +373,7 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
         return document_records
 
     @staticmethod
-    def extract_geometry_collection_db(db_path, real_estate_geometry):
+    def extract_geometry_collection_db(db_path, real_estate_geometry, tolerance=None):
         """
         Decides the geometry collection cases of geometric filter operations when the database contains multi
         geometries but the passed geometry does not.
@@ -392,27 +392,20 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
             HTTPBadRequest
         """
         srid = Config.get('srid')
-        sql_text_point = 'ST_Intersects(ST_CollectionExtract({0}, 1), ST_GeomFromText(\'{1}\', {2}))'.format(
-            db_path,
-            real_estate_geometry.wkt,
-            srid
-        )
-        sql_text_line = 'ST_Intersects(ST_CollectionExtract({0}, 2), ST_GeomFromText(\'{1}\', {2}))'.format(
-            db_path,
-            real_estate_geometry.wkt,
-            srid
-        )
-        sql_text_polygon = 'ST_Intersects(ST_CollectionExtract({0}, 3), ' \
-                           'ST_GeomFromText(\'{1}\', {2}))'.format(
-                                db_path,
-                                real_estate_geometry.wkt,
-                                srid
-                            )
-        clause_blocks = [
-            text(sql_text_point),
-            text(sql_text_line),
-            text(sql_text_polygon)
-        ]
+        extract_point = f"ST_CollectionExtract({db_path}, 1)"
+        extract_line = f"ST_CollectionExtract({db_path}, 2)"
+        extract_polygon = f"ST_CollectionExtract({db_path}, 3)"
+        geometry_string = f'ST_GeomFromText(\'{real_estate_geometry.wkt}\', {srid})'
+        if tolerance is None:
+            clause_blocks = [
+                text(f'ST_Intersects({extract}, {geometry_string})')
+                for extract in [extract_point, extract_line, extract_polygon]
+            ]
+        else:
+            clause_blocks = [
+                text(f'ST_Distance({extract}, {geometry_string}) < {tolerance}')
+                for extract in [extract_point, extract_line, extract_polygon]
+            ]
         return or_(*clause_blocks)
 
     def handle_collection(self, session, geometry_to_check):
@@ -438,7 +431,8 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
                         schema=self._model_.__table__.schema,
                         table=self._model_.__table__.name
                     ),
-                    geometry_to_check
+                    geometry_to_check,
+                    self._tolerance
                 )
             )
 

--- a/pyramid_oereb/core/records/geometry.py
+++ b/pyramid_oereb/core/records/geometry.py
@@ -130,7 +130,15 @@ class GeometryRecord(object):
         else:
             return result
 
-    def calculate(self, real_estate, min_length, min_area, length_unit, area_unit, geometry_types):
+    def reset_calculation(self):
+        self._units = None
+        self._area_share = None
+        self._length_share = None
+        self._nr_of_points = None
+        self._test_passed = False
+        self.calculated = False
+
+    def calculate(self, real_estate, min_length, min_area, length_unit, area_unit, geometry_types, tolerance=None):
         """
         Entry method for calculation. It checks if the geometry type of this instance is a geometry
         collection which has to be unpacked first in case of collection.
@@ -147,11 +155,15 @@ class GeometryRecord(object):
         Returns:
             bool: True if intersection fits the limits.
         """
+        if tolerance is None:
+            re_limit = real_estate.limit
+        else:
+            re_limit = real_estate.limit.buffer(tolerance)
         line_types = geometry_types.get('line').get('types')
         polygon_types = geometry_types.get('polygon').get('types')
         point_types = geometry_types.get('point').get('types')
         if self.published:
-            intersection = self.geom.intersection(real_estate.limit)
+            intersection = self.geom.intersection(re_limit)
             if not intersection.is_empty:
                 result = self._extract_collection(intersection)
                 if self.geom.type not in point_types + line_types + polygon_types:

--- a/pyramid_oereb/core/records/geometry.py
+++ b/pyramid_oereb/core/records/geometry.py
@@ -138,7 +138,8 @@ class GeometryRecord(object):
         self._test_passed = False
         self.calculated = False
 
-    def calculate(self, real_estate, min_length, min_area, length_unit, area_unit, geometry_types, tolerance=None):
+    def calculate(self, real_estate, min_length, min_area, length_unit, area_unit, geometry_types,
+                  tolerance=None):
         """
         Entry method for calculation. It checks if the geometry type of this instance is a geometry
         collection which has to be unpacked first in case of collection.

--- a/pyramid_oereb/core/records/plr.py
+++ b/pyramid_oereb/core/records/plr.py
@@ -62,7 +62,7 @@ class PlrRecord(EmptyPlrRecord):
     def __init__(self, theme, legend_entry, law_status, published_from, published_until, responsible_office,
                  symbol, view_service, geometries, sub_theme=None, type_code=None,
                  type_code_list=None, documents=None, info=None, min_length=0.0,
-                 min_area=0.0, length_unit=u'm', area_unit=u'm2', view_service_id=None):
+                 min_area=0.0, length_unit=u'm', area_unit=u'm2', view_service_id=None, tolerance=None):
         """
         Args:
             theme (pyramid_oereb.lib.records.theme.ThemeRecord): The theme to which the PLR belongs to.
@@ -120,6 +120,7 @@ class PlrRecord(EmptyPlrRecord):
         self.min_area = min_area
         self.area_unit = area_unit
         self.length_unit = length_unit
+        self.tolerance = tolerance
         self._area_share = None
         self._part_in_percent = None
         self._length_share = None
@@ -236,7 +237,8 @@ class PlrRecord(EmptyPlrRecord):
                     real_estate,
                     self.min_length, self.min_area,
                     self.length_unit, self.area_unit,
-                    geometry_types
+                    geometry_types,
+                    self.tolerance
             ):
                 tested_geometries.append(geometry)
                 inside = True

--- a/tests/contrib.data_sources.interlis_2_3/sources/test_plr.py
+++ b/tests/contrib.data_sources.interlis_2_3/sources/test_plr.py
@@ -1,0 +1,271 @@
+import pytest
+from unittest.mock import patch
+
+from datetime import date, timedelta
+
+from pyramid.path import DottedNameResolver
+
+from sqlalchemy import create_engine, orm
+from sqlalchemy.schema import CreateSchema
+from sqlalchemy.engine.url import URL
+
+from shapely.geometry import Polygon
+
+from pyramid_oereb.core.records.real_estate import RealEstateRecord
+from pyramid_oereb.core.records.municipality import MunicipalityRecord
+from pyramid_oereb.core.records.theme import ThemeRecord
+
+from pyramid_oereb.core.processor import Processor
+from pyramid_oereb.contrib.data_sources.interlis_2_3.sources.plr import (
+    StandardThemeConfigParser
+)
+
+
+@pytest.fixture(scope='session')
+def interlis_db_engine(base_engine):
+    # def test_db_engine(base_engine, test_db_name, config_path):
+    # """
+    # create a new test DB called test_db_name and its engine
+    # """
+
+    test_interlis_db_name = "interlis_test"
+    base_connection = base_engine.connect()
+    # terminate existing connections to be able to DROP the DB
+    base_connection.execute('SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity '
+                            f'WHERE pg_stat_activity.datname = \'{test_interlis_db_name}\' '
+                            'AND pid <> pg_backend_pid();')
+    # sqlalchemy uses transactions by default, COMMIT end the current transaction and allows
+    # creation and destruction of DB
+    base_connection.execute('COMMIT')
+    base_connection.execute(f"DROP DATABASE if EXISTS {test_interlis_db_name}")
+    base_connection.execute('COMMIT')
+    base_connection.execute(f"CREATE DATABASE {test_interlis_db_name}")
+
+    test_db_url = URL.create(
+        base_engine.url.get_backend_name(),
+        base_engine.url.username,
+        base_engine.url.password,
+        base_engine.url.host,
+        base_engine.url.port,
+        database=test_interlis_db_name
+    )
+    engine = create_engine(test_db_url)
+    engine.execute("CREATE EXTENSION POSTGIS")
+    return engine
+
+
+@pytest.fixture(scope='session')
+def interlis_dbsession(interlis_db_engine):
+    session = orm.sessionmaker(bind=interlis_db_engine)()
+    with patch(
+        'pyramid_oereb.core.adapter.DatabaseAdapter.get_session', return_value=session
+    ), patch.object(
+        session, "close"
+    ):
+        yield session
+
+
+@pytest.fixture
+def interlis_transact(interlis_dbsession):
+    transact = interlis_dbsession.begin_nested()
+    yield transact
+    transact.rollback()
+    interlis_dbsession.expire_all()
+
+
+@pytest.fixture
+def interlis_land_use_plans(pyramid_oereb_test_config,
+                            interlis_db_engine, interlis_dbsession, interlis_transact):
+    del interlis_transact
+
+    theme_config = pyramid_oereb_test_config.get_theme_config_by_code('ch.Nutzungsplanung')
+    theme_config["source"]["class"] = (
+        "pyramid_oereb.contrib.data_sources.interlis_2_3.sources.plr.DatabaseSource"
+    )
+    theme_config["source"]["params"]["model_factory"] = (
+        "pyramid_oereb.contrib.data_sources.interlis_2_3.models.theme.model_factory_string_pk"
+    )
+    theme_config["hooks"]["get_symbol"] = (
+        "pyramid_oereb.contrib.data_sources.interlis_2_3.hook_methods.get_symbol"
+    )
+    config_parser = StandardThemeConfigParser(**theme_config)
+    models = config_parser.get_models()
+
+    interlis_db_engine.execute(CreateSchema('land_use_plans'))
+    models.Geometry.metadata.create_all(interlis_db_engine)
+
+    localised_uris = {
+        models.LocalisedUri(**{
+            't_id': 1,
+            'language': 'de',
+            'text': 'http://my.wms.com',
+            'multilingualuri_id': 1
+        })
+    }
+    interlis_dbsession.add_all(localised_uris)
+    uris = {
+        models.MultilingualUri(**{
+            't_id': 1,
+            'view_service_id': 1,
+        })
+    }
+    interlis_dbsession.add_all(uris)
+    view_services = {
+        models.ViewService(**{
+            't_id': 1
+        })
+    }
+    interlis_dbsession.add_all(view_services)
+    legend_entries = {
+        models.LegendEntry(**{
+            't_id': 1,
+            'symbol': b"",
+            'legend_text_de': 'interlis',
+            'type_code': 'type',
+            'type_code_list': 'type',
+            'theme': 'ch.Nutzungsplanung',
+            'view_service_id': 1
+        })
+    }
+    interlis_dbsession.add_all(legend_entries)
+    offices = {
+        models.Office(**{
+            't_id': 1
+        })
+    }
+    interlis_dbsession.add_all(offices)
+    plrs = {
+        models.PublicLawRestriction(**{
+            't_id': 1,
+            'law_status': 'inKraft',
+            'published_from': date.today().isoformat(),
+            'published_until': (date.today() + timedelta(days=100)).isoformat(),
+            'view_service_id': 1,
+            'legend_entry_id': 1,
+            'office_id': 1
+        })
+    }
+    interlis_dbsession.add_all(plrs)
+    geometries = {
+        models.Geometry(**{
+            't_id': 1,
+            'law_status': 'inKraft',
+            'published_from': date.today().isoformat(),
+            'published_until': (date.today() + timedelta(days=100)).isoformat(),
+            'geo_metadata': 'Large polygon PLR',
+            'public_law_restriction_id': 1,
+            'surface': 'SRID=2056;POLYGON((1 -1, 9 -1, 9 7, 1 7, 1 8, 10 8, 10 -2, 1 -2, 1 -1))',
+        }),
+        models.Geometry(**{
+            't_id': 2,
+            'law_status': 'inKraft',
+            'published_from': date.today().isoformat(),
+            'published_until': (date.today() + timedelta(days=100)).isoformat(),
+            'geo_metadata': 'Line',
+            'public_law_restriction_id': 1,
+            'line': 'SRID=2056;LINESTRING(1 0.1, 2 0.1)',
+        }),
+        models.Geometry(**{
+            't_id': 3,
+            'law_status': 'inKraft',
+            'published_from': date.today().isoformat(),
+            'published_until': (date.today() + timedelta(days=100)).isoformat(),
+            'geo_metadata': 'Line',
+            'public_law_restriction_id': 1,
+            'line': 'SRID=2056;LINESTRING(1 0.1, 2 0.2)',
+        }),
+        models.Geometry(**{
+            't_id': 4,
+            'law_status': 'inKraft',
+            'published_from': date.today().isoformat(),
+            'published_until': (date.today() + timedelta(days=100)).isoformat(),
+            'geo_metadata': 'Small polygon PLR',
+            'public_law_restriction_id': 1,
+            'point': 'SRID=2056;POINT(1 2)',
+        })
+    }
+    interlis_dbsession.add_all(geometries)
+    interlis_dbsession.flush()
+
+
+@pytest.fixture
+def oblique_limit_real_estate_record():
+    return RealEstateRecord(
+        'test_type', 'BL', 'Nusshof', 1234, land_registry_area=3.2,
+        limit=Polygon(((0, 0), (3, 0), (3, 0.3)))
+    )
+
+
+# @pytest.fixture
+# def interlis_real_estate():
+#     theme = ThemeRecord('code', dict(), 100)
+#     geometry_records = [
+#         GeometryRecord(law_status, datetime.date.today(), None, LineString(((1, 0.1), (2, 0.2))))
+#     ]
+#     return PlrRecord(
+#         theme,
+#         LegendEntryRecord(
+#             ImageRecord('1'.encode('utf-8')),
+#             {'en': 'Content'},
+#             'CodeA',
+#             None,
+#             theme,
+#             view_service_id=1
+#         ),
+#         law_status,
+#         date.today() + timedelta(days=0),
+#         date.today() + timedelta(days=2),
+#         OfficeRecord({'en': 'Office'}),
+#         ImageRecord('1'.encode('utf-8')),
+#         ViewServiceRecord({'de': 'http://my.wms.com'}, 1, 1.0, 'de', 2056, None, None),
+#         geometry_records,
+#         documents=[]
+#     )
+
+
+@pytest.fixture
+def processor_data(pyramid_oereb_test_config, main_schema):
+    with patch(
+            'pyramid_oereb.core.config.Config.municipalities',
+            [MunicipalityRecord(1234, 'test', True)]
+        ), patch(
+            'pyramid_oereb.core.config.Config.themes',
+            [ThemeRecord('ch.Nutzungsplanung', dict(), 100, document_records=[])]
+    ):
+        yield pyramid_oereb_test_config
+
+
+def test_related_geometries(processor_data, pyramid_oereb_test_config, interlis_land_use_plans,
+                            oblique_limit_real_estate_record):
+    plr_cadastre_authority = pyramid_oereb_test_config.get_plr_cadastre_authority()
+    plr = pyramid_oereb_test_config.get_theme_config_by_code('ch.Nutzungsplanung')
+    plr_source_class = DottedNameResolver().maybe_resolve(plr.get('source').get('class'))
+    plr_sources = []
+    plr_sources.append(plr_source_class(**plr))
+
+    from pyramid_oereb.core.views.webservice import Parameter
+    request_params = Parameter('json', egrid='TEST')
+    # municipality = pyramid_oereb_test_config.municipality_by_fosnr(oblique_limit_real_estate_record.fosnr)
+    municipality = MunicipalityRecord(1234, 'test', True)
+
+    from pyramid_oereb.core.readers.extract import ExtractReader
+    extract_reader = ExtractReader(
+        plr_sources,
+        plr_cadastre_authority
+    )
+    extract_raw = extract_reader.read(
+        request_params, oblique_limit_real_estate_record, municipality
+    )
+    # processor = Processor(
+    #     real_estate_reader=real_estate_reader,
+    #     plr_sources=plr_sources,
+    #     extract_reader=extract_reader,
+    # )
+    processor = Processor(
+        real_estate_reader=None,
+        plr_sources=plr_sources,
+        extract_reader=extract_reader,
+    )
+    assert len(extract_raw.real_estate.public_law_restrictions[0].geometries) == 4
+    extract = processor.plr_tolerance_check(extract_raw)
+    assert len(extract.real_estate.public_law_restrictions[0].geometries) == 1

--- a/tests/contrib.data_sources.standard/sources/conftest.py
+++ b/tests/contrib.data_sources.standard/sources/conftest.py
@@ -11,6 +11,12 @@ def app_config():
             "name": "test",
             "models": "pyramid_oereb.contrib.data_sources.standard.models.main",
             "db_connection": "postgresql://postgres:postgres@123.123.123.123:5432/pyramid_oereb_test"
+        },
+        'geometry_types': {
+            'point': {'types': []},
+            'line': {'types': []},
+            'polygon': {'types': []},
+            'collection': {'types': ['GeometryCollection']}
         }
     }
 

--- a/tests/core/records/test_plr.py
+++ b/tests/core/records/test_plr.py
@@ -207,7 +207,9 @@ def test_sum_points(geometry_record, test, method, geometry_types):
 @pytest.fixture
 def oblique_geometry_plr_record():
     theme = ThemeRecord('code', dict(), 100)
-    geometry_records = [GeometryRecord(law_status, datetime.date.today(), None, LineString(((1, 0.1), (2, 0.2))))]
+    geometry_records = [
+        GeometryRecord(law_status, datetime.date.today(), None, LineString(((1, 0.1), (2, 0.2))))
+    ]
     return PlrRecord(
         theme,
         LegendEntryRecord(
@@ -266,7 +268,9 @@ def processor_data(pyramid_oereb_test_config, main_schema):
         yield pyramid_oereb_test_config
 
 
-def test_linestring_calculation(geometry_types, oblique_geometry_plr_record, oblique_limit_real_estate_record):
+def test_linestring_calculation(geometry_types,
+                                oblique_geometry_plr_record,
+                                oblique_limit_real_estate_record):
     oblique_geometry_plr_record.tolerance = fi.epsilon
     oblique_geometry_plr_record.calculate(oblique_limit_real_estate_record, geometry_types)
     assert oblique_geometry_plr_record.length_share > 0
@@ -282,7 +286,7 @@ def oblique_land_use_plan(pyramid_oereb_test_config, dbsession, transact, land_u
 
     dbsession.add(models.PublicLawRestriction(id=5, law_status='inKraft',
                                               published_from=(date.today() - timedelta(days=7)).isoformat(),
-                                              published_until=(date.today() + timedelta(days=100)).isoformat(),
+                                              published_until=(date.today() + timedelta(days=7)).isoformat(),
                                               view_service_id=1,
                                               legend_entry_id=1, office_id=1))
     dbsession.add(models.Geometry(id=6, law_status='inKraft', public_law_restriction_id=5,
@@ -301,7 +305,9 @@ def test_linestring_process_no_tol(real_estate_data, main_schema, land_use_plans
     request_params = Parameter('json', egrid='TEST')
 
     municipality = Config.municipality_by_fosnr(oblique_limit_real_estate_record.fosnr)
-    extract_raw = processor._extract_reader_.read(request_params, oblique_limit_real_estate_record, municipality)
+    extract_raw = processor._extract_reader_.read(
+        request_params, oblique_limit_real_estate_record, municipality
+    )
     extract = processor.plr_tolerance_check(extract_raw)
     plrs = extract.real_estate.public_law_restrictions
     assert len(plrs) == 0
@@ -319,7 +325,9 @@ def test_linestring_process_with_tol(real_estate_data, main_schema, land_use_pla
     request_params = Parameter('json', egrid='TEST')
 
     municipality = Config.municipality_by_fosnr(oblique_limit_real_estate_record.fosnr)
-    extract_raw = processor._extract_reader_.read(request_params, oblique_limit_real_estate_record, municipality)
+    extract_raw = processor._extract_reader_.read(
+        request_params, oblique_limit_real_estate_record, municipality
+    )
     extract = processor.plr_tolerance_check(extract_raw)
     plrs = extract.real_estate.public_law_restrictions
     assert len(plrs) == 1

--- a/tests/core/records/test_plr.py
+++ b/tests/core/records/test_plr.py
@@ -1,18 +1,23 @@
 # -*- coding: utf-8 -*-
 import datetime
 from datetime import date, timedelta
+from sys import float_info as fi
 import pytest
+from unittest.mock import patch
 from shapely.geometry import Point, LineString, Polygon
 from shapely.wkt import loads
 
+from pyramid_oereb.core.processor import create_processor
 from pyramid_oereb.core.records.geometry import GeometryRecord
 from pyramid_oereb.core.records.image import ImageRecord
 from pyramid_oereb.core.records.law_status import LawStatusRecord
+from pyramid_oereb.core.records.municipality import MunicipalityRecord
 from pyramid_oereb.core.records.office import OfficeRecord
 from pyramid_oereb.core.records.plr import PlrRecord
 from pyramid_oereb.core.records.real_estate import RealEstateRecord
 from pyramid_oereb.core.records.theme import ThemeRecord
 from pyramid_oereb.core.records.view_service import ViewServiceRecord, LegendEntryRecord
+from pyramid_oereb.contrib.data_sources.standard.sources.plr import StandardThemeConfigParser
 
 
 law_status = LawStatusRecord(
@@ -197,3 +202,125 @@ def test_sum_points(geometry_record, test, method, geometry_types):
         documents=[]
     )
     assert getattr(plr_record, method)() == test
+
+
+@pytest.fixture
+def oblique_geometry_plr_record():
+    theme = ThemeRecord('code', dict(), 100)
+    geometry_records = [GeometryRecord(law_status, datetime.date.today(), None, LineString(((1, 0.1), (2, 0.2))))]
+    return PlrRecord(
+        theme,
+        LegendEntryRecord(
+            ImageRecord('1'.encode('utf-8')),
+            {'en': 'Content'},
+            'CodeA',
+            None,
+            theme,
+            view_service_id=1
+        ),
+        law_status,
+        date.today() + timedelta(days=0),
+        date.today() + timedelta(days=2),
+        OfficeRecord({'en': 'Office'}),
+        ImageRecord('1'.encode('utf-8')),
+        ViewServiceRecord({'de': 'http://my.wms.com'}, 1, 1.0, 'de', 2056, None, None),
+        geometry_records,
+        documents=[]
+    )
+
+
+@pytest.fixture
+def oblique_limit_real_estate_record():
+    return RealEstateRecord(
+        'test_type', 'BL', 'Nusshof', 1234, land_registry_area=3.2,
+        limit=Polygon(((0, 0), (3, 0), (3, 0.3)))
+    )
+
+
+def test_tolerance_outside(geometry_types, oblique_geometry_plr_record, oblique_limit_real_estate_record):
+    oblique_geometry_plr_record.geometries[0].reset_calculation()
+    assert not oblique_geometry_plr_record.geometries[0].calculate(
+        oblique_limit_real_estate_record,
+        oblique_geometry_plr_record.min_length, oblique_geometry_plr_record.min_area,
+        oblique_geometry_plr_record.length_unit, oblique_geometry_plr_record.area_unit,
+        geometry_types
+    )
+
+
+def test_tolerance_inside(geometry_types, oblique_geometry_plr_record, oblique_limit_real_estate_record):
+    oblique_geometry_plr_record.geometries[0].reset_calculation()
+    assert oblique_geometry_plr_record.geometries[0].calculate(
+        oblique_limit_real_estate_record,
+        oblique_geometry_plr_record.min_length, oblique_geometry_plr_record.min_area,
+        oblique_geometry_plr_record.length_unit, oblique_geometry_plr_record.area_unit,
+        geometry_types, tolerance=fi.epsilon
+    )
+
+
+@pytest.fixture
+def processor_data(pyramid_oereb_test_config, main_schema):
+    with patch(
+        'pyramid_oereb.core.config.Config.municipalities',
+        [MunicipalityRecord(1234, 'test', True)]
+    ):
+        yield pyramid_oereb_test_config
+
+
+def test_linestring_calculation(geometry_types, oblique_geometry_plr_record, oblique_limit_real_estate_record):
+    oblique_geometry_plr_record.tolerance = fi.epsilon
+    oblique_geometry_plr_record.calculate(oblique_limit_real_estate_record, geometry_types)
+    assert oblique_geometry_plr_record.length_share > 0
+
+
+@pytest.fixture
+def oblique_land_use_plan(pyramid_oereb_test_config, dbsession, transact, land_use_plans):
+    del transact
+
+    theme_config = pyramid_oereb_test_config.get_theme_config_by_code('ch.Nutzungsplanung')
+    config_parser = StandardThemeConfigParser(**theme_config)
+    models = config_parser.get_models()
+
+    dbsession.add(models.PublicLawRestriction(id=5, law_status='inKraft',
+                                              published_from=(date.today() - timedelta(days=7)).isoformat(),
+                                              published_until=(date.today() + timedelta(days=100)).isoformat(),
+                                              view_service_id=1,
+                                              legend_entry_id=1, office_id=1))
+    dbsession.add(models.Geometry(id=6, law_status='inKraft', public_law_restriction_id=5,
+                                  published_from=(date.today() - timedelta(days=7)).isoformat(),
+                                  published_until=(date.today() + timedelta(days=100)).isoformat(),
+                                  geom='SRID=2056;LINESTRING (1 0.1, 2 0.2)'))
+    dbsession.flush()
+
+
+def test_linestring_process_no_tol(real_estate_data, main_schema, land_use_plans, processor_data,
+                                   oblique_land_use_plan, oblique_limit_real_estate_record):
+    from pyramid_oereb.core.views.webservice import Parameter
+    from pyramid_oereb.core.config import Config
+
+    processor = create_processor()
+    request_params = Parameter('json', egrid='TEST')
+
+    municipality = Config.municipality_by_fosnr(oblique_limit_real_estate_record.fosnr)
+    extract_raw = processor._extract_reader_.read(request_params, oblique_limit_real_estate_record, municipality)
+    extract = processor.plr_tolerance_check(extract_raw)
+    plrs = extract.real_estate.public_law_restrictions
+    assert len(plrs) == 0
+
+
+def test_linestring_process_with_tol(real_estate_data, main_schema, land_use_plans, processor_data,
+                                     oblique_land_use_plan, oblique_limit_real_estate_record):
+    from pyramid_oereb.core.views.webservice import Parameter
+    from pyramid_oereb.core.config import Config
+
+    for i, plr in enumerate(Config._config["plrs"]):
+        Config._config["plrs"][i]["tolerance"] = fi.epsilon
+
+    processor = create_processor()
+    request_params = Parameter('json', egrid='TEST')
+
+    municipality = Config.municipality_by_fosnr(oblique_limit_real_estate_record.fosnr)
+    extract_raw = processor._extract_reader_.read(request_params, oblique_limit_real_estate_record, municipality)
+    extract = processor.plr_tolerance_check(extract_raw)
+    plrs = extract.real_estate.public_law_restrictions
+    assert len(plrs) == 1
+    assert plrs[0].length_share == 1

--- a/tests/core/renderer/test_json.py
+++ b/tests/core/renderer/test_json.py
@@ -235,7 +235,7 @@ def test_format_real_estate(DummyRenderInfo, real_estate_test_data):
     default_param(),
     Parameter('json', False, True, False, 'BL0200002829', '1000', 'CH775979211712', 'de'),
 ])
-def test_format_plr(DummyRenderInfo, parameter):
+def test_format_plr(DummyRenderInfo, parameter, pyramid_oereb_test_config):
     renderer = Renderer(DummyRenderInfo())
     renderer._language = 'de'
     renderer._params = parameter

--- a/tests/resources/sample_data/themes.json
+++ b/tests/resources/sample_data/themes.json
@@ -9,7 +9,8 @@
             "rm": "Planisaziun d’utilisaziun (chantunal/communal)",
             "en": "Land use plans (cantonal/municipal)"
         },
-        "extract_index": 1
+        "extract_index": 1,
+        "document_records": []
     },
     {
         "code": "ch.BelasteteStandorte",


### PR DESCRIPTION
tolerance can be configured on plr base in yaml file as shown below:

if there is a tolerance, geometries are compared with buffer / distance
if there is no defined tolerance, the simple operations are used (Intersects / Intersection)
```
pyramid_oereb:
  plrs:
    - code: ch.Nutzungsplanung
      geometry_type: GEOMETRYCOLLECTION
      thresholds:
        length:
          limit: 1.0
          unit: 'm'
          precision: 2
        area:
          limit: 1.0
          unit: 'm²'
          precision: 2
        percentage:
          precision: 1
      tolerance: 0.00001
```

