### PR TITLE
Remove python 3.7 from officially supported python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/.github/workflows/daily_check.yaml
+++ b/.github/workflows/daily_check.yaml
@@ -42,7 +42,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - python3.7
           - python3.8
           - python3.9
           - python3.10

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,10 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Pyramid",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application"


### PR DESCRIPTION
Fixes #1627 