### PR TITLE
Allow to always add real estate geometry in XML extract

### DIFF
--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -175,6 +175,9 @@ pyramid_oereb:
   # Configuration option for full extract: apply SLD on land register WMS (defaults to true)
   full_extract_use_sld: true
 
+  # Configuration option for always outputting real estate geometry in XML extract
+  # xml_extract_use_real_estate_geometry: true
+
   # Configuration for OEREBlex
   oereblex:
     # OEREBlex host

--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -46,7 +46,7 @@ pyramid_oereb:
     # Configuration for XML2PDF print service
     renderer: pyramid_oereb.contrib.print_proxy.xml_2_pdf.xml_2_pdf.Renderer
     # Define whether all geometry data must be included when sending the data to the print service
-    with_geometry: True
+    with_geometry: False
     # Base URL with application of the print server
     base_url: https://oereb-dev.gis-daten.ch/oereb/report/create
     token: 24ba4328-a306-4832-905d-b979388d4cab

--- a/pyramid_oereb/core/config.py
+++ b/pyramid_oereb/core/config.py
@@ -1236,6 +1236,12 @@ class Config(object):
         return Config._config.get('real_estate_type')
 
     @staticmethod
+    def get_xml_extract_use_real_estate_geometry():
+        assert Config._config is not None
+
+        return Config._config.get('xml_extract_use_real_estate_geometry')
+
+    @staticmethod
     def get_plan_for_land_register_main_page_config():
         """
         Returns dictionary of plan for land register for the main page from the config file.

--- a/pyramid_oereb/core/renderer/extract/templates/xml/real_estate.xml
+++ b/pyramid_oereb/core/renderer/extract/templates/xml/real_estate.xml
@@ -4,6 +4,7 @@
     from pyramid_oereb import Config
 
     real_estate_type = Config.get_real_estate_type_by_data_code(real_estate.type)
+    real_estate_with_geometry = Config.get_xml_extract_use_real_estate_geometry()
 %>
 <data:RealEstate>
 %if real_estate.number:
@@ -31,7 +32,7 @@
     <data:MetadataOfGeographicalBaseData>${real_estate.metadata_of_geographical_base_data | x}</data:MetadataOfGeographicalBaseData>
 %endif
     <data:LandRegistryArea>${int(real_estate.land_registry_area)}</data:LandRegistryArea>
-%if extract.real_estate.limit and params.with_geometry:
+%if extract.real_estate.limit and (params.with_geometry or real_estate_with_geometry):
     <data:Limit>
         <geometry:surface>
             %for polygon in real_estate.limit.geoms:


### PR DESCRIPTION
Add configuration parameter to always add real estate geometry in XML extract, 
independently of general parameter GEOMETRY.

Use case: producing the extract for the xml2pdf service, which requires the real estate geometry (limit), but not all geometries. Having this configuration possibility reduces the size of the payload sent to the print service by up to 50%.

Tested on Glarus server.