### PR TITLE
Add option to not verify certificate when calling the real estate WMS

### DIFF
--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -238,6 +238,7 @@ pyramid_oereb:
         fr: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&STYLES=default&CRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
       layer_index: 0
       layer_opacity: 1.0
+      verify_certificate: True
     plan_for_land_register_main_page:
       # WMS URL to query the plan for land register specially for static extracts overview page
       reference_wms:
@@ -245,6 +246,7 @@ pyramid_oereb:
         fr: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&STYLES=default&CRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
       layer_index: 0
       layer_opacity: 1.0
+      verify_certificate: True
     visualisation:
       method: pyramid_oereb.core.hook_methods.produce_sld_content
       # Note: these parameters must fit to the attributes provided by the RealEstateRecord!!!!

--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -246,6 +246,7 @@ pyramid_oereb:
         fr: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&STYLES=default&CRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
       layer_index: 0
       layer_opacity: 1.0
+      # Option to check certificate for external WMS. Default and recommended setting: True
       verify_certificate: True
     visualisation:
       method: pyramid_oereb.core.hook_methods.produce_sld_content

--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -238,6 +238,7 @@ pyramid_oereb:
         fr: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&STYLES=default&CRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
       layer_index: 0
       layer_opacity: 1.0
+      # Option to check certificate for external WMS. Default and recommended setting: True
       verify_certificate: True
     plan_for_land_register_main_page:
       # WMS URL to query the plan for land register specially for static extracts overview page

--- a/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
+++ b/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
@@ -16,7 +16,7 @@ As of the moment of writing this includes:
 
 
 from sqlalchemy import Column, ForeignKey
-from sqlalchemy import String, Integer, Float, Date
+from sqlalchemy import String, Integer, Float, Date, Boolean
 from geoalchemy2.types import Geometry as GeoAlchemyGeometry
 from sqlalchemy.orm import relationship
 from sqlalchemy_utils import JSONType
@@ -174,7 +174,8 @@ def get_view_service(base, schema_name, pk_type):
             reference_wms (dict of str): The actual url which leads to the desired cartographic
                 representation (multilingual).
             layer_index (int): Index for sorting the layering of the view services for a theme
-            layer_opacity (float): Opacity of a view service
+            layer_opacity (float): Opacity of a view servicA
+            verify_certificate (boolean): Whether the certificate of the WMS shall be verified
         """
         __table_args__ = {'schema': schema_name}
         __tablename__ = 'view_service'
@@ -182,6 +183,7 @@ def get_view_service(base, schema_name, pk_type):
         reference_wms = Column(JSONType, nullable=False)
         layer_index = Column(Integer, nullable=False)
         layer_opacity = Column(Float, nullable=False)
+        verify_certificate = Column(Boolean, nullable=True)
 
     return ViewService
 

--- a/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
+++ b/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
@@ -16,7 +16,7 @@ As of the moment of writing this includes:
 
 
 from sqlalchemy import Column, ForeignKey
-from sqlalchemy import String, Integer, Float, Date, Boolean
+from sqlalchemy import String, Integer, Float, Date
 from geoalchemy2.types import Geometry as GeoAlchemyGeometry
 from sqlalchemy.orm import relationship
 from sqlalchemy_utils import JSONType

--- a/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
+++ b/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
@@ -174,7 +174,7 @@ def get_view_service(base, schema_name, pk_type):
             reference_wms (dict of str): The actual url which leads to the desired cartographic
                 representation (multilingual).
             layer_index (int): Index for sorting the layering of the view services for a theme
-            layer_opacity (float): Opacity of a view servicA
+            layer_opacity (float): Opacity of a view service
         """
         __table_args__ = {'schema': schema_name}
         __tablename__ = 'view_service'

--- a/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
+++ b/pyramid_oereb/contrib/data_sources/standard/models/__init__.py
@@ -175,7 +175,6 @@ def get_view_service(base, schema_name, pk_type):
                 representation (multilingual).
             layer_index (int): Index for sorting the layering of the view services for a theme
             layer_opacity (float): Opacity of a view servicA
