### PR TITLE
Test coverage: add a linestring theme

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -690,8 +690,8 @@ def forest_perimeters(pyramid_oereb_test_config, dbsession, transact, wms_url_co
     dbsession.add_all(legend_entries.values())
 
     plrs = {
-        'plr1': models.PublicLawRestriction(**{
-            'id': 1,
+        'plr3001': models.PublicLawRestriction(**{
+            'id': 3001,
             'law_status': 'inKraft',
             'published_from': date.today().isoformat(),
             'published_until': (date.today() + timedelta(days=100)).isoformat(),
@@ -704,12 +704,12 @@ def forest_perimeters(pyramid_oereb_test_config, dbsession, transact, wms_url_co
 
     geometries = {
         models.Geometry(**{
-            'id': 1,
+            'id': 3001,
             'law_status': 'inKraft',
             'published_from': date.today().isoformat(),
             'published_until': (date.today() + timedelta(days=100)).isoformat(),
             'geo_metadata': 'Simple linestring',
-            'public_law_restriction_id': 1,
+            'public_law_restriction_id': 3001,
             'geom': 'SRID=2056;LINESTRING(1 0.1, 2 0.2)',
         }),
         }

--- a/tests/contrib.data_sources.standard/sources/test_plr.py
+++ b/tests/contrib.data_sources.standard/sources/test_plr.py
@@ -136,7 +136,11 @@ def config_themes(app_config):
             {"de": "Nutzungsplanung (kantonal/kommunal)"},
             20,
             "ch.Subcode"
-        )
+        ), ThemeRecord(
+            "ch.StatischeWaldgrenzen",
+            {"de": "Test Thema Linestring"},
+            300
+        ),
     ]
     with patch(
             'pyramid_oereb.core.config.Config.themes', themes

--- a/tests/contrib.print_proxy.mapfish_print/resources/mfp_print_request.json
+++ b/tests/contrib.print_proxy.mapfish_print/resources/mfp_print_request.json
@@ -20,6 +20,10 @@
       {
         "Code": "ch.BelasteteStandorte",
         "Text": "Kataster der belasteten Standorte"
+      },
+      {
+	"Code": "ch.StatischeWaldgrenzen",
+	"Text": "Statische Waldgrenzen"
       }
     ],
     "PLRCadastreAuthority_City": "Wabern",

--- a/tests/core/readers/test_extract.py
+++ b/tests/core/readers/test_extract.py
@@ -58,11 +58,12 @@ def test_init(plr_sources, plr_cadastre_authority):
 
 
 @pytest.mark.run(order=2)
-def test_read(main_schema, land_use_plans, contaminated_sites, plr_sources, plr_cadastre_authority,
+def test_read(main_schema, land_use_plans, contaminated_sites, forest_perimeters,
+              plr_sources, plr_cadastre_authority,
               real_estate, municipality):
     from pyramid_oereb.core.readers.extract import ExtractReader
 
-    del main_schema, land_use_plans, contaminated_sites
+    del main_schema, land_use_plans, contaminated_sites, forest_perimeters
 
     reader = ExtractReader(plr_sources, plr_cadastre_authority)
     extract = reader.read(MockParameter(), real_estate, municipality)

--- a/tests/core/records/test_plr.py
+++ b/tests/core/records/test_plr.py
@@ -276,11 +276,11 @@ def test_linestring_calculation(geometry_types,
     assert oblique_geometry_plr_record.length_share > 0
 
 
-@pytest.fixture(params=['SRID=2056;LINESTRING (1 0.1, 2 0.2)'])
-def oblique_land_use_plan(request, pyramid_oereb_test_config, dbsession, transact, land_use_plans):
+@pytest.fixture(params=['SRID=2056;LINESTRING(1 0.1, 2 0.2)'])
+def oblique_forest_perimeter(request, pyramid_oereb_test_config, dbsession, transact, forest_perimeters):
     del transact
 
-    theme_config = pyramid_oereb_test_config.get_theme_config_by_code('ch.Nutzungsplanung')
+    theme_config = pyramid_oereb_test_config.get_theme_config_by_code('ch.StatischeWaldgrenzen')
     config_parser = StandardThemeConfigParser(**theme_config)
     models = config_parser.get_models()
 
@@ -296,8 +296,8 @@ def oblique_land_use_plan(request, pyramid_oereb_test_config, dbsession, transac
     dbsession.flush()
 
 
-def test_linestring_process_no_tol(real_estate_data, main_schema, land_use_plans, processor_data,
-                                   oblique_land_use_plan, oblique_limit_real_estate_record):
+def test_linestring_process_no_tol(real_estate_data, main_schema, forest_perimeters, processor_data,
+                                   oblique_forest_perimeter, oblique_limit_real_estate_record):
     from pyramid_oereb.core.views.webservice import Parameter
     from pyramid_oereb.core.config import Config
 
@@ -313,8 +313,8 @@ def test_linestring_process_no_tol(real_estate_data, main_schema, land_use_plans
     assert len(plrs) == 0
 
 
-def test_linestring_process_with_tol(real_estate_data, main_schema, land_use_plans, processor_data,
-                                     oblique_land_use_plan, oblique_limit_real_estate_record):
+def test_linestring_process_with_tol(real_estate_data, main_schema, forest_perimeters, processor_data,
+                                     oblique_forest_perimeter, oblique_limit_real_estate_record):
     from pyramid_oereb.core.views.webservice import Parameter
     from pyramid_oereb.core.config import Config
 
@@ -342,14 +342,13 @@ def oblique_limit_collection_real_estate_record():
     )
 
 
-def test_linestring_collection_process(real_estate_data, main_schema, land_use_plans, processor_data,
-                                       oblique_land_use_plan, oblique_limit_collection_real_estate_record):
+def test_linestring_collection_process(real_estate_data, main_schema, forest_perimeters, processor_data,
+                                       oblique_forest_perimeter, oblique_limit_collection_real_estate_record):
     from pyramid_oereb.core.views.webservice import Parameter
     from pyramid_oereb.core.config import Config
 
     for i, plr in enumerate(Config._config["plrs"]):
         Config._config["plrs"][i]["tolerances"] = {'ALL': fi.epsilon}
-        Config._config["plrs"][i]["geometry_type"] = "GEOMETRYCOLLECTION"
 
     processor = create_processor()
     request_params = Parameter('json', egrid='TEST')

--- a/tests/core/records/test_plr.py
+++ b/tests/core/records/test_plr.py
@@ -330,7 +330,7 @@ def test_linestring_process_with_tol(real_estate_data, main_schema, forest_perim
     )
     extract = processor.plr_tolerance_check(extract_raw)
     plrs = extract.real_estate.public_law_restrictions
-    assert len(plrs) == 1
+    assert len(plrs) == 2
     assert plrs[0].length_share == 1
 
 
@@ -359,5 +359,5 @@ def test_linestring_collection_process(real_estate_data, main_schema, forest_per
     )
     extract = processor.plr_tolerance_check(extract_raw)
     plrs = extract.real_estate.public_law_restrictions
-    assert len(plrs) == 1
+    assert len(plrs) == 2
     assert plrs[0].length_share == 1

--- a/tests/core/webservice/test_getextractbyid.py
+++ b/tests/core/webservice/test_getextractbyid.py
@@ -191,12 +191,12 @@ def test_return_json(pyramid_oereb_test_config, pyramid_test_config, schema_json
     if topics == 'ALL' and egrid == 'TEST':
         assert len(real_estate.get('RestrictionOnLandownership')) == 2
         assert len(extract.get('ConcernedTheme')) == 2
-        assert len(extract.get('NotConcernedTheme')) == 0
+        assert len(extract.get('NotConcernedTheme')) == 1
         assert len(extract.get('ThemeWithoutData')) == 0
         restrictions = real_estate.get('RestrictionOnLandownership')
         assert restrictions[0]['Theme']['Code'] == 'ch.Nutzungsplanung'
         assert restrictions[1]['Theme']['Code'] == 'ch.BelasteteStandorte'
-        # simplified dataset, containing only two restrictions insetead of previously 14
+        # simplified dataset, containing only two restrictions instead of previously 14
 
     if topics == 'ALL_FEDERAL':
         assert len(real_estate.get('RestrictionOnLandownership')) == 2

--- a/tests/resources/sample_data/themes.json
+++ b/tests/resources/sample_data/themes.json
@@ -24,5 +24,14 @@
         },
         "extract_index": 200,
         "document_records": []
+    },
+    {
+        "code": "ch.StatischeWaldgrenzen",
+        "sub_code": null,
+        "title": {
+            "de": "Thema mit Linestring"
+        },
+        "extract_index": 300,
+        "document_records": []
     }
 ]

--- a/tests/resources/test_config.yml
+++ b/tests/resources/test_config.yml
@@ -63,6 +63,7 @@ pyramid_oereb:
   srid: 2056
   plrs:
     - code: ch.Nutzungsplanung
+      geometry_type: GEOMETRYCOLLECTION
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -102,6 +103,7 @@ pyramid_oereb:
         transfer_code: Hinweis
         extract_code: Hint
     - code: ch.BelasteteStandorte
+      geometry_type: GEOMETRYCOLLECTION
       law_status_lookup:
         - data_code: inKraft
           transfer_code: inKraft
@@ -140,6 +142,43 @@ pyramid_oereb:
         percentage:
           precision: 1
       federal: true
+    - code: ch.StatischeWaldgrenzen
+      geometry_type: LINESTRING
+      law_status_lookup:
+        - data_code: inKraft
+          transfer_code: inKraft
+          extract_code: inForce
+      federal: false
+      source:
+        class: pyramid_oereb.contrib.data_sources.standard.sources.plr.DatabaseSource
+        params:
+          db_connection: *main_db_connection
+          model_factory: pyramid_oereb.contrib.data_sources.standard.models.theme.model_factory_string_pk
+          schema_name: forest_perimeters
+      hooks:
+        get_symbol: pyramid_oereb.contrib.data_sources.standard.hook_methods.get_symbol
+        get_symbol_ref: pyramid_oereb.core.hook_methods.get_symbol_ref
+      thresholds:
+        length:
+          limit: 1.0
+          unit: 'm'
+          precision: 2
+        area:
+          limit: 1.0
+          unit: 'm²'
+          precision: 2
+        percentage:
+          precision: 1
+      document_types_lookup:
+      - data_code: Rechtsvorschrift
+        transfer_code: Rechtsvorschrift
+        extract_code: LegalProvision
+      - data_code: GesetzlicheGrundlage
+        transfer_code: GesetzlicheGrundlage
+        extract_code: Law
+      - data_code: Hinweis
+        transfer_code: Hinweis
+        extract_code: Hint
 
   real_estate:
     plan_for_land_register:


### PR DESCRIPTION
Partially addresses #1646, regarding geoalchemy warnings.

In the test coverage,
* define geometry_type to avoid invalid usage of geoalchemy - but this by itself creates errors due to geometry type mismatch in linestring tests,
* this PR thus also introduces a linestring theme, which shall be used to run tests with linestring tables