### PR TITLE
Add print configuration parameter for municipality name

### DIFF
--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -113,6 +113,8 @@ pyramid_oereb:
     #   - ogcserver
     # Flag to print or not the canton logo
     print_canton_logo: true
+    # Flag to print or not the municipality name
+    print_municipality_name: true
 % endif
 
   # The "app_schema" property contains only one sub property "name". This is directly related to the database

--- a/printable_extract.json
+++ b/printable_extract.json
@@ -1104,5 +1104,6 @@
       ]
     }
   },
-  "PrintCantonLogo": true
+  "PrintCantonLogo": true,
+  "PrintMunicipalityName": true
 }

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
@@ -569,6 +569,7 @@ class Renderer(JsonRenderer):
                     legend['NrOfPoints'] = '{0}'.format(legend['NrOfPoints'])
 
         extract_dict['PrintCantonLogo'] = Config.get('print', {}).get('print_canton_logo', True)
+        extract_dict['PrintMunicipalityName'] = Config.get('print', {}).get('print_municipality_name', True)
 
         log.debug("After transformation, extract_dict is {}".format(json.dumps(extract_dict, indent=4)))
         return extract_dict
@@ -755,7 +756,6 @@ class Renderer(JsonRenderer):
         Provides the sort key for the supplied hint / law / legal provision
         element as a tuple consisting of:
          * index
-
         Notes
         - index is defined by Interlis model OeREBKRM_V2_0 as range -1000..1000
         - "Index = None" if geolink_formatter processes entry from OEREBLEX that has no index

--- a/tests/contrib.print_proxy.mapfish_print/resources/expected_getspec_extract.json
+++ b/tests/contrib.print_proxy.mapfish_print/resources/expected_getspec_extract.json
@@ -1104,5 +1104,6 @@
       ]
     }
   },
-  "PrintCantonLogo": true
+  "PrintCantonLogo": true,
+  "PrintMunicipalityName": true
 }

--- a/tests/contrib.print_proxy.mapfish_print/resources/mfp_print_request.json
+++ b/tests/contrib.print_proxy.mapfish_print/resources/mfp_print_request.json
@@ -29,6 +29,7 @@
     "PLRCadastreAuthority_PostalCode": "3084",
     "PLRCadastreAuthority_Street": "Seftigenstrasse",
     "PrintCantonLogo": true,
+    "PrintMunicipalityName": true,
     "QRCodeRef": "http://example.com/image/qrcode?extract_url=http%3A%2F%2Fexample.com",
     "RealEstate_Canton": "BL",
     "RealEstate_EGRID": "TEST",

--- a/tests/resources/test_config.yml
+++ b/tests/resources/test_config.yml
@@ -289,8 +289,8 @@ pyramid_oereb:
     compute_toc_pages: true
     wms_url_params:
       TRANSPARENT: 'true'
-    # Flag to print or not the canton logo
     print_canton_logo: true
+    print_municipality_name: true
 
   geometry_types:
     point:


### PR DESCRIPTION
Related to https://github.com/openoereb/pyramid_oereb_mfp/issues/129:
as discussed in https://github.com/openoereb/pyramid_oereb_mfp/pull/130, instead of removing the municipality name in the PDF output, a configuration option is introduced.