### PR TITLE
interlis-tests

### DIFF
--- a/tests/contrib.data_sources.interlis_2_3/sources/test_plr.py
+++ b/tests/contrib.data_sources.interlis_2_3/sources/test_plr.py
@@ -131,7 +131,8 @@ def interlis_land_use_plans(pyramid_oereb_test_config,
     interlis_dbsession.add_all(legend_entries)
     offices = {
         models.Office(**{
-            't_id': 1
+            't_id': 1,
+            'name_de': 'Amt'
         })
     }
     interlis_dbsession.add_all(offices)


### PR DESCRIPTION
closes https://github.com/openoereb/pyramid_oereb/issues/1651

The "name" of the office is mandatory in the oereb interlis model (LocalisationCH_V1.MultilingualText). ili2pg transforms this information to additional table columns ("name_de", "name_fr", ...). In https://github.com/openoereb/pyramid_oereb/blob/780e2f185ccb443a310af4197c987a34c12db51b/pyramid_oereb/contrib/data_sources/interlis_2_3/interlis_2_3_utils.py#L3 this information from the database is transformed to a dictionary. Office must be named in one language at least (otherwise the interlis file is not valid).
I added "name_de" in the office class. 