-            verify_certificate (boolean): Whether the certificate of the WMS shall be verified
         """
         __table_args__ = {'schema': schema_name}
         __tablename__ = 'view_service'
@@ -183,7 +182,6 @@ def get_view_service(base, schema_name, pk_type):
         reference_wms = Column(JSONType, nullable=False)
         layer_index = Column(Integer, nullable=False)
         layer_opacity = Column(Float, nullable=False)
-        verify_certificate = Column(Boolean, nullable=True)
 
     return ViewService
 

--- a/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
@@ -162,6 +162,7 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
+            Config.get('verify_certificate'),
             legends=legend_entry_records
         )
         return view_service_record

--- a/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
@@ -162,8 +162,8 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            Config.get('verify_certificate'),
-            legends=legend_entry_records
+            legends=legend_entry_records,
+            verify_certificate=view_service_from_db.verify_certificate
         )
         return view_service_record
 

--- a/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
@@ -163,7 +163,8 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
             Config.get('srid'),
             Config.get('proxies'),
             legends=legend_entry_records,
-            verify_certificate=view_service_from_db.verify_certificate
+            # Note: our standard database model does not contain an option to override the verify_certificate
+            verify_certificate=True
         )
         return view_service_record
 

--- a/pyramid_oereb/core/readers/real_estate.py
+++ b/pyramid_oereb/core/readers/real_estate.py
@@ -64,7 +64,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            Config.get('verify_certificate')
+            plan_for_land_register_config.get('verify_certificate')
         )
 
         plan_for_land_register_main_page_config = Config.get_plan_for_land_register_main_page_config()
@@ -75,7 +75,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            Config.get('verify_certificate')
+            plan_for_land_register_main_page_config.get('verify_certificate')
         )
 
         self._source_.read(params, nb_ident=nb_ident, number=number, egrid=egrid, geometry=geometry)

--- a/pyramid_oereb/core/readers/real_estate.py
+++ b/pyramid_oereb/core/readers/real_estate.py
@@ -63,7 +63,8 @@ class RealEstateReader(object):
             plan_for_land_register_config.get('layer_opacity'),
             Config.get('default_language'),
             Config.get('srid'),
-            Config.get('proxies')
+            Config.get('proxies'),
+            Config.get('verify_certificate')
         )
 
         plan_for_land_register_main_page_config = Config.get_plan_for_land_register_main_page_config()
@@ -73,7 +74,8 @@ class RealEstateReader(object):
             plan_for_land_register_main_page_config.get('layer_opacity'),
             Config.get('default_language'),
             Config.get('srid'),
-            Config.get('proxies')
+            Config.get('proxies'),
+            Config.get('verify_certificate')
         )
 
         self._source_.read(params, nb_ident=nb_ident, number=number, egrid=egrid, geometry=geometry)

--- a/pyramid_oereb/core/readers/real_estate.py
+++ b/pyramid_oereb/core/readers/real_estate.py
@@ -64,7 +64,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            plan_for_land_register_config.get('verify_certificate')
+            verify_certificate=plan_for_land_register_config.get('verify_certificate')
         )
 
         plan_for_land_register_main_page_config = Config.get_plan_for_land_register_main_page_config()
@@ -75,7 +75,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            plan_for_land_register_main_page_config.get('verify_certificate')
+            verify_certificate=plan_for_land_register_main_page_config.get('verify_certificate')
         )
 
         self._source_.read(params, nb_ident=nb_ident, number=number, egrid=egrid, geometry=geometry)

--- a/pyramid_oereb/core/readers/real_estate.py
+++ b/pyramid_oereb/core/readers/real_estate.py
@@ -64,7 +64,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            verify_certificate=plan_for_land_register_config.get('verify_certificate')
+            verify_certificate=plan_for_land_register_config.get('verify_certificate', True)
         )
 
         plan_for_land_register_main_page_config = Config.get_plan_for_land_register_main_page_config()
@@ -75,7 +75,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            verify_certificate=plan_for_land_register_main_page_config.get('verify_certificate')
+            verify_certificate=plan_for_land_register_main_page_config.get('verify_certificate', True)
         )
 
         self._source_.read(params, nb_ident=nb_ident, number=number, egrid=egrid, geometry=geometry)

--- a/pyramid_oereb/core/records/view_service.py
+++ b/pyramid_oereb/core/records/view_service.py
@@ -80,7 +80,7 @@ class ViewServiceRecord(object):
     """
 
     def __init__(self, reference_wms, layer_index, layer_opacity, default_language,
-                 srid, proxies=None, legends=None):
+                 srid, proxies=None, legends=None, verify_certificate=True):
         """
 
         Args:
@@ -105,6 +105,7 @@ class ViewServiceRecord(object):
         self.default_language = default_language
         self.srid = srid
         self.proxies = proxies
+        self.verify_certificate = verify_certificate
 
         if legends is None:
             self.legends = []
@@ -247,7 +248,7 @@ class ViewServiceRecord(object):
         if uri_validator(wms):
             log.debug(f"Downloading image, url: {wms}")
             try:
-                response = requests.get(wms, proxies=self.proxies)
+                response = requests.get(wms, proxies=self.proxies, verify=self.verify_certificate)
             except Exception as ex:
                 dedicated_msg = f"An image could not be downloaded. URL was: {wms}, error was {ex}"
                 log.error(dedicated_msg)

--- a/pyramid_oereb/core/records/view_service.py
+++ b/pyramid_oereb/core/records/view_service.py
@@ -248,7 +248,7 @@ class ViewServiceRecord(object):
         if uri_validator(wms):
             log.debug(f"Downloading image, url: {wms}")
             try:
-                response = requests.get(wms, proxies=self.proxies, verify=self.verify_certicate)
+                response = requests.get(wms, proxies=self.proxies, verify=self.verify_certificate)
             except Exception as ex:
                 dedicated_msg = f"An image could not be downloaded. URL was: {wms}, error was {ex}"
                 log.error(dedicated_msg)

--- a/pyramid_oereb/core/records/view_service.py
+++ b/pyramid_oereb/core/records/view_service.py
@@ -80,7 +80,7 @@ class ViewServiceRecord(object):
     """
 
     def __init__(self, reference_wms, layer_index, layer_opacity, default_language,
-                 srid, proxies=None, legends=None, verify_certificate=True):
+                 srid, proxies=None, verify_certificate=True, legends=None):
         """
 
         Args:
@@ -248,7 +248,7 @@ class ViewServiceRecord(object):
         if uri_validator(wms):
             log.debug(f"Downloading image, url: {wms}")
             try:
-                response = requests.get(wms, proxies=self.proxies, verify=self.verify_certificate)
+                response = requests.get(wms, proxies=self.proxies)
             except Exception as ex:
                 dedicated_msg = f"An image could not be downloaded. URL was: {wms}, error was {ex}"
                 log.error(dedicated_msg)

--- a/pyramid_oereb/core/records/view_service.py
+++ b/pyramid_oereb/core/records/view_service.py
@@ -248,7 +248,7 @@ class ViewServiceRecord(object):
         if uri_validator(wms):
             log.debug(f"Downloading image, url: {wms}")
             try:
-                response = requests.get(wms, proxies=self.proxies)
+                response = requests.get(wms, proxies=self.proxies, verify=self.verify_certicate)
             except Exception as ex:
                 dedicated_msg = f"An image could not be downloaded. URL was: {wms}, error was {ex}"
                 log.error(dedicated_msg)

--- a/pyramid_oereb/core/records/view_service.py
+++ b/pyramid_oereb/core/records/view_service.py
@@ -80,7 +80,7 @@ class ViewServiceRecord(object):
     """
 
     def __init__(self, reference_wms, layer_index, layer_opacity, default_language,
-                 srid, proxies=None, verify_certificate=True, legends=None):
+                 srid, proxies=None, legends=None, verify_certificate=True):
         """
 
         Args:
@@ -91,6 +91,7 @@ class ViewServiceRecord(object):
             srid (int): The SRID which is used for the WMS.
             proxies (dict or None): The proxies which may be used
             legends (list of LegendEntry or None): A list of all relevant legend entries.
+            verify_certificate (bool): indicates whether call to the WMS shall be verified
         """
         self.reference_wms = reference_wms
         self.image = dict()  # multilingual dict with binary map images resulting from calling the wms link
