### PR TITLE
Fix xml2pdf usage when using embedded images

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/xml_2_pdf/xml_2_pdf.py
+++ b/pyramid_oereb/contrib/print_proxy/xml_2_pdf/xml_2_pdf.py
@@ -50,9 +50,6 @@ class Renderer(XmlRenderer):
 
         log.debug("Parameter webservice is {}".format(value[1]))
 
-        if value[1].images:
-            raise HTTPBadRequest('With image is not allowed in the print')
-
         self._request = self.get_request(system)
         # If language present in request, use that. Otherwise, keep language from base class
         if 'lang' in self._request.GET:

--- a/pyramid_oereb/contrib/print_proxy/xml_2_pdf/xml_2_pdf.py
+++ b/pyramid_oereb/contrib/print_proxy/xml_2_pdf/xml_2_pdf.py
@@ -3,7 +3,6 @@ import requests
 import logging
 
 from pyramid.exceptions import ConfigurationError
-from pyramid.httpexceptions import HTTPBadRequest
 from pyramid_oereb import Config
 from pyramid_oereb.core.renderer.extract.xml_ import Renderer as XmlRenderer
 


### PR DESCRIPTION
xml2pdf is already configured via "use_wms" regarding the issue of using embedded images or not, therefore this should never be disallowed.

This is a follow up to the pull request https://github.com/openoereb/pyramid_oereb/pull/1612 , which was thus incomplete.

Note: this code change was tested on Glarus server.