### PR TITLE
Test suite: silence warning which is explicitly checked

### DIFF
--- a/tests/core/records/test_plr.py
+++ b/tests/core/records/test_plr.py
@@ -97,12 +97,13 @@ def test_published(published_from, published_until, published):
     assert plr_record.published == published
 
 
+@pytest.mark.filterwarnings("ignore: Type of")
 def test_wrong_legend_entry_text_type():
     theme = ThemeRecord('code', dict(), 100)
     with pytest.warns(UserWarning):
         legendentry = LegendEntryRecord(
             ImageRecord('1'.encode('utf-8')),
-            'legendentry',
+            'legendentry_intentional_wrong_structure',
             'CodeA',
             None,
             theme,


### PR DESCRIPTION
Partially addresses #1646 :

For this test case, #1648 correctly introduced an explicit check that an expected UserWarning actually occurs.
But in addition, to avoid a warning showing in the test suite execution output, a "filterwarnings" must be added.