@@ -105,14 +106,13 @@ class ViewServiceRecord(object):
         self.default_language = default_language
         self.srid = srid
         self.proxies = proxies
-        self.verify_certificate = verify_certificate
-
         if legends is None:
             self.legends = []
         else:
             for legend in legends:
                 assert isinstance(legend.symbol, ImageRecord)
             self.legends = legends
+        self.verify_certificate = verify_certificate
 
     @staticmethod
     def sanitize_layer_index(layer_index):

--- a/tests/core/records/test_view_service.py
+++ b/tests/core/records/test_view_service.py
@@ -20,7 +20,8 @@ def test_init():
         'de',
         2056,
         None,
-        None
+        True,
+        None,
     )
     assert isinstance(record.reference_wms, dict)
     assert isinstance(record.layer_index, int)
@@ -29,6 +30,7 @@ def test_init():
     assert record.default_language == 'de'
     assert record.srid == 2056
     assert record.proxies is None
+    assert record.verify_certificate is True
     assert len(record.legends) == 0
 
 
@@ -49,6 +51,7 @@ def test_init_with_relation(pyramid_oereb_test_config):
         'de',
         2056,
         None,
+        True,
         legend_records
     )
     assert isinstance(record.reference_wms, dict)

--- a/tests/core/records/test_view_service.py
+++ b/tests/core/records/test_view_service.py
@@ -66,20 +66,20 @@ def test_init_with_relation(pyramid_oereb_test_config):
 
 def test_invalid_layer_index_arguments(pyramid_oereb_test_config):
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, -1001, 1, 'de', 2056, None, None)
+        ViewServiceRecord({'de': 'http://example.com'}, -1001, 1, 'de', 2056, None, True, None)
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, 1001, 1, 'de', 2056, None, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1001, 1, 'de', 2056, None, True, None)
     with pytest.warns(UserWarning, match='Type of "layer_index" should be "int"'):
