### PR TITLE
Xml2pdf proxy: less logs in error case

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/xml_2_pdf/xml_2_pdf.py
+++ b/pyramid_oereb/contrib/print_proxy/xml_2_pdf/xml_2_pdf.py
@@ -116,11 +116,13 @@ class Renderer(XmlRenderer):
                 proxies=Config.get('proxies')
             )
             if backend_answer.status_code != requests.codes.ok:
-                log.warning("request_pdf failed for url {}, data_extract was {}".format(url, data_extract))
+                log.warning("request_pdf failed for url {}".format(url))
+                log.debug("data extract for failed request was {}".format(data_extract))
             return backend_answer
         except Exception as e:
             log.exception(e)
-            log.warning("request_pdf failed for url {}, data_extract was {}".format(url, data_extract))
+            log.warning("request_pdf failed for url {}".format(url))
+            log.debug("data extract for failed request was {}".format(data_extract))
             raise e
 
     @staticmethod


### PR DESCRIPTION
Xml2pdf proxy: less logs in error case (depending on log level), because always outputting extract data makes log analysis difficult.