### PR TITLE
remove exception.py from code

### DIFF
--- a/pyramid_oereb/core/exception.py
+++ b/pyramid_oereb/core/exception.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-
-
-class ConfigurationError(Exception):
-    pass


### PR DESCRIPTION
exception.py is not used anywhere and can be deleted.