### PR TITLE
Fix example for wms_url_keep_params

### DIFF
--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -108,9 +108,10 @@ pyramid_oereb:
     # If you want the print to keep some custom URL parameters directly from the reference_wms you have defined,
     # then use the configuration option wms_url_keep_params.
     # In wms_url_keep_params, you can list which URL parameter values should be read from the reference_wms
-    # and used by the print.
+    # and used by the print. Because URL parameters are converted to upper-case (see #1463), you must use
+    # uppercase for the parameter names.
     # wms_url_keep_params:
-    #   - ogcserver
+    #   - OGCSERVER
     # Flag to print or not the canton logo
     print_canton_logo: true
 % endif


### PR DESCRIPTION
Follow-up for change introduced in #1463 

The code could be improved by being more tolerant in the name matching lower/uppercase,
but as a quick help, I propose to change the comment and example in the configuration file.