### PR TITLE
1381 - add error logs to config.py - no data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bullseye
+FROM python:3.11-buster
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pyramid_oereb/core/config.py
+++ b/pyramid_oereb/core/config.py
@@ -886,7 +886,7 @@ class Config(object):
             ConfigurationError
         """
 
-        real_estate_types_config = Config.get('real_estate_type')
+        real_estate_types_config = Config.get_real_estate_type_config()
         if real_estate_types_config is None:
             raise ConfigurationError("Missing configuration for real estate type source config")
         real_estate_type_reader = RealEstateTypeReader(

--- a/pyramid_oereb/core/config.py
+++ b/pyramid_oereb/core/config.py
@@ -269,7 +269,7 @@ class Config(object):
         )
         theme_records = theme_reader.read()
         if len(theme_records) == 0:
-            log.error('No records found for themes.')        
+            log.error('No records found for themes.')
         return theme_records
 
     @staticmethod
@@ -428,7 +428,6 @@ class Config(object):
         if len(avaliablity_records) == 0:
             log.error('No records found for availability.')
         return avaliablity_records
-
 
     @staticmethod
     def _read_glossaries():

--- a/pyramid_oereb/core/config.py
+++ b/pyramid_oereb/core/config.py
@@ -426,7 +426,7 @@ class Config(object):
 
         avaliablity_records = availability_reader.read()
         if len(avaliablity_records) == 0:
-            log.error('No records found for availability.')
+            log.info('No records found for availability.')
         return avaliablity_records
 
     @staticmethod
@@ -949,7 +949,7 @@ class Config(object):
 
         map_layering_record = map_layering_reader.read()
         if len(map_layering_record) == 0:
-            log.error('No records found for map layering.')
+            log.info('No records found for map layering.')
         return map_layering_record
 
     @staticmethod

--- a/pyramid_oereb/core/config.py
+++ b/pyramid_oereb/core/config.py
@@ -190,19 +190,40 @@ class Config(object):
         """
         Initializes availabilities from the configured source.
         """
-        Config.availabilities = Config._read_availabilities()
+        try:
+            Config.availabilities = Config._read_availabilities()
+        except ProgrammingError:
+            Config.availabilities = None
 
     @staticmethod
     def init_glossaries():
-        Config.glossaries = Config._read_glossaries()
+        """
+        Initializes glossaries from the configured source.
+        """
+        try:
+            Config.glossaries = Config._read_glossaries()
+        except ProgrammingError:
+            Config.glossaries = None
 
     @staticmethod
     def init_disclaimers():
-        Config.disclaimers = Config._read_disclaimers()
+        """
+        Initializes disclaimers from the configured source.
+        """
+        try:
+            Config.disclaimers = Config._read_disclaimers()
+        except ProgrammingError:
+            Config.disclaimers = None
 
     @staticmethod
     def init_municipalities():
-        Config.municipalities = Config._read_municipalities()
+        """
+        Initializes municipalities from the configured source.
+        """
+        try:
+            Config.municipalities = Config._read_municipalities()
+        except ProgrammingError:
+            Config.municipalities = None
 
     @staticmethod
     def assemble_relation_themes_documents():
@@ -246,7 +267,10 @@ class Config(object):
             theme_config.get('source').get('class'),
             **Config.get_theme_config().get('source').get('params')
         )
-        return theme_reader.read()
+        theme_records = theme_reader.read()
+        if len(theme_records) == 0:
+            log.error('No records found for themes.')        
+        return theme_records
 
     @staticmethod
     def _read_theme_document():
@@ -269,7 +293,10 @@ class Config(object):
             theme_document_config.get('source').get('class'),
             **Config.get_theme_document_config().get('source').get('params')
         )
-        return theme_document_reader.read()
+        theme_document_records = theme_document_reader.read()
+        if len(theme_document_records) == 0:
+            log.error('No records found for theme documents.')
+        return theme_document_records
 
     @staticmethod
     def _read_general_information():
@@ -292,7 +319,10 @@ class Config(object):
             info_config.get('source').get('class'),
             **Config.get_info_config().get('source').get('params')
         )
-        return info_reader.read()
+        general_info_records = info_reader.read()
+        if len(general_info_records) == 0:
+            log.error('No records found for general information.')
+        return general_info_records
 
     @staticmethod
     def _read_law_status():
@@ -315,7 +345,10 @@ class Config(object):
             law_status_config.get('source').get('class'),
             **law_status_config.get('source').get('params')
         )
-        return law_status_reader.read()
+        law_status_records = law_status_reader.read()
+        if len(law_status_records) == 0:
+            log.error('No records found for law status.')
+        return law_status_records
 
     @staticmethod
     def _read_documents():
@@ -338,7 +371,10 @@ class Config(object):
             document_config.get('source').get('class'),
             **document_config.get('source').get('params')
         )
-        return document_reader.read(Config.offices)
+        document_records = document_reader.read(Config.offices)
+        if len(document_records) == 0:
+            log.error('No records found for documents.')
+        return document_records
 
     @staticmethod
     def _read_offices():
@@ -361,7 +397,10 @@ class Config(object):
             office_config.get('source').get('class'),
             **office_config.get('source').get('params')
         )
-        return office_reader.read()
+        office_records = office_reader.read()
+        if len(office_records) == 0:
+            log.error('No records found for office.')
+        return office_records
 
     @staticmethod
     def _read_availabilities():
@@ -384,7 +423,12 @@ class Config(object):
             availability_config.get('source').get('class'),
             **availability_config.get('source').get('params')
         )
-        return availability_reader.read()
+
+        avaliablity_records = availability_reader.read()
+        if len(avaliablity_records) == 0:
+            log.error('No records found for availability.')
+        return avaliablity_records
+
 
     @staticmethod
     def _read_glossaries():
@@ -406,7 +450,10 @@ class Config(object):
             glossary_config.get('source').get('class'),
             **glossary_config.get('source').get('params')
         )
-        return glossary_reader.read()
+        glossary_records = glossary_reader.read()
+        if len(glossary_records) == 0:
+            log.error('No records found for glossaries.')
+        return glossary_records
 
     @staticmethod
     def _read_disclaimers():
@@ -428,7 +475,10 @@ class Config(object):
             disclaimer_config.get('source').get('class'),
             **disclaimer_config.get('source').get('params')
         )
-        return disclaimer_reader.read()
+        disclaimer_record = disclaimer_reader.read()
+        if len(disclaimer_record) == 0:
+            log.error('No records found for disclaimer.')
+        return disclaimer_record
 
     @staticmethod
     def _read_municipalities():
@@ -450,7 +500,10 @@ class Config(object):
             municipality_config.get('source').get('class'),
             **municipality_config.get('source').get('params')
         )
-        return municipality_reader.read()
+        municipality_record = municipality_reader.read()
+        if len(municipality_record) == 0:
+            log.error('No records found for municipalities.')
+        return municipality_record
 
     @staticmethod
     def get_srid():
@@ -563,7 +616,10 @@ class Config(object):
             logo_config.get('source').get('class'),
             **Config.get_logo_config().get('source').get('params')
         )
-        return logo_reader.read()
+        logo_record = logo_reader.read()
+        if len(logo_record) == 0:
+            log.error('No records found for logos.')
+        return logo_record
 
     @staticmethod
     def get_logos():
@@ -784,7 +840,10 @@ class Config(object):
             document_types_config.get('source').get('class'),
             **Config.get_document_types_config().get('source').get('params')
         )
-        return document_types_reader.read()
+        document_types_record = document_types_reader.read()
+        if len(document_types_record) == 0:
+            log.error('No records found for document types.')
+        return document_types_record
 
     @staticmethod
     def get_document_types():
@@ -835,7 +894,10 @@ class Config(object):
             real_estate_types_config.get('source').get('class'),
             **real_estate_types_config.get('source').get('params'))
 
-        return real_estate_type_reader.read()
+        real_estate_types_record = real_estate_type_reader.read()
+        if len(real_estate_types_record) == 0:
+            log.error('No records found for real estate types.')
+        return real_estate_types_record
 
     @staticmethod
     def get_real_estate_types():
@@ -886,7 +948,10 @@ class Config(object):
             map_layering_config.get('source').get('class'),
             **map_layering_config.get('source').get('params'))
 
-        return map_layering_reader.read()
+        map_layering_record = map_layering_reader.read()
+        if len(map_layering_record) == 0:
+            log.error('No records found for map layering.')
+        return map_layering_record
 
     @staticmethod
     def get_map_layering():
@@ -1173,8 +1238,7 @@ class Config(object):
             unicode (str): The available crs.
         """
 
