### PR TITLE
fix error appearing in dev environment

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print/mapfish_print.py
@@ -115,7 +115,10 @@ class Renderer(JsonRenderer):
                     pdf_reader = PdfReader(pdf)
                     x = []
                     for i in range(len(pdf_reader.outline)):
-                        x.append(pdf_reader.outline[i]['/Page']['/StructParents'])
+                        if isinstance(pdf_reader.outline[i], list):
+                            x.append(pdf_reader.outline[i][0]['/Page']['/StructParents'])
+                        else:
+                            x.append(pdf_reader.outline[i]['/Page']['/StructParents'])
                     try:
                         true_nb_of_toc = min(x)-1
                     except ValueError:


### PR DESCRIPTION
This fixes #1813 
when the table of contented is created an error appears if the following is configured:
```
compute_toc_pages: true
```

Once this is fixed we should set the MFP version back to 3.30 -> revert https://github.com/openoereb/pyramid_oereb_mfp/pull/139

Pleas test as well as possible!