### PR TITLE
Deprecation notice about urllib3[secure]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ image==1.5.33
 shapely==1.8.2
 SQLAlchemy==1.4.39
 pyaml-env==1.1.5
-urllib3[secure]==1.26.11
+urllib3==1.26.11
 waitress==2.1.2
 pyreproj==2.0.0
 mako-render==0.1.0


### PR DESCRIPTION
### Description
pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
https://github.com/urllib3/urllib3/issues/2680
removed urllib3[secure]
updated with urllib3