### PR TITLE
Restrict the version of Numpy used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ recommend = [
     "image==1.5.33",
     "shapely==2.0.4",
     "SQLAlchemy==2.0.31",
+    "numpy<2",
     "pyaml-env==1.2.1",
     "urllib3==2.2.2",
     "waitress==3.0.0",


### PR DESCRIPTION
Restrict the version of Numpy used, as incompatibilities with other libraries have been detected in an operational environment (Jura).
This is quick-fix pull request; because the current CI does not detect this issue, the root cause needs to be investigated further.