-        ViewServiceRecord({'de': 'http://example.com'}, 1.0, 1, 'de', 2056, None, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1.0, 1, 'de', 2056, None, True, None)
 
 
 def test_invalid_layer_layer_opacity(pyramid_oereb_test_config):
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, 1, 2.0, 'de', 2056, None, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1, 2.0, 'de', 2056, None, True, None)
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, 1, -1.1, 'de', 2056, None, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1, -1.1, 'de', 2056, None, True, None)
     with pytest.warns(UserWarning, match='Type of "layer_opacity" should be "float"'):
-        ViewServiceRecord({'de': 'http://example.com'}, 1, 1, 'de', 2056, None, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1, 1, 'de', 2056, None, True, None)
 
 
 def test_check_min_max_attributes():

--- a/tests/core/records/test_view_service.py
+++ b/tests/core/records/test_view_service.py
@@ -20,8 +20,8 @@ def test_init():
         'de',
         2056,
         None,
-        True,
         None,
+        True
     )
     assert isinstance(record.reference_wms, dict)
     assert isinstance(record.layer_index, int)
@@ -30,8 +30,8 @@ def test_init():
     assert record.default_language == 'de'
     assert record.srid == 2056
     assert record.proxies is None
-    assert record.verify_certificate is True
     assert len(record.legends) == 0
+    assert record.verify_certificate is True
 
 
 def test_init_with_relation(pyramid_oereb_test_config):
@@ -51,8 +51,8 @@ def test_init_with_relation(pyramid_oereb_test_config):
         'de',
         2056,
         None,
-        True,
-        legend_records
+        legend_records,
+        True
     )
     assert isinstance(record.reference_wms, dict)
     assert isinstance(record.layer_index, int)
@@ -66,20 +66,20 @@ def test_init_with_relation(pyramid_oereb_test_config):
 
 def test_invalid_layer_index_arguments(pyramid_oereb_test_config):
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, -1001, 1, 'de', 2056, None, True, None)
+        ViewServiceRecord({'de': 'http://example.com'}, -1001, 1, 'de', 2056, None, None, True)
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, 1001, 1, 'de', 2056, None, True, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1001, 1, 'de', 2056, None, None, True)
     with pytest.warns(UserWarning, match='Type of "layer_index" should be "int"'):
-        ViewServiceRecord({'de': 'http://example.com'}, 1.0, 1, 'de', 2056, None, True, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1.0, 1, 'de', 2056, None, None, True)
 
 
 def test_invalid_layer_layer_opacity(pyramid_oereb_test_config):
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, 1, 2.0, 'de', 2056, None, True, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1, 2.0, 'de', 2056, None, None, True)
     with pytest.raises(AttributeError):
-        ViewServiceRecord({'de': 'http://example.com'}, 1, -1.1, 'de', 2056, None, True, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1, -1.1, 'de', 2056, None, None, True)
     with pytest.warns(UserWarning, match='Type of "layer_opacity" should be "float"'):
-        ViewServiceRecord({'de': 'http://example.com'}, 1, 1, 'de', 2056, None, True, None)
+        ViewServiceRecord({'de': 'http://example.com'}, 1, 1, 'de', 2056, None, None, True)
 
 
 def test_check_min_max_attributes():


### PR DESCRIPTION
Add option to not verify certificate when calling the real estate WMS. Useful for example if the WMS has a self-signed certificate.

In addition to the CI, this PR was tested locally with
http://localhost:6543/oereb/extract/json?EGRID=CH113928077734&WITHIMAGES=true

with both settings (verify_certificate True and False)