### PR TITLE
2101 fix daily ci

### DIFF
--- a/tests/core/sources/test_address_geoadmin.py
+++ b/tests/core/sources/test_address_geoadmin.py
@@ -86,4 +86,4 @@ def test_read(pyramid_oereb_test_config, status_code):
             assert address.street_name == u'Muehlemattstrasse'
             assert isinstance(address.geom, Point)
             assert address.geom.x == 2621857.986995669
-            assert address.geom.y == 1259852.8231037296
+            assert address.geom.y == 1259852.8231037268

--- a/tests/core/sources/test_address_geoadmin.py
+++ b/tests/core/sources/test_address_geoadmin.py
@@ -2,6 +2,7 @@
 
 from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.contrib.data_sources.swisstopo.address import AddressGeoAdminSource
+import sys
 import pytest
 import requests_mock
 from requests import HTTPError
@@ -86,4 +87,15 @@ def test_read(pyramid_oereb_test_config, status_code):
             assert address.street_name == u'Muehlemattstrasse'
             assert isinstance(address.geom, Point)
             assert address.geom.x == 2621857.986995669
-            assert address.geom.y == 1259852.8231037268
+
+            # TODO: Remove workaround when Python 3.9 will no longer be supported
+            # This is a workaround needed as long as Python 3.9 is supported due to Numpy v2.2.4 used in
+            # Python 3.10 or higher, which does not support Python versions 3.9 or lower
+            # (where Numpy v2.0.2 or lower is used)
+            # Define the expected y-coordinate value based on Python version
+            if sys.version_info[:2] > (3, 9):
+                expected_geom_y = 1259852.8231037296
+            else:
+                expected_geom_y = 1259852.8231037268
+
+            assert address.geom.y == expected_geom_y

--- a/tests/core/sources/test_address_geoadmin.py
+++ b/tests/core/sources/test_address_geoadmin.py
@@ -86,4 +86,4 @@ def test_read(pyramid_oereb_test_config, status_code):
             assert address.street_name == u'Muehlemattstrasse'
             assert isinstance(address.geom, Point)
             assert address.geom.x == 2621857.986995669
-            assert address.geom.y == 1259852.8231037268
+            assert address.geom.y == 1259852.8231037296


### PR DESCRIPTION
The CI failed due to a failing test (see changes). The code uses the Shapely dependency which itself uses Numpy. However, the version of Numpy used depends on the underlying Python base interpreter. For Python versions 3.10, 3.11 and 3.12, Numpy v2.2.4  is used, whereas for Python version 3.9 Numpy v2.0.2 is used. Somehow, the different Numpy versions apply different calculations resulting in different values for the y-coordinate in the affected test (again, see changes). This PR provides a temporary workaround to handle the different Python versions. Needs to be corrected once support for Python 3.9 is dropped.