### PR TITLE
Provide a general WMS verify certificate option

### DIFF
--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -238,8 +238,6 @@ pyramid_oereb:
         fr: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&STYLES=default&CRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
       layer_index: 0
       layer_opacity: 1.0
-      # Option to check certificate for external WMS. Default and recommended setting: True
-      verify_certificate: True
     plan_for_land_register_main_page:
       # WMS URL to query the plan for land register specially for static extracts overview page
       reference_wms:
@@ -247,8 +245,6 @@ pyramid_oereb:
         fr: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&STYLES=default&CRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
       layer_index: 0
       layer_opacity: 1.0
-      # Option to check certificate for external WMS. Default and recommended setting: True
-      verify_certificate: True
     visualisation:
       method: pyramid_oereb.core.hook_methods.produce_sld_content
       # Note: these parameters must fit to the attributes provided by the RealEstateRecord!!!!
@@ -1412,6 +1408,9 @@ pyramid_oereb:
         - data_code: Hinweis
           transfer_code: Hinweis
           extract_code: Hint
+
+  # Option to check certificate for external WMS calls. Default and recommended setting: True
+  verify_certificate_wms: True
 
   # The error message returned if an error occurs when requesting a static extract
   # The content of the message is defined in the specification (document "Inhalt und Darstellung des statischen Auszugs")

--- a/dev/config/pyramid_oereb.yml.mako
+++ b/dev/config/pyramid_oereb.yml.mako
@@ -1409,7 +1409,8 @@ pyramid_oereb:
           transfer_code: Hinweis
           extract_code: Hint
 
-  # Option to check certificate for external WMS calls. Default and recommended setting: True
+  # Option to check certificate for external WMS calls in standard and oereblex themes.
+  # Default and recommended setting: True
   verify_certificate_wms: True
 
   # The error message returned if an error occurs when requesting a static extract

--- a/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/plr.py
@@ -163,8 +163,7 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
             Config.get('srid'),
             Config.get('proxies'),
             legends=legend_entry_records,
-            # Note: our standard database model does not contain an option to override the verify_certificate
-            verify_certificate=True
+            verify_certificate=Config.get('verify_certificate_wms', True)
         )
         return view_service_record
 

--- a/pyramid_oereb/core/readers/real_estate.py
+++ b/pyramid_oereb/core/readers/real_estate.py
@@ -64,7 +64,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            verify_certificate=plan_for_land_register_config.get('verify_certificate', True)
+            verify_certificate=Config.get('verify_certificate_wms', True)
         )
 
         plan_for_land_register_main_page_config = Config.get_plan_for_land_register_main_page_config()
@@ -75,7 +75,7 @@ class RealEstateReader(object):
             Config.get('default_language'),
             Config.get('srid'),
             Config.get('proxies'),
-            verify_certificate=plan_for_land_register_main_page_config.get('verify_certificate', True)
+            verify_certificate=Config.get('verify_certificate_wms', True)
         )
 
         self._source_.read(params, nb_ident=nb_ident, number=number, egrid=egrid, geometry=geometry)


### PR DESCRIPTION
Provide a general WMS verify certificate option, for cantonal setups where all WMS are served with self-signed certificates

Improves https://github.com/openoereb/pyramid_oereb/pull/2005 , tested in canton Jura infrastructure.