-        assert Config._config is not None
-        srid = Config._config.get('srid')
+        srid = Config.get_srid()
         return u'epsg:{}'.format(srid)
 
     @staticmethod

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -131,7 +131,7 @@ def test_init_logos_error():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_logos(test_logos_config,expected_result):
+def test_read_logos(test_logos_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_logo_config', return_value=test_logos_config):
         with patch.object(LogoReader, 'read', return_value=[None] * expected_result):
@@ -264,7 +264,7 @@ def test_get_theme_config_by_code_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_themes(test_themes_config,expected_result):
+def test_read_themes(test_themes_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_theme_config', return_value=test_themes_config):
         with patch.object(ThemeReader, 'read', return_value=[None] * expected_result):
@@ -300,7 +300,7 @@ def test_read_themes_config_none():
     }, 1)
     ])
 @pytest.mark.run(order=-1)
-def test_read_theme_document(test_theme_document_config,expected_result):
+def test_read_theme_document(test_theme_document_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_theme_document_config', return_value=test_theme_document_config):
         with patch.object(ThemeDocumentReader, 'read', return_value=[None] * expected_result):
@@ -459,7 +459,7 @@ def test_get_extract_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_general_information(test_general_information_config,expected_result):
+def test_read_general_information(test_general_information_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_info_config', return_value=test_general_information_config):
         with patch.object(GeneralInformationReader, 'read', return_value=[None] * expected_result):
@@ -496,7 +496,7 @@ def test_read_general_information_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_law_status(test_law_status_config,expected_result):
+def test_read_law_status(test_law_status_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_law_status_config', return_value=test_law_status_config):
         with patch.object(LawStatusReader, 'read', return_value=[None] * expected_result):
@@ -534,7 +534,7 @@ def test_read_law_status_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_documents(test_documents_config,expected_result):
+def test_read_documents(test_documents_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_document_config', return_value=test_documents_config):
         with patch.object(DocumentReader, 'read', return_value=[None] * expected_result):
@@ -570,7 +570,7 @@ def test_read_documents_config_none():
     }, 1),
 ])
 @pytest.mark.run(order=-1)
