### PR TITLE
Dev lib updates

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
-flake8==5.0.4  # update to flake>=6.0.0 requires Python >= 3.8.1, higher than pyramid_oereb support
-pyflakes==2.5.0 # update to pyflakes>=3.0.0 depends on flake8 update to version 6
-pycodestyle==2.9.1 # update to pycodestyle>=2.10.0 depends on flake8 update
-Sphinx==4.3.2  #  Update to Sphinx>=4.4.0 conflicts with flake8 version due to changes in importlib-metadata
+flake8==6.0.0
+pyflakes==3.0.1
+pycodestyle==2.10.0
+Sphinx==4.5.0
 sphinx_rtd_theme==1.1.1
 psycopg2==2.9.5
 mccabe==0.7.0

--- a/tests/core/webservice/test_getcapabilities.py
+++ b/tests/core/webservice/test_getcapabilities.py
@@ -25,7 +25,7 @@ def test_getcapabilities(pyramid_oereb_test_config, schema_json_extract, municip
     assert isinstance(caps[u'topic'], list)
     assert len(caps[u'topic']) == 4
     assert caps[u'topic'][1][u'Code'] == u'ch.StatischeWaldgrenzen'
-    forest_perimeter_languages = list(map(lambda l: l[u'Language'], caps[u'topic'][1][u'Text']))
+    forest_perimeter_languages = list(map(lambda x: x[u'Language'], caps[u'topic'][1][u'Text']))
     assert u'de' in forest_perimeter_languages
     assert u'fr' in forest_perimeter_languages
     assert u'it' in forest_perimeter_languages


### PR DESCRIPTION
With the minimum requirement Python 3.8, several dev libraries can now be updated (and they must be updated manually in one PR, because of the version dependencies between them)