### PR TITLE
Update document.py

### DIFF
--- a/pyramid_oereb/contrib/data_sources/oereblex/sources/document.py
+++ b/pyramid_oereb/contrib/data_sources/oereblex/sources/document.py
@@ -199,12 +199,16 @@ class OEREBlexSource(Base):
             raise AssertionError('Missing authority for document #{0}'.format(document.id))
         if oereblex_doctype is None:
             raise AssertionError('Missing type for document #{0}'.format(document.id))
+        if document.authority_url is None:
+            authority_url = None
+        else:
+            authority_url = {language: document.authority_url}
 
         # Get document type
         document_type = Config.get_document_type_by_data_code(self._code, oereblex_doctype)
 
         # Create related office record
-        office = OfficeRecord({language: authority}, office_at_web={language: document.authority_url})
+        office = OfficeRecord({language: authority}, office_at_web=authority_url)
 
         # Get files
         records = []

--- a/tests/core/sources/test_document_oereblex.py
+++ b/tests/core/sources/test_document_oereblex.py
@@ -297,6 +297,9 @@ def test_read_related_notice_as_main(oereblex_test_config):
         assert isinstance(document.responsible_office, OfficeRecord)
         assert document.responsible_office.name == {'de': '-'}
         assert document.responsible_office.office_at_web is None
+        assert source.records[0].responsible_office.office_at_web == {
+            'de': "http%3A%2F%2Fwww.zihlschlacht-sitterdorf.ch"
+        }
         assert document.published_from == datetime.date(1970, 1, 1)
         assert document.index == 40
 


### PR DESCRIPTION
Fix broken interface. If the URL is None we won't need a multilingual dict like {"de": None} but a real None. This PR is solving the issue

This is a followup of #1763 which break the tests :grimacing: 