-def test_read_offices(test_offices_config,expected_result):
+def test_read_offices(test_offices_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_office_config', return_value=test_offices_config):
         with patch.object(OfficeReader, 'read', return_value=[None] * expected_result):
@@ -606,7 +606,7 @@ def test_read_offices_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_availabilities(test_availability_config,expected_result):
+def test_read_availabilities(test_availability_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_availability_config', return_value=test_availability_config):
         with patch.object(AvailabilityReader, 'read', return_value=[None] * expected_result):
@@ -642,7 +642,7 @@ def test_read_availabilities_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_glossaries(test_glossary_config,expected_result):
+def test_read_glossaries(test_glossary_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_glossary_config', return_value=test_glossary_config):
         with patch.object(GlossaryReader, 'read', return_value=[None] * expected_result):
@@ -678,7 +678,7 @@ def test_read_glossaries_config_none():
     }, 1),
 ])
 @pytest.mark.run(order=-1)
-def test_read_disclaimers(test_disclaimer_config,expected_result):
+def test_read_disclaimers(test_disclaimer_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_disclaimer_config', return_value=test_disclaimer_config):
         with patch.object(DisclaimerReader, 'read', return_value=[None] * expected_result):
@@ -714,7 +714,7 @@ def test_read_disclaimers_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_municipalities(test_municipality_config,expected_result):
+def test_read_municipalities(test_municipality_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_municipality_config', return_value=test_municipality_config):
         with patch.object(MunicipalityReader, 'read', return_value=[None] * expected_result):
@@ -750,7 +750,7 @@ def test_read_municipalities_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_document_types(test_document_types_config,expected_result):
+def test_read_document_types(test_document_types_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_document_types_config', return_value=test_document_types_config):
         with patch.object(DocumentTypeReader, 'read', return_value=[None] * expected_result):
@@ -786,7 +786,7 @@ def test_read_document_types_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_real_estate_types(test_real_estate_type_config,expected_result):
+def test_read_real_estate_types(test_real_estate_type_config, expected_result):
     Config._config = None
     with patch.object(Config, 'get_real_estate_type_config', return_value=test_real_estate_type_config):
         with patch.object(RealEstateTypeReader, 'read', return_value=[None] * expected_result):
@@ -826,7 +826,7 @@ def test_read_real_estate_types_config_none():
     }, 1)
 ])
 @pytest.mark.run(order=-1)
-def test_read_map_layering(test_map_layering_config,expected_result):
+def test_read_map_layering(test_map_layering_config, expected_result):
     Config._config = None
     Config._config = test_map_layering_config
     with patch.object(MapLayeringReader, 'read', return_value=[None] * expected_result):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -109,6 +109,7 @@ def test_init_logos_error():
         Config.init_logos()
         assert Config.logos is None
 
+
 @pytest.mark.parametrize('test_logos_config,expected_result', [
     ({
         "source": {
@@ -118,7 +119,7 @@ def test_init_logos_error():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.logo.DatabaseSource",
@@ -127,7 +128,7 @@ def test_init_logos_error():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_logos(test_logos_config,expected_result):
@@ -136,12 +137,14 @@ def test_read_logos(test_logos_config,expected_result):
         with patch.object(LogoReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_logos()) == expected_result
 
+
 @pytest.mark.run(order=-1)
 def test_read_logos_config_none():
     Config._config = None
     with patch.object(Config, 'get_logo_config', return_value=None):
         with pytest.raises(ConfigurationError):
             Config._read_logos()
+
 
 @pytest.mark.run(order=-1)
 def test_get_logo_hooks():
@@ -249,7 +252,7 @@ def test_get_theme_config_by_code_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.theme.DatabaseSource",
@@ -258,7 +261,7 @@ def test_get_theme_config_by_code_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_themes(test_themes_config,expected_result):
@@ -285,7 +288,7 @@ def test_read_themes_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.theme_document.DatabaseSource",
@@ -294,7 +297,7 @@ def test_read_themes_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"
             }
         }
-    },1)
+    }, 1)
     ])
 @pytest.mark.run(order=-1)
 def test_read_theme_document(test_theme_document_config,expected_result):
