### PR TITLE
Fix sqlalchemy deprecation warnings (in preparation for SQLAlchemy 2)

### DIFF
--- a/pyramid_oereb/contrib/data_sources/interlis_2_3/models/theme.py
+++ b/pyramid_oereb/contrib/data_sources/interlis_2_3/models/theme.py
@@ -1,8 +1,7 @@
 from sqlalchemy import Column, ForeignKey
 from sqlalchemy import LargeBinary, String, Integer, Date, Text
-from sqlalchemy.ext.declarative import declarative_base
 from geoalchemy2.types import Geometry as GeoAlchemyGeometry
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 
 
 class Models(object):

--- a/pyramid_oereb/contrib/data_sources/standard/models/main.py
+++ b/pyramid_oereb/contrib/data_sources/standard/models/main.py
@@ -28,9 +28,8 @@ from pyramid_oereb.contrib.data_sources.standard.models import get_office, get_d
 from sqlalchemy import Column, PrimaryKeyConstraint, ForeignKey, UniqueConstraint, DateTime
 from sqlalchemy import Unicode, String, text, Integer, Boolean, Float
 from geoalchemy2 import Geometry
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy_utils import JSONType
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 
 from pyramid_oereb.core.config import Config
 

--- a/pyramid_oereb/contrib/data_sources/standard/models/theme.py
+++ b/pyramid_oereb/contrib/data_sources/standard/models/theme.py
@@ -1,5 +1,5 @@
 from sqlalchemy import String, Integer
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from pyramid_oereb.contrib.data_sources.standard.models import (
     get_office,

--- a/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
+++ b/pyramid_oereb/contrib/stats/scripts/create_stats_tables.py
@@ -6,6 +6,7 @@ import ast
 from mako.template import Template
 import os
 import optparse
+from sqlalchemy import text
 
 SCRIPT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 
@@ -54,5 +55,5 @@ def _create_views(config_file,
     fake_handler = SQLAlchemyHandler(ast.literal_eval(config[config_section][config_sql_args])[0])
     fake_handler.create_db()
     create_view_sql = Template(filename='{}/templates/views.sql.mako'.format(SCRIPT_FOLDER))
-    fake_handler.session.execute(create_view_sql.render(schema_name=schema_name, tablename=tablename))
+    fake_handler.session.execute(text(create_view_sql.render(schema_name=schema_name, tablename=tablename)))
     fake_handler.session.commit()

--- a/pyramid_oereb/core/sources/__init__.py
+++ b/pyramid_oereb/core/sources/__init__.py
@@ -6,6 +6,7 @@ import time
 import logging
 from pyramid.config import ConfigurationError
 from pyramid.path import DottedNameResolver
+from sqlalchemy import text
 
 log = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class BaseDatabaseSource(Base):
     def health_check(self):
         session = self._adapter_.get_session(self._key_)
         try:
-            session.execute('SELECT 1')
+            session.execute(text('SELECT 1'))
             return True
         except Exception:
             return False

--- a/tests/contrib.data_sources.interlis_2_3/sources/test_plr.py
+++ b/tests/contrib.data_sources.interlis_2_3/sources/test_plr.py
@@ -6,7 +6,7 @@ from sys import float_info as fi
 
 from pyramid.path import DottedNameResolver
 
-from sqlalchemy import create_engine, orm
+from sqlalchemy import create_engine, orm, text
 from sqlalchemy.schema import CreateSchema
 from sqlalchemy.engine.url import URL
 
@@ -30,17 +30,17 @@ def interlis_db_engine(base_engine):
     # """
 
     test_interlis_db_name = "interlis_test"
-    base_connection = base_engine.connect()
-    # terminate existing connections to be able to DROP the DB
-    base_connection.execute('SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity '
-                            f'WHERE pg_stat_activity.datname = \'{test_interlis_db_name}\' '
-                            'AND pid <> pg_backend_pid();')
-    # sqlalchemy uses transactions by default, COMMIT end the current transaction and allows
-    # creation and destruction of DB
-    base_connection.execute('COMMIT')
-    base_connection.execute(f"DROP DATABASE if EXISTS {test_interlis_db_name}")
-    base_connection.execute('COMMIT')
-    base_connection.execute(f"CREATE DATABASE {test_interlis_db_name}")
+    with base_engine.begin() as base_connection:
+        # terminate existing connections to be able to DROP the DB
+        term_stmt = 'SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity ' \
+            f'WHERE pg_stat_activity.datname = \'{test_interlis_db_name}\' AND pid <> pg_backend_pid();'
+        base_connection.execute(text(term_stmt))
+        # sqlalchemy uses transactions by default, COMMIT end the current transaction and allows
+        # creation and destruction of DB
+        base_connection.execute(text('COMMIT'))
+        base_connection.execute(text(f"DROP DATABASE if EXISTS {test_interlis_db_name}"))
+        base_connection.execute(text('COMMIT'))
+        base_connection.execute(text(f"CREATE DATABASE {test_interlis_db_name}"))
 
     test_db_url = URL.create(
         base_engine.url.get_backend_name(),
@@ -51,7 +51,8 @@ def interlis_db_engine(base_engine):
         database=test_interlis_db_name
     )
     engine = create_engine(test_db_url)
-    engine.execute("CREATE EXTENSION POSTGIS")
+    with engine.begin() as connection:
+        connection.execute(text("CREATE EXTENSION POSTGIS"))
     return engine
 
 
@@ -92,7 +93,8 @@ def interlis_land_use_plans(pyramid_oereb_test_config,
     config_parser = StandardThemeConfigParser(**theme_config)
     models = config_parser.get_models()
 
-    interlis_db_engine.execute(CreateSchema('land_use_plans'))
+    with interlis_db_engine.begin() as connection:
+        connection.execute(CreateSchema('land_use_plans'))
     models.Geometry.metadata.create_all(interlis_db_engine)
 
     localised_uris = {

--- a/tests/contrib.data_sources.standard/test_hook_methods.py
+++ b/tests/contrib.data_sources.standard/test_hook_methods.py
@@ -3,7 +3,7 @@ import binascii
 import pytest
 from unittest.mock import patch
 from sqlalchemy import Integer
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from pyramid.httpexceptions import HTTPNotFound, HTTPServerError
 from pyramid_oereb.contrib.data_sources.standard.hook_methods import get_symbol
 from pyramid_oereb.contrib.data_sources.standard.models import get_view_service, get_legend_entry

--- a/tests/contrib.data_sources.standard/test_init.py
+++ b/tests/contrib.data_sources.standard/test_init.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy import String, DateTime, Column
 from pyramid_oereb.contrib.data_sources.standard import create_schema_sql, tables, create_tables_sql,\
     create_sql

--- a/tests/contrib.data_sources.standard/test_models_document.py
+++ b/tests/contrib.data_sources.standard/test_models_document.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy import String, Integer, Date
 from sqlalchemy import inspect
 from sqlalchemy_utils import JSONType

--- a/tests/contrib.data_sources.standard/test_models_office.py
+++ b/tests/contrib.data_sources.standard/test_models_office.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy import String, Integer, inspect
 from sqlalchemy_utils import JSONType
 from pyramid_oereb.contrib.data_sources.standard.models import get_office

--- a/tests/contrib.stats/test_logger.py
+++ b/tests/contrib.stats/test_logger.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from pyramid.paster import get_app, setup_logging
 from webtest import TestApp
 from pyramid_oereb.core.config import Config
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from psycopg2.errors import UndefinedTable
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
@@ -33,13 +33,14 @@ def test_log_app(webtestapp, logo_test_data, clear_stats_db_engine, stats_db_url
     with patch.object(Config, 'logos', logo_test_data):
         webtestapp.get("/oereb/image/logo/oereb/de.png")
 
-    # wait maximum 15s for async log handler to complete its oprations (db creation and log message)
+    # wait maximum 15s for async log handler to complete its operations (db creation and log message)
     eng = create_engine(stats_db_url)
     for i in range(30):
         try:
-            log_result = eng.execute(
-                "select logger, level, msg from oereb_logs.logs order by created_at desc"
-            ).first()
+            with eng.begin() as connection:
+                log_result = connection.execute(
+                    text("select logger, level, msg from oereb_logs.logs order by created_at desc")
+                ).first()
             if log_result is not None:
                 break
         except (OperationalError, ProgrammingError, UndefinedTable):

--- a/tests/core/test_standard_db_creation.py
+++ b/tests/core/test_standard_db_creation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 from io import StringIO
+from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 
@@ -14,7 +15,7 @@ def test_create_standard_db(config_path, dbsession, transact):
     # tables already exist in DB => error
     with pytest.raises(ProgrammingError):
         sql_file.seek(0)
-        dbsession.execute(sql_file.read())
+        dbsession.execute(text(sql_file.read()))
 
 
 @pytest.mark.run(order=-9)
@@ -26,7 +27,7 @@ def test_create_main_schema(config_path, dbsession, transact):
     # tables already exist in DB => error
     with pytest.raises(ProgrammingError):
         sql_file.seek(0)
-        dbsession.execute(sql_file.read())
+        dbsession.execute(text(sql_file.read()))
 
 
 @pytest.mark.run(order=-9)
@@ -42,14 +43,14 @@ def test_create_standard_db_if_not_exists(config_path, dbsession, transact):
     )
 
     sql_file.seek(0)
-    dbsession.execute(sql_file.read())
+    dbsession.execute(text(sql_file.read()))
 
 
 @pytest.mark.run(order=-9)
-def test_reate_main_schema_if_not_exists(config_path, dbsession, transact):
+def test_create_main_schema_if_not_exists(config_path, dbsession, transact):
     from pyramid_oereb.contrib.data_sources.create_tables import create_main_schema_from_configuration_
     sql_file = StringIO()
     create_main_schema_from_configuration_(config_path, sql_file=sql_file, if_not_exists=True)
 
     sql_file.seek(0)
-    dbsession.execute(sql_file.read())
+    dbsession.execute(text(sql_file.read()))


### PR DESCRIPTION
Fixes #1663

Address sqlalchemy deprecation warnings, in preparation for SQLAlchemy 2.

To see details of the warnings, add SQLALCHEMY_WARN_20=1 before the py.test calls in the Makefile.