### PR TITLE
Critical security issue CVE-2024-49768

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ recommend = [
     "SQLAlchemy==2.0.32",
     "pyaml-env==1.2.1",
     "urllib3==2.2.2",
-    "waitress==3.0.0",
+    "waitress==3.0.1",
     "pyreproj==3.0.0",
     "mako-render==0.1.0",
     "requests==2.32.3",


### PR DESCRIPTION
The waitress library needs an update from "waitress==3.0.0" to "waitress==3.0.1" to fix the issue.

See https://avd.aquasec.com/nvd/2024/cve-2024-49768/