@@ -444,7 +447,7 @@ def test_get_extract_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.general_information.DatabaseSource",
@@ -453,7 +456,7 @@ def test_get_extract_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_general_information(test_general_information_config,expected_result):
@@ -477,11 +480,11 @@ def test_read_general_information_config_none():
             "class":
             "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource",
             "params": {
-                "db_connection": "*main_db_connection", 
+                "db_connection": "*main_db_connection",
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource",
@@ -490,7 +493,7 @@ def test_read_general_information_config_none():
               "model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_law_status(test_law_status_config,expected_result):
@@ -518,7 +521,7 @@ def test_read_law_status_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class":
@@ -528,7 +531,7 @@ def test_read_law_status_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_documents(test_documents_config,expected_result):
@@ -555,7 +558,7 @@ def test_read_documents_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.office.DatabaseSource",
@@ -564,7 +567,7 @@ def test_read_documents_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"
             }
         }
-    },1),
+    }, 1),
 ])
 @pytest.mark.run(order=-1)
 def test_read_offices(test_offices_config,expected_result):
@@ -591,7 +594,7 @@ def test_read_offices_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.availability.DatabaseSource",
@@ -600,7 +603,7 @@ def test_read_offices_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_availabilities(test_availability_config,expected_result):
@@ -627,7 +630,7 @@ def test_read_availabilities_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.glossary.DatabaseSource",
@@ -636,7 +639,7 @@ def test_read_availabilities_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_glossaries(test_glossary_config,expected_result):
@@ -663,7 +666,7 @@ def test_read_glossaries_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.disclaimer.DatabaseSource",
@@ -672,7 +675,7 @@ def test_read_glossaries_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"
             }
         }
-    },1),
+    }, 1),
 ])
 @pytest.mark.run(order=-1)
 def test_read_disclaimers(test_disclaimer_config,expected_result):
@@ -699,7 +702,7 @@ def test_read_disclaimers_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.municipality.DatabaseSource",
@@ -708,7 +711,7 @@ def test_read_disclaimers_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_municipalities(test_municipality_config,expected_result):
@@ -735,7 +738,7 @@ def test_read_municipalities_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.document_types.DatabaseSource",
@@ -744,7 +747,7 @@ def test_read_municipalities_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_document_types(test_document_types_config,expected_result):
@@ -771,7 +774,7 @@ def test_read_document_types_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"
             }
         }
-    },0),
+    }, 0),
     ({
         "source": {
             "class": "pyramid_oereb.contrib.data_sources.standard.sources.real_estate_type.DatabaseSource",
@@ -780,7 +783,7 @@ def test_read_document_types_config_none():
                 "model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_real_estate_types(test_real_estate_type_config,expected_result):
@@ -809,7 +812,7 @@ def test_read_real_estate_types_config_none():
                 }
             }
         }
-    },0),
+    }, 0),
     ({
         "map_layering": {
             "source": {
@@ -820,7 +823,7 @@ def test_read_real_estate_types_config_none():
                 }
             }
         }
-    },1)
+    }, 1)
 ])
 @pytest.mark.run(order=-1)
 def test_read_map_layering(test_map_layering_config,expected_result):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -9,6 +9,20 @@ from pyramid.config import ConfigurationError
 # from pyramid_oereb.core.adapter import FileAdapter
 from pyramid_oereb.core.config import Config
 from pyramid_oereb.core.records.office import OfficeRecord
+from pyramid_oereb.core.readers.theme import ThemeReader
+from pyramid_oereb.core.readers.theme_document import ThemeDocumentReader
+from pyramid_oereb.core.readers.general_information import GeneralInformationReader
+from pyramid_oereb.core.readers.law_status import LawStatusReader
+from pyramid_oereb.core.readers.document import DocumentReader
+from pyramid_oereb.core.readers.office import OfficeReader
+from pyramid_oereb.core.readers.availability import AvailabilityReader
+from pyramid_oereb.core.readers.glossary import GlossaryReader
+from pyramid_oereb.core.readers.disclaimer import DisclaimerReader
+from pyramid_oereb.core.readers.municipality import MunicipalityReader
+from pyramid_oereb.core.readers.logo import LogoReader
+from pyramid_oereb.core.readers.document_types import DocumentTypeReader
+from pyramid_oereb.core.readers.real_estate_type import RealEstateTypeReader
+from pyramid_oereb.core.readers.map_layering import MapLayeringReader
 
 
 # order=-1 to run them after all and don't screw the configuration in Config
@@ -95,6 +109,23 @@ def test_init_logos_error():
         Config.init_logos()
         assert Config.logos is None
 
