### PR TITLE
update-version-geolink-formatter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ waitress==2.1.2
 pyreproj==2.0.0
 mako-render==0.1.0
 requests==2.28.2
-geolink-formatter==2.0.2
+geolink-formatter==2.0.3
 pyconizer==0.1.4
 c2cwsgiutils[standard]==5.1.6


### PR DESCRIPTION
Update of geolink_formatter to version 2.0.3. This version does not use the package "defusedxml". PR should remove warning described in https://github.com/openoereb/pyramid_oereb/issues/1646.