### PR TITLE
Sort theme lists

### DIFF
--- a/pyramid_oereb/core/readers/extract.py
+++ b/pyramid_oereb/core/readers/extract.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from operator import attrgetter
 from pyramid.path import DottedNameResolver
 
 from shapely.geometry import box
@@ -101,6 +102,11 @@ class ExtractReader(object):
         else:
             for plr_source in self._plr_sources_:
                 themes_without_data.append(Config.get_theme_by_code_sub_code(plr_source.info.get('code')))
+
+        # sort theme lists
+        concerned_themes.sort(key=attrgetter('extract_index'))
+        not_concerned_themes.sort(key=attrgetter('extract_index'))
+        themes_without_data.sort(key=attrgetter('extract_index'))
 
         # sort plr according to theme, sub-theme and law-status
         start_time = timer()


### PR DESCRIPTION
The theme lists should be sorted in all cases, according to extract_index.
So far, we have been sorting them only in the special case when a theme gets shifted to the not concerned themes due to the tolerance check: https://github.com/openoereb/pyramid_oereb/blob/bfa5ddc491d611ec7f8a93e784d696e2621d9b94/pyramid_oereb/core/processor.py#L133-L134