+@pytest.mark.parametrize('test_logos_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.logo.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.logo.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_logos(test_logos_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_logo_config', return_value=test_logos_config):
+        with patch.object(LogoReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_logos()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_logos_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_logo_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_logos()
 
 @pytest.mark.run(order=-1)
 def test_get_logo_hooks():
@@ -192,6 +223,41 @@ def test_get_theme_config_by_code_none():
     with pytest.raises(AssertionError):
         Config.get_theme_config_by_code('ch.NE.Baulinien')
 
+@pytest.mark.parametrize('test_themes_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_themes(test_themes_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_theme_config', return_value=test_themes_config):
+        with patch.object(ThemeReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_themes()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_themes_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_theme_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_themes()
+
+@pytest.mark.parametrize('test_theme_document_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme_document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme_document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_theme_document(test_theme_document_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_theme_document_config', return_value=test_theme_document_config):
+        with patch.object(ThemeDocumentReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_theme_document()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_theme_document_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_theme_document_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_theme_document()
 
 @pytest.mark.parametrize('test_value,expected_value', [
     ({'real_estate_type': {}}, {}),
@@ -314,3 +380,200 @@ def test_get_extract_config_none():
     Config._config = None
     with pytest.raises(AssertionError):
         Config.get_extract_config()
+
+@pytest.mark.parametrize('test_general_information_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.general_information.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.general_information.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_general_information(test_general_information_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_info_config', return_value=test_general_information_config):
+        with patch.object(GeneralInformationReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_general_information()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_general_information_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_info_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_general_information()
+
+@pytest.mark.parametrize('test_law_status_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_law_status(test_law_status_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_law_status_config', return_value=test_law_status_config):
+        with patch.object(LawStatusReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_law_status()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_law_status_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_law_status_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_law_status()
+
+@pytest.mark.parametrize('test_documents_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_documents(test_documents_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_document_config', return_value=test_documents_config):
+        with patch.object(DocumentReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_documents()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_documents_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_document_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_documents()
+
+@pytest.mark.parametrize('test_offices_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.office.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.office.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_offices(test_offices_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_office_config', return_value=test_offices_config):
+        with patch.object(OfficeReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_offices()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_offices_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_office_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_offices()
+
+@pytest.mark.parametrize('test_availability_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.availability.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.availability.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_availabilities(test_availability_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_availability_config', return_value=test_availability_config):
+        with patch.object(AvailabilityReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_availabilities()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_availabilities_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_availability_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_availabilities()
+
+@pytest.mark.parametrize('test_glossary_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.glossary.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.glossary.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_glossaries(test_glossary_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_glossary_config', return_value=test_glossary_config):
+        with patch.object(GlossaryReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_glossaries()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_glossaries_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_glossary_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_glossaries()
+
+@pytest.mark.parametrize('test_disclaimer_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.disclaimer.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.disclaimer.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_disclaimers(test_disclaimer_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_disclaimer_config', return_value=test_disclaimer_config):
+        with patch.object(DisclaimerReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_disclaimers()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_disclaimers_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_disclaimer_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_disclaimers()
+
+@pytest.mark.parametrize('test_municipality_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.municipality.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.municipality.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_municipalities(test_municipality_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_municipality_config', return_value=test_municipality_config):
+        with patch.object(MunicipalityReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_municipalities()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_municipalities_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_municipality_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_municipalities()
+
+@pytest.mark.parametrize('test_document_types_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document_types.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document_types.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_document_types(test_document_types_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_document_types_config', return_value=test_document_types_config):
+        with patch.object(DocumentTypeReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_document_types()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_document_types_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_document_types_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_document_types()
+
+@pytest.mark.parametrize('test_real_estate_type_config,expected_result', [
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.real_estate_type.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"}}},0),
+    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.real_estate_type.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_real_estate_types(test_real_estate_type_config,expected_result):
+    Config._config = None
+    with patch.object(Config, 'get_real_estate_type_config', return_value=test_real_estate_type_config):
+        with patch.object(RealEstateTypeReader, 'read', return_value=[None] * expected_result):
+            assert len(Config._read_real_estate_types()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_real_estate_types_config_none():
+    Config._config = None
+    with patch.object(Config, 'get_real_estate_type_config', return_value=None):
+        with pytest.raises(ConfigurationError):
+            Config._read_real_estate_types()
+
+@pytest.mark.parametrize('test_map_layering_config,expected_result', [
+    ({"map_layering": {"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.map_layering.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.MapLayering"}}}},0),
+    ({"map_layering": {"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.map_layering.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.MapLayering"}}}},1),
+    ])
+@pytest.mark.run(order=-1)
+def test_read_map_layering(test_map_layering_config,expected_result):
+    Config._config = None
+    Config._config = test_map_layering_config
+    with patch.object(MapLayeringReader, 'read', return_value=[None] * expected_result):
+        assert len(Config._read_map_layering()) == expected_result
+
+@pytest.mark.run(order=-1)
+def test_read_map_layering_config_none():
+    Config._config = {}
+    with pytest.raises(ConfigurationError):
+        Config._read_map_layering()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -110,9 +110,25 @@ def test_init_logos_error():
         assert Config.logos is None
 
 @pytest.mark.parametrize('test_logos_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.logo.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.logo.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.logo.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.logo.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Logo"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_logos(test_logos_config,expected_result):
     Config._config = None
@@ -223,16 +239,34 @@ def test_get_theme_config_by_code_none():
     with pytest.raises(AssertionError):
         Config.get_theme_config_by_code('ch.NE.Baulinien')
 
+
 @pytest.mark.parametrize('test_themes_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.theme.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.theme.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Theme"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_themes(test_themes_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_theme_config', return_value=test_themes_config):
         with patch.object(ThemeReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_themes()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_themes_config_none():
@@ -241,9 +275,26 @@ def test_read_themes_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_themes()
 
+
 @pytest.mark.parametrize('test_theme_document_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme_document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.theme_document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"}}},1),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.theme_document.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.theme_document.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.ThemeDocument"
+            }
+        }
+    },1)
     ])
 @pytest.mark.run(order=-1)
 def test_read_theme_document(test_theme_document_config,expected_result):
@@ -252,12 +303,14 @@ def test_read_theme_document(test_theme_document_config,expected_result):
         with patch.object(ThemeDocumentReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_theme_document()) == expected_result
 
+
 @pytest.mark.run(order=-1)
 def test_read_theme_document_config_none():
     Config._config = None
     with patch.object(Config, 'get_theme_document_config', return_value=None):
         with pytest.raises(ConfigurationError):
             Config._read_theme_document()
+
 
 @pytest.mark.parametrize('test_value,expected_value', [
     ({'real_estate_type': {}}, {}),
@@ -381,16 +434,34 @@ def test_get_extract_config_none():
     with pytest.raises(AssertionError):
         Config.get_extract_config()
 
+
 @pytest.mark.parametrize('test_general_information_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.general_information.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.general_information.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.general_information.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.general_information.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.GeneralInformation"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_general_information(test_general_information_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_info_config', return_value=test_general_information_config):
         with patch.object(GeneralInformationReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_general_information()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_general_information_config_none():
@@ -399,16 +470,35 @@ def test_read_general_information_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_general_information()
 
+
 @pytest.mark.parametrize('test_law_status_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"}}},1),
-    ])
+    ({
+        "source": {
+            "class":
+            "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection", 
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.law_status.DatabaseSource",
+            "params": {
+              "db_connection": "*main_db_connection",
+              "model": "pyramid_oereb.contrib.data_sources.standard.models.main.LawStatus"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_law_status(test_law_status_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_law_status_config', return_value=test_law_status_config):
         with patch.object(LawStatusReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_law_status()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_law_status_config_none():
@@ -417,16 +507,36 @@ def test_read_law_status_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_law_status()
 
+
 @pytest.mark.parametrize('test_documents_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"}}},1),
-    ])
+    ({
+        "source": {
+            "class":
+            "pyramid_oereb.contrib.data_sources.standard.sources.document.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class":
+            "pyramid_oereb.contrib.data_sources.standard.sources.document.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Document"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_documents(test_documents_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_document_config', return_value=test_documents_config):
         with patch.object(DocumentReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_documents()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_documents_config_none():
@@ -435,16 +545,34 @@ def test_read_documents_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_documents()
 
+
 @pytest.mark.parametrize('test_offices_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.office.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.office.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.office.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.office.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Office"
+            }
+        }
+    },1),
+])
 @pytest.mark.run(order=-1)
 def test_read_offices(test_offices_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_office_config', return_value=test_offices_config):
         with patch.object(OfficeReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_offices()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_offices_config_none():
@@ -453,16 +581,34 @@ def test_read_offices_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_offices()
 
+
 @pytest.mark.parametrize('test_availability_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.availability.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.availability.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.availability.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.availability.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Availability"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_availabilities(test_availability_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_availability_config', return_value=test_availability_config):
         with patch.object(AvailabilityReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_availabilities()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_availabilities_config_none():
@@ -471,16 +617,34 @@ def test_read_availabilities_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_availabilities()
 
+
 @pytest.mark.parametrize('test_glossary_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.glossary.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.glossary.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.glossary.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.glossary.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Glossary"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_glossaries(test_glossary_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_glossary_config', return_value=test_glossary_config):
         with patch.object(GlossaryReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_glossaries()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_glossaries_config_none():
@@ -489,16 +653,34 @@ def test_read_glossaries_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_glossaries()
 
+
 @pytest.mark.parametrize('test_disclaimer_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.disclaimer.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.disclaimer.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.disclaimer.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.disclaimer.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Disclaimer"
+            }
+        }
+    },1),
+])
 @pytest.mark.run(order=-1)
 def test_read_disclaimers(test_disclaimer_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_disclaimer_config', return_value=test_disclaimer_config):
         with patch.object(DisclaimerReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_disclaimers()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_disclaimers_config_none():
@@ -507,16 +689,34 @@ def test_read_disclaimers_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_disclaimers()
 
+
 @pytest.mark.parametrize('test_municipality_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.municipality.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.municipality.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.municipality.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.municipality.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.Municipality"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_municipalities(test_municipality_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_municipality_config', return_value=test_municipality_config):
         with patch.object(MunicipalityReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_municipalities()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_municipalities_config_none():
@@ -525,16 +725,34 @@ def test_read_municipalities_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_municipalities()
 
+
 @pytest.mark.parametrize('test_document_types_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document_types.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.document_types.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.document_types.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.document_types.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.DocumentTypeText"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_document_types(test_document_types_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_document_types_config', return_value=test_document_types_config):
         with patch.object(DocumentTypeReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_document_types()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_document_types_config_none():
@@ -543,16 +761,34 @@ def test_read_document_types_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_document_types()
 
+
 @pytest.mark.parametrize('test_real_estate_type_config,expected_result', [
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.real_estate_type.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"}}},0),
-    ({"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.real_estate_type.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"}}},1),
-    ])
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.real_estate_type.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"
+            }
+        }
+    },0),
+    ({
+        "source": {
+            "class": "pyramid_oereb.contrib.data_sources.standard.sources.real_estate_type.DatabaseSource",
+            "params": {
+                "db_connection": "*main_db_connection",
+                "model": "pyramid_oereb.contrib.data_sources.standard.models.main.RealEstateType"
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_real_estate_types(test_real_estate_type_config,expected_result):
     Config._config = None
     with patch.object(Config, 'get_real_estate_type_config', return_value=test_real_estate_type_config):
         with patch.object(RealEstateTypeReader, 'read', return_value=[None] * expected_result):
             assert len(Config._read_real_estate_types()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_real_estate_types_config_none():
@@ -561,16 +797,38 @@ def test_read_real_estate_types_config_none():
         with pytest.raises(ConfigurationError):
             Config._read_real_estate_types()
 
+
 @pytest.mark.parametrize('test_map_layering_config,expected_result', [
-    ({"map_layering": {"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.map_layering.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.MapLayering"}}}},0),
-    ({"map_layering": {"source": {"class": "pyramid_oereb.contrib.data_sources.standard.sources.map_layering.DatabaseSource","params": {"db_connection": "*main_db_connection","model": "pyramid_oereb.contrib.data_sources.standard.models.main.MapLayering"}}}},1),
-    ])
+    ({
+        "map_layering": {
+            "source": {
+                "class": "pyramid_oereb.contrib.data_sources.standard.sources.map_layering.DatabaseSource",
+                "params": {
+                    "db_connection": "*main_db_connection",
+                    "model": "pyramid_oereb.contrib.data_sources.standard.models.main.MapLayering"
+                }
+            }
+        }
+    },0),
+    ({
+        "map_layering": {
+            "source": {
+                "class": "pyramid_oereb.contrib.data_sources.standard.sources.map_layering.DatabaseSource",
+                "params": {
+                    "db_connection": "*main_db_connection",
+                    "model": "pyramid_oereb.contrib.data_sources.standard.models.main.MapLayering"
+                }
+            }
+        }
+    },1)
+])
 @pytest.mark.run(order=-1)
 def test_read_map_layering(test_map_layering_config,expected_result):
     Config._config = None
     Config._config = test_map_layering_config
     with patch.object(MapLayeringReader, 'read', return_value=[None] * expected_result):
         assert len(Config._read_map_layering()) == expected_result
+
 
 @pytest.mark.run(order=-1)
 def test_read_map_layering_config_none():

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -838,3 +838,250 @@ def test_read_map_layering_config_none():
     Config._config = {}
     with pytest.raises(ConfigurationError):
         Config._read_map_layering()
+
+
+@pytest.mark.run(order=1)
+def test_init_availabilities():
+    Config._config = None
+    with patch.object(Config, '_read_availabilities', return_value=""):
+        assert Config.availabilities is None
+        Config.init_availabilities()
+        assert Config.availabilities == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_availabilities_error():
+    def mock_read_availabilities():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_availabilities', mock_read_availabilities):
+        Config._config = None
+        Config.init_availabilities()
+        assert Config.availabilities is None
+
+
+@pytest.mark.run(order=1)
+def test_init_glossaries():
+    Config._config = None
+    with patch.object(Config, '_read_glossaries', return_value=""):
+        assert Config.glossaries is None
+        Config.init_glossaries()
+        assert Config.glossaries == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_glossaries_error():
+    def mock_read_glossaries():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_glossaries', mock_read_glossaries):
+        Config._config = None
+        Config.init_glossaries()
+        assert Config.glossaries is None
+
+
+@pytest.mark.run(order=1)
+def test_init_disclaimers():
+    Config._config = None
+    with patch.object(Config, '_read_disclaimers', return_value=""):
+        assert Config.disclaimers is None
+        Config.init_disclaimers()
+        assert Config.disclaimers == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_disclaimers_error():
+    def mock_read_disclaimers():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_disclaimers', mock_read_disclaimers):
+        Config._config = None
+        Config.init_disclaimers()
+        assert Config.disclaimers is None
+
+
+@pytest.mark.run(order=1)
+def test_init_municipalities():
+    Config._config = None
+    with patch.object(Config, '_read_municipalities', return_value=""):
+        assert Config.municipalities is None
+        Config.init_municipalities()
+        assert Config.municipalities == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_municipalities_error():
+    def mock_read_municipalities():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_municipalities', mock_read_municipalities):
+        Config._config = None
+        Config.init_municipalities()
+        assert Config.municipalities is None
+
+
+@pytest.mark.run(order=1)
+def test_init_document_types():
+    Config._config = None
+    with patch.object(Config, '_read_document_types', return_value=""):
+        assert Config.document_types is None
+        Config.init_document_types()
+        assert Config.document_types == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_document_types_error():
+    def mock_read_document_types():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_document_types', mock_read_document_types):
+        Config._config = None
+        Config.init_document_types()
+        assert Config.document_types is None
+
+
+@pytest.mark.run(order=1)
+def test_init_real_estate_types():
+    Config._config = None
+    with patch.object(Config, '_read_real_estate_types', return_value=""):
+        assert Config.real_estate_types is None
+        Config.init_real_estate_types()
+        assert Config.real_estate_types == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_real_estate_types_error():
+    def mock_read_real_estate_types():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_real_estate_types', mock_read_real_estate_types):
+        Config._config = None
+        Config.init_real_estate_types()
+        assert Config.real_estate_types is None
+
+
+@pytest.mark.run(order=1)
+def test_init_map_layering():
+    Config._config = None
+    with patch.object(Config, '_read_map_layering', return_value=""):
+        assert Config.map_layering is None
+        Config.init_map_layering()
+        assert Config.map_layering == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_map_layering_error():
+    def mock_read_map_layering():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_map_layering', mock_read_map_layering):
+        Config._config = None
+        Config.init_map_layering()
+        assert Config.map_layering is None
+
+
+@pytest.mark.run(order=1)
+def test_init_themes():
+    Config._config = None
+    with patch.object(Config, '_read_themes', return_value=""):
+        assert Config.themes is None
+        Config.init_themes()
+        assert Config.themes == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_themes_error():
+    def mock_read_themes():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_themes', mock_read_themes):
+        Config._config = None
+        Config.init_themes()
+        assert Config.themes is None
+
+
+@pytest.mark.run(order=1)
+def test_init_theme_document():
+    Config._config = None
+    with patch.object(Config, '_read_theme_document', return_value=""):
+        assert Config.theme_document is None
+        Config.init_theme_document()
+        assert Config.theme_document == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_theme_document_error():
+    def mock_read_theme_document():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_theme_document', mock_read_theme_document):
+        Config._config = None
+        Config.init_theme_document()
+        assert Config.theme_document is None
+
+
+@pytest.mark.run(order=1)
+def test_init_general_information():
+    Config._config = None
+    with patch.object(Config, '_read_general_information', return_value=""):
+        assert Config.general_information is None
+        Config.init_general_information()
+        assert Config.general_information == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_general_information_error():
+    def mock_read_general_information():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_general_information', mock_read_general_information):
+        Config._config = None
+        Config.init_general_information()
+        assert Config.general_information is None
+
+
+@pytest.mark.run(order=1)
+def test_init_law_status():
+    Config._config = None
+    with patch.object(Config, '_read_law_status', return_value=""):
+        assert Config.law_status is None
+        Config.init_law_status()
+        assert Config.law_status == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_law_status_error():
+    def mock_read_law_status():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_law_status', mock_read_law_status):
+        Config._config = None
+        Config.init_law_status()
+        assert Config.law_status is None
+
+
+@pytest.mark.run(order=1)
+def test_init_documents():
+    Config._config = None
+    with patch.object(Config, '_read_documents', return_value=""):
+        assert Config.documents is None
+        Config.init_documents()
+        assert Config.documents == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_documents_error():
+    def mock_read_documents():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_documents', mock_read_documents):
+        Config._config = None
+        Config.init_documents()
+        assert Config.documents is None
+
+
+@pytest.mark.run(order=1)
+def test_init_offices():
+    Config._config = None
+    with patch.object(Config, '_read_offices', return_value=""):
+        assert Config.offices is None
+        Config.init_offices()
+        assert Config.offices == ""
+
+
+@pytest.mark.run(order=1)
+def test_init_offices_error():
+    def mock_read_offices():
+        raise ProgrammingError('a', 'b', 'c')
+    with patch.object(Config, '_read_offices', mock_read_offices):
+        Config._config = None
+        Config.init_offices()
+        assert Config.offices is None


### PR DESCRIPTION
When a configuration is faulty, we throw exceptions. But if the configured sources do not contain data the integrator does not get the feedback accordingly.
