### PR TITLE
Eliminate url encoding for symbol_ref in xml extract (#1677)

### DIFF
--- a/pyramid_oereb/core/renderer/extract/templates/xml/legend_entry.xml
+++ b/pyramid_oereb/core/renderer/extract/templates/xml/legend_entry.xml
@@ -3,7 +3,7 @@
 %if params.images:
 <data:Symbol>${legend_entry.symbol.encode()}</data:Symbol>
 %else:
-<data:SymbolRef>${get_symbol_ref(request, legend_entry)|u}</data:SymbolRef>
+<data:SymbolRef>${get_symbol_ref(request, legend_entry)| x}</data:SymbolRef>
 %endif
 <data:LegendText>
     <%include file="multilingual_text.xml" args="text=legend_entry.legend_text, not_null=True"/>

--- a/pyramid_oereb/core/renderer/extract/templates/xml/public_law_restriction.xml
+++ b/pyramid_oereb/core/renderer/extract/templates/xml/public_law_restriction.xml
@@ -37,7 +37,7 @@
     %if params.images:
     <data:Symbol>${public_law_restriction.symbol.encode()}</data:Symbol>
     %else:
-    <data:SymbolRef>${get_symbol_ref(request, public_law_restriction.legend_entry)|u}</data:SymbolRef>
+    <data:SymbolRef>${get_symbol_ref(request, public_law_restriction.legend_entry)| x}</data:SymbolRef>
     %endif
     %for geometry in public_law_restriction.geometries:
     <%include file="geometry.xml" args="geometry=geometry"/>


### PR DESCRIPTION
Fixes #1677 