### PR TITLE
Pytest: capture expected warnings

### DIFF
--- a/tests/contrib.data_sources.standard/test_hook_methods.py
+++ b/tests/contrib.data_sources.standard/test_hook_methods.py
@@ -194,6 +194,7 @@ def test_get_symbol_binary_content(theme_config, one_result_binary_session, png_
         assert body == b64.decode(binascii.b2a_base64(png_binary).decode('ascii'))
 
 
+@pytest.mark.filterwarnings("ignore:srid not enforced")
 def test_get_symbol_no_symbol_content(theme_config, one_result_no_symbol_session):
     with patch(
             'pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
@@ -202,6 +203,7 @@ def test_get_symbol_no_symbol_content(theme_config, one_result_no_symbol_session
             get_symbol({'identifier': "1"}, theme_config)
 
 
+@pytest.mark.filterwarnings("ignore:srid not enforced")
 def test_get_symbol_wrong_param(theme_config, one_result_no_symbol_session):
     with patch(
             'pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
@@ -210,6 +212,7 @@ def test_get_symbol_wrong_param(theme_config, one_result_no_symbol_session):
             get_symbol({'identif': "1"}, theme_config)
 
 
+@pytest.mark.filterwarnings("ignore:srid not enforced")
 def test_get_symbol_no_legend_entry(theme_config, no_result_session):
     with patch(
             'pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
@@ -218,6 +221,7 @@ def test_get_symbol_no_legend_entry(theme_config, no_result_session):
             get_symbol({'identifier': "2"}, theme_config)
 
 
+@pytest.mark.filterwarnings("ignore:srid not enforced")
 def test_get_symbol_wrong_content(theme_config, one_result_wrong_content_session):
     with patch('pyramid_oereb.core.adapter.DatabaseAdapter.get_session',
                return_value=one_result_wrong_content_session()):

--- a/tests/contrib.stats/test_logger.py
+++ b/tests/contrib.stats/test_logger.py
@@ -21,7 +21,8 @@ def webtestapp(test_db_engine):
     return test_app
 
 
-def test_log_logo(webtestapp):
+@pytest.mark.filterwarnings("ignore:srid not enforced")
+def test_log_wrong_data(webtestapp):
     """
     Test webapp entrypoint with insufficiently initialized test data
     """

--- a/tests/core/records/test_disclaimer.py
+++ b/tests/core/records/test_disclaimer.py
@@ -28,7 +28,8 @@ def record_correct():
 
 @pytest.fixture
 def record_incorrect():
-    yield DisclaimerRecord('title', 'content')
+    with pytest.warns(UserWarning):
+        yield DisclaimerRecord('title', 'content')
 
 
 def test_init(record_correct):
@@ -36,7 +37,6 @@ def test_init(record_correct):
     assert isinstance(record_correct.content, dict)
 
 
-@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types(record_incorrect):
     assert isinstance(record_incorrect.title, str)
     assert isinstance(record_incorrect.content, str)

--- a/tests/core/records/test_disclaimer.py
+++ b/tests/core/records/test_disclaimer.py
@@ -36,6 +36,7 @@ def test_init(record_correct):
     assert isinstance(record_correct.content, dict)
 
 
+@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types(record_incorrect):
     assert isinstance(record_incorrect.title, str)
     assert isinstance(record_incorrect.content, str)

--- a/tests/core/records/test_document.py
+++ b/tests/core/records/test_document.py
@@ -125,6 +125,7 @@ def test_legal_provision(law_test_data, law_status_record, office_record, docume
     assert legal_provision.document_type.code == 'GesetzlicheGrundlage'
 
 
+@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types(document_type_record):
     record = DocumentRecord(
         document_type_record,

--- a/tests/core/records/test_document.py
+++ b/tests/core/records/test_document.py
@@ -125,23 +125,23 @@ def test_legal_provision(law_test_data, law_status_record, office_record, docume
     assert legal_provision.document_type.code == 'GesetzlicheGrundlage'
 
 
-@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types(document_type_record):
-    record = DocumentRecord(
-        document_type_record,
-        'wrong_type',
-        'law_status',
-        'wrong_title',
-        'office_record',
-        'date_from',
-        'date_until',
-        'text_at_web',
-        'abbreviation',
-        'official_number',
-        'only_in_municipality',
-        'article_numbers',
-        1
-    )
+    with pytest.warns(UserWarning):
+        record = DocumentRecord(
+            document_type_record,
+            'wrong_type',
+            'law_status',
+            'wrong_title',
+            'office_record',
+            'date_from',
+            'date_until',
+            'text_at_web',
+            'abbreviation',
+            'official_number',
+            'only_in_municipality',
+            'article_numbers',
+            1
+        )
     assert isinstance(record.title, str)
     assert isinstance(record.index, str)
     assert isinstance(record.responsible_office, str)

--- a/tests/core/records/test_document_type.py
+++ b/tests/core/records/test_document_type.py
@@ -12,8 +12,8 @@ def test_document_type_init():
     }
 
 
-@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types():
-    record = DocumentTypeRecord({'de': 'titel'}, 'content')
+    with pytest.warns(UserWarning):
+        record = DocumentTypeRecord({'de': 'titel'}, 'content')
     assert isinstance(record.code, dict)
     assert isinstance(record.title, str)

--- a/tests/core/records/test_document_type.py
+++ b/tests/core/records/test_document_type.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from pyramid_oereb.core.records.document_types import DocumentTypeRecord
 
 
@@ -10,6 +12,7 @@ def test_document_type_init():
     }
 
 
+@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types():
     record = DocumentTypeRecord({'de': 'titel'}, 'content')
     assert isinstance(record.code, dict)

--- a/tests/core/records/test_extract.py
+++ b/tests/core/records/test_extract.py
@@ -74,6 +74,7 @@ def test_init(pyramid_oereb_test_config):
     assert isinstance(record.update_date_os, datetime.datetime)
 
 
+@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types():
     record = ExtractRecord(
         'real_estate',

--- a/tests/core/records/test_extract.py
+++ b/tests/core/records/test_extract.py
@@ -74,23 +74,23 @@ def test_init(pyramid_oereb_test_config):
     assert isinstance(record.update_date_os, datetime.datetime)
 
 
-@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types():
-    record = ExtractRecord(
-        'real_estate',
-        'logo_plr_cadastre',
-        'federal_logo',
-        'cantonal_logo',
-        'municipality_logo',
-        'plr_cadastre_authority',
-        'update_date_os',
-        'disclaimers',
-        'glossaries',
-        'concerned_theme',
-        'not_concerned_theme',
-        'theme_without_data',
-        'general_information'
-    )
+    with pytest.warns(UserWarning):
+        record = ExtractRecord(
+            'real_estate',
+            'logo_plr_cadastre',
+            'federal_logo',
+            'cantonal_logo',
+            'municipality_logo',
+            'plr_cadastre_authority',
+            'update_date_os',
+            'disclaimers',
+            'glossaries',
+            'concerned_theme',
+            'not_concerned_theme',
+            'theme_without_data',
+            'general_information'
+        )
     assert isinstance(record.real_estate, str)
     assert isinstance(record.logo_plr_cadastre, str)
     assert isinstance(record.federal_logo, str)

--- a/tests/core/records/test_general_information.py
+++ b/tests/core/records/test_general_information.py
@@ -25,6 +25,7 @@ def test_init():
     assert isinstance(record.content, dict)
 
 
+@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types():
     record = GeneralInformationRecord('titel', 'content')
     assert isinstance(record.title, str)

--- a/tests/core/records/test_general_information.py
+++ b/tests/core/records/test_general_information.py
@@ -25,9 +25,9 @@ def test_init():
     assert isinstance(record.content, dict)
 
 
-@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_types():
-    record = GeneralInformationRecord('titel', 'content')
+    with pytest.warns(UserWarning):
+        record = GeneralInformationRecord('titel', 'content')
     assert isinstance(record.title, str)
     assert isinstance(record.content, str)
 

--- a/tests/core/records/test_plr.py
+++ b/tests/core/records/test_plr.py
@@ -97,6 +97,7 @@ def test_published(published_from, published_until, published):
     assert plr_record.published == published
 
 
+@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_legend_entry_text_type():
     theme = ThemeRecord('code', dict(), 100)
     plr_record = PlrRecord(

--- a/tests/core/records/test_plr.py
+++ b/tests/core/records/test_plr.py
@@ -97,19 +97,20 @@ def test_published(published_from, published_until, published):
     assert plr_record.published == published
 
 
-@pytest.mark.filterwarnings("ignore:Type of")
 def test_wrong_legend_entry_text_type():
     theme = ThemeRecord('code', dict(), 100)
-    plr_record = PlrRecord(
-        theme,
-        LegendEntryRecord(
+    with pytest.warns(UserWarning):
+        legendentry = LegendEntryRecord(
             ImageRecord('1'.encode('utf-8')),
             'legendentry',
             'CodeA',
             None,
             theme,
             view_service_id=1
-        ),
+        )
+    plr_record = PlrRecord(
+        theme,
+        legendentry,
         law_status,
         date.today() + timedelta(days=0),
         date.today() + timedelta(days=2),


### PR DESCRIPTION
Pytest: explicitly check that warnings are actually emitted where expected in type check tests
(but don't have them outputted as test warnings, to avoid confusing warnings in test executions)

Partially